### PR TITLE
Add Google authentication to Security HQ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ lazy val hq = (project in file("hq")).
       filters,
       "com.gu" %% "play-googleauth" % "0.6.0",
       "joda-time" % "joda-time" % "2.9.9",
-      "org.typelevel" %% "cats-core" % "1.0.0-MF",
+      "org.typelevel" %% "cats" % "0.8.1",
       "com.github.tototoshi" %% "scala-csv" % "1.3.5",
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val hq = (project in file("hq")).
     libraryDependencies ++= Seq(
       ws,
       filters,
+      "com.gu" %% "play-googleauth" % "0.6.0",
       "joda-time" % "joda-time" % "2.9.9",
       "org.typelevel" %% "cats-core" % "1.0.0-MF",
       "com.github.tototoshi" %% "scala-csv" % "1.3.5",

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -181,6 +181,9 @@ Resources:
       - Namespace: aws:elasticbeanstalk:application:environment
         OptionName: HQ_CONFIG_PATH
         Value: !Sub security/${Stage}/security-hq/security-hq.conf
+      - Namespace: aws:elasticbeanstalk:application:environment
+        OptionName: HQ_CERT_PATH
+        Value: !Sub security/${Stage}/security-hq/security-hq-service-account-cert.json
 
       # running
       - Namespace: aws:elasticbeanstalk:environment

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -22,8 +22,8 @@ class AppComponents(context: Context)
 
   override def router: Router = new Routes(
     httpErrorHandler,
-    new HQController(configuration)(ec),
-    new SecurityGroupsController(configuration)(ec),
+    new HQController(configuration)(ec, wsClient),
+    new SecurityGroupsController(configuration)(ec, wsClient),
     new AuthController(environment)(wsClient, configuration),
     new UtilityController(),
     new Assets(httpErrorHandler)

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -24,6 +24,7 @@ class AppComponents(context: Context)
     httpErrorHandler,
     new HQController(configuration)(ec),
     new SecurityGroupsController(configuration)(ec),
+    new AuthController(environment)(wsClient, configuration),
     new UtilityController(),
     new Assets(httpErrorHandler)
   )

--- a/hq/app/auth/SecurityHQAuthActions.scala
+++ b/hq/app/auth/SecurityHQAuthActions.scala
@@ -1,0 +1,21 @@
+package auth
+
+import com.gu.googleauth.{GoogleAuthConfig, Actions => GoogleAuthActions}
+import config.Config
+import controllers.routes
+import play.api.Configuration
+import play.api.mvc.Call
+
+
+trait SecurityHQAuthActions extends GoogleAuthActions {
+  implicit val config: Configuration
+
+  override val loginTarget: Call = routes.AuthController.login()
+  override val failureRedirectTarget: Call = routes.AuthController.loginError()
+  override val defaultRedirectTarget: Call = routes.HQController.index()
+
+  override val authConfig: GoogleAuthConfig = Config.googleSettings
+
+  val googleGroupChecker = Config.googleGroupChecker
+  val requiredGoogleGroups = Set(Config.twoFAGroup)
+}

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -1,12 +1,59 @@
 package config
 
+import java.io.FileInputStream
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.gu.googleauth.{GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
 import model.{AwsAccount, DEV, PROD, Stage}
 import play.api.Configuration
 
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 
 object Config {
+  def googleSettings(implicit config: Configuration): GoogleAuthConfig = {
+    val clientId = requiredString(config, "auth.google.clientId")
+    val clientSecret = requiredString(config, "auth.google.clientSecret")
+    val domain = requiredString(config, "auth.domain")
+    val redirectUrl = s"${requiredString(config, "host")}/oauthCallback"
+    GoogleAuthConfig(
+      clientId,
+      clientSecret,
+      redirectUrl,
+      domain
+    )
+  }
+
+  def googleGroupChecker(implicit config: Configuration): GoogleGroupChecker = {
+    val twoFAUser = requiredString(config, "auth.google.2faUser")
+    val serviceAccountCertPath = requiredString(config, "auth.google.serviceAccountCertPath")
+
+    val credentials: GoogleCredential = {
+      val jsonCertStream =
+        Try(new FileInputStream(serviceAccountCertPath))
+          .getOrElse(throw new RuntimeException(s"Could not load service account JSON from $serviceAccountCertPath"))
+      GoogleCredential.fromStream(jsonCertStream)
+    }
+
+    val serviceAccount = GoogleServiceAccount(
+      credentials.getServiceAccountId,
+      credentials.getServiceAccountPrivateKey,
+      twoFAUser
+    )
+    new GoogleGroupChecker(serviceAccount)
+  }
+
+  def twoFAGroup(implicit config: Configuration): String = {
+    requiredString(config, "auth.google.2faGroupId")
+  }
+
+  private def requiredString(config: Configuration, key: String): String = {
+    config.getString(key).getOrElse {
+      throw new RuntimeException(s"Missing required config property $key")
+    }
+  }
+
   def getAwsAccounts(config: Configuration): List[AwsAccount] = {
     val accounts = for {
       accountConfigs <- config.getConfigList("hq.accounts").toList
@@ -16,14 +63,6 @@ object Config {
     accounts.sortBy(_.name)
   }
 
-  private[config] def getAwsAccount(config: Configuration): Option[AwsAccount] = {
-    for {
-      id <- config.getString("id")
-      name <- config.getString("name")
-      roleArn <- config.getString("roleArn")
-    } yield AwsAccount(id, name, roleArn)
-  }
-
   def getStage(config: Configuration): Stage = {
     config.getString("stage") match {
       case Some("DEV") => DEV
@@ -31,5 +70,13 @@ object Config {
       case Some(stage) => throw config.reportError("stage", s"$stage is not a valid stage, expected one of DEV, PROD")
       case None => throw config.reportError("stage", s"Missing application stage, expected one of DEV, PROD")
     }
+  }
+
+  private[config] def getAwsAccount(config: Configuration): Option[AwsAccount] = {
+    for {
+      id <- config.getString("id")
+      name <- config.getString("name")
+      roleArn <- config.getString("roleArn")
+    } yield AwsAccount(id, name, roleArn)
   }
 }

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -12,6 +12,15 @@ import scala.util.Try
 
 
 object Config {
+  def getStage(config: Configuration): Stage = {
+    config.getString("stage") match {
+      case Some("DEV") => DEV
+      case Some("PROD") => PROD
+      case Some(stage) => throw config.reportError("stage", s"$stage is not a valid stage, expected one of DEV, PROD")
+      case None => throw config.reportError("stage", s"Missing application stage, expected one of DEV, PROD")
+    }
+  }
+
   def googleSettings(implicit config: Configuration): GoogleAuthConfig = {
     val clientId = requiredString(config, "auth.google.clientId")
     val clientSecret = requiredString(config, "auth.google.clientSecret")
@@ -61,15 +70,6 @@ object Config {
       awsAccount <- getAwsAccount(accountConfig)
     } yield awsAccount
     accounts.sortBy(_.name)
-  }
-
-  def getStage(config: Configuration): Stage = {
-    config.getString("stage") match {
-      case Some("DEV") => DEV
-      case Some("PROD") => PROD
-      case Some(stage) => throw config.reportError("stage", s"$stage is not a valid stage, expected one of DEV, PROD")
-      case None => throw config.reportError("stage", s"Missing application stage, expected one of DEV, PROD")
-    }
   }
 
   private[config] def getAwsAccount(config: Configuration): Option[AwsAccount] = {

--- a/hq/app/controllers/AuthController.scala
+++ b/hq/app/controllers/AuthController.scala
@@ -1,0 +1,31 @@
+package controllers
+
+import auth.SecurityHQAuthActions
+import play.api.{Configuration, Environment}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{Action, Controller}
+
+
+class AuthController(environment: Environment)
+  (implicit val wsClient: WSClient, val config: Configuration)
+  extends Controller with SecurityHQAuthActions {
+
+  implicit val mode = environment.mode
+
+  def login = Action.async { implicit request =>
+    startGoogleLogin()
+  }
+
+  def loginError = Action { implicit request =>
+    val error = request.flash.get("error").getOrElse("There was an error logging in")
+    ???
+  }
+
+  def logout = Action { implicit request =>
+    Redirect(routes.HQController.index()).withNewSession
+  }
+
+  def oauthCallback = Action.async { implicit request =>
+    processOauth2Callback(requiredGoogleGroups, googleGroupChecker)
+  }
+}

--- a/hq/app/controllers/AuthController.scala
+++ b/hq/app/controllers/AuthController.scala
@@ -7,7 +7,7 @@ import play.api.mvc.{Action, Controller}
 
 
 class AuthController(environment: Environment)
-  (implicit val wsClient: WSClient, val config: Configuration)
+                    (implicit val wsClient: WSClient, val config: Configuration)
   extends Controller with SecurityHQAuthActions {
 
   implicit val mode = environment.mode
@@ -18,7 +18,7 @@ class AuthController(environment: Environment)
 
   def loginError = Action { implicit request =>
     val error = request.flash.get("error").getOrElse("There was an error logging in")
-    ???
+    Ok(views.html.loginError(error, None))
   }
 
   def logout = Action { implicit request =>

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -1,24 +1,29 @@
 package controllers
 
+import auth.SecurityHQAuthActions
 import aws.AWS
 import aws.support.{TrustedAdvisor, TrustedAdvisorExposedIAMKeys}
 import config.Config
 import model.ExposedIAMKeyDetail
 import play.api._
+import play.api.libs.ws.WSClient
 import play.api.mvc._
 import utils.attempt.PlayIntegration.attempt
 
 import scala.concurrent.ExecutionContext
 
 
-class HQController(val config: Configuration)(implicit val ec: ExecutionContext) extends Controller {
+class HQController(val config: Configuration)
+                  (implicit val ec: ExecutionContext, val wsClient: WSClient)
+  extends Controller  with SecurityHQAuthActions {
+
   private val accounts = Config.getAwsAccounts(config)
 
-  def index = Action {
+  def index = AuthAction {
     Ok(views.html.index(accounts))
   }
 
-  def account(accountId: String) = Action.async {
+  def account(accountId: String) = AuthAction.async {
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)
@@ -28,11 +33,11 @@ class HQController(val config: Configuration)(implicit val ec: ExecutionContext)
     }
   }
 
-  def iam = Action {
+  def iam = AuthAction {
     Ok(views.html.iam.iam())
   }
 
-  def iamAccount(accountId: String) = Action.async {
+  def iamAccount(accountId: String) = AuthAction.async {
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)
@@ -46,7 +51,7 @@ class HQController(val config: Configuration)(implicit val ec: ExecutionContext)
     }
   }
 
-  def dependencies = Action {
+  def dependencies = AuthAction {
     Ok(views.html.dependencies.dependencies())
   }
 }

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -2,23 +2,28 @@ package controllers
 
 import java.util.concurrent.Executors
 
+import auth.SecurityHQAuthActions
 import aws.AWS
 import aws.ec2.EC2
 import config.Config
 import play.api._
+import play.api.libs.ws.WSClient
 import play.api.mvc._
 import utils.attempt.PlayIntegration.attempt
 
 import scala.concurrent.ExecutionContext
 
 
-class SecurityGroupsController(val config: Configuration)(implicit val ec: ExecutionContext) extends Controller {
+class SecurityGroupsController(val config: Configuration)
+                              (implicit val ec: ExecutionContext, val wsClient: WSClient)
+  extends Controller with SecurityHQAuthActions {
+
   private val accounts = Config.getAwsAccounts(config)
 
   // highly parallel for making simultaneous requests across all AWS accounts
   val highlyAsyncExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
 
-  def securityGroups = Action.async {
+  def securityGroups = AuthAction.async {
     attempt {
       for {
         allFlaggedSgs <- EC2.allFlaggedSgs(accounts)(highlyAsyncExecutionContext)
@@ -27,7 +32,7 @@ class SecurityGroupsController(val config: Configuration)(implicit val ec: Execu
     }
   }
 
-  def securityGroupsAccount(accountId: String) = Action.async {
+  def securityGroupsAccount(accountId: String) = AuthAction.async {
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)
@@ -36,7 +41,7 @@ class SecurityGroupsController(val config: Configuration)(implicit val ec: Execu
     }
   }
 
-  def dependencies = Action {
+  def dependencies = AuthAction {
     Ok(views.html.dependencies.dependencies())
   }
 }

--- a/hq/app/views/loginError.scala.html
+++ b/hq/app/views/loginError.scala.html
@@ -1,0 +1,17 @@
+@(error: String, user: Option[com.gu.googleauth.UserIdentity] = None)(implicit mode: play.api.Mode.Mode)
+
+@main(Nil) { @* Header *@
+<div class="container">
+    <div class="row">
+        <h1 class="header center-on-small-only grey-text text-lighten-5">Security HQ</h1>
+    </div>
+</div>
+
+} { @* Main content *@
+<div class="container">
+    <div class="row">
+        <h2>Error</h2>
+        <p>@error</p>
+    </div>
+</div>
+}

--- a/hq/beanstalk/setup.sh
+++ b/hq/beanstalk/setup.sh
@@ -6,3 +6,4 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 touch /tmp/test-setup-ran
 
 aws s3 cp s3://$HQ_CONFIG_BUCKET/$HQ_CONFIG_PATH $ROOT
+aws s3 cp s3://$HQ_CONFIG_BUCKET/$HQ_CERT_PATH $ROOT

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -25,10 +25,23 @@ application.secret = ${APPLICATION_SECRET}
 
 stage = ${STAGE}
 
+host=${HOST}
+
 hq {
   # default to empty list if the config is missing (for now)
   account = []
   accounts = ${?AWS_ACCOUNTS}
+}
+
+auth {
+  domain=${AUTH_DOMAIN}
+  google {
+    serviceAccountCertPath=${GOOGLE_SERVICE_ACCOUNT_CERT_PATH}
+    clientId=${GOOGLE_CLIENT_ID}
+    clientSecret=${GOOGLE_CLIENT_SECRET}
+    2faUser=${GOOGLE_2FA_USER}
+    2faGroupId=${2FA_GROUP_ID}
+  }
 }
 
 ## Akka

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -13,6 +13,11 @@ GET        /security-groups                           controllers.SecurityGroups
 GET        /security-groups/:accountId                controllers.SecurityGroupsController.securityGroupsAccount(accountId)
 GET        /dependencies                              controllers.HQController.dependencies
 
+GET        /login                                     controllers.AuthController.login
+GET        /loginError                                controllers.AuthController.loginError
+GET        /oauthCallback                             controllers.AuthController.oauthCallback
+GET        /logout                                    controllers.AuthController.logout
+
 GET        /healthcheck                               controllers.UtilityController.healthcheck
 
 # Map static resources from the /public folder to the /assets URL path


### PR DESCRIPTION
### What does this change?

- New routes for login and login failure! 🎉

- Uses [play-googleauth](https://github.com/guardian/play-googleauth) to control access! 🎉

### Any other comments?

play-googleauth 0.6.0 has an issue with the cats that was currently in the project:

```
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn] 	* org.typelevel:cats-core_2.11:0.8.1 -> 1.0.0-MF
```

So it has been swapped out..