### PR TITLE
Add the support actions required for Trusted Advisor

### DIFF
--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -32,6 +32,7 @@ Resources:
             Action:
             # Analyse security groups
             - trustedadvisor:Describe*
+            - support:*
             - ec2:DescribeNetworkInterfaces
             # IAM credentials overview
             - iam:GenerateCredentialReport

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -30,7 +30,7 @@ object Failure {
       s"AWS unknown error, service: $serviceName (check logs for stacktrace)"
     }
     val friendlyMessage = serviceNameOpt.fold("Unknown error while making API calls to AWS.") { serviceName =>
-      s"Unknown error while making an API to AWS' $serviceName service"
+      s"Unknown error while making an API call to AWS' $serviceName service"
     }
     Failure(details, friendlyMessage, 500)
   }


### PR DESCRIPTION
Update to the watched-account template to solve AWSSupport access denied issue:

```
security-hq is not authorized to perform: support: (Service: AWSSupport...
```

> To use the Trusted Advisor-related actions provided by the AWS Support API, your policy must include the support:* action (explicitly or implicitly); none of the trustedadvisor action permissions restrict your access.

http://docs.aws.amazon.com/IAM/latest/UserGuide/list_trustedadvisor.html