### PR TITLE
Resolve the unexpected errors when parsing SG open ports

### DIFF
--- a/hq/app/aws/support/TrustedAdvisor.scala
+++ b/hq/app/aws/support/TrustedAdvisor.scala
@@ -56,14 +56,13 @@ object TrustedAdvisor {
 
   def parseTrustedAdvisorCheckResult[A <: TrustedAdvisorCheckDetails](parseDetails: TrustedAdvisorResourceDetail => Attempt[A], ec: ExecutionContext)(result: DescribeTrustedAdvisorCheckResultResult): Attempt[TrustedAdvisorDetailsResult[A]] = {
     implicit val executionContext: ExecutionContext = ec
-    val details = result.getResult.getFlaggedResources.asScala.toList
     for {
-      as <- Attempt.traverse(details)(parseDetails)
+      resources <- Attempt.traverse(result.getResult.getFlaggedResources.asScala.toList)(parseDetails)
     } yield TrustedAdvisorDetailsResult(
       checkId = result.getResult.getCheckId,
       status = result.getResult.getStatus,
       timestamp = fromISOString(result.getResult.getTimestamp),
-      flaggedResources = as,
+      flaggedResources = resources,
       resourcesIgnored = result.getResult.getResourcesSummary.getResourcesIgnored,
       resourcesFlagged = result.getResult.getResourcesSummary.getResourcesFlagged,
       resourcesSuppressed = result.getResult.getResourcesSummary.getResourcesSuppressed

--- a/hq/app/aws/support/TrustedAdvisorSGOpenPorts.scala
+++ b/hq/app/aws/support/TrustedAdvisorSGOpenPorts.scala
@@ -38,6 +38,18 @@ object TrustedAdvisorSGOpenPorts {
           alertLevel = alertLevel,
           isSuppressed = detail.getIsSuppressed
         )
+      case region :: name :: sgId :: protocol :: alertLevel :: port :: _ =>
+        SGOpenPortsDetail(
+          status = detail.getStatus,
+          region = detail.getRegion,
+          name = name,
+          id = sgId,
+          vpcId = "EC2 classic",
+          protocol = protocol,
+          port = port,
+          alertLevel = alertLevel,
+          isSuppressed = detail.getIsSuppressed
+        )
       case metadata =>
         throw new RuntimeException(s"Could not parse SGOpenPorts from TrustedAdvisorResourceDetail with metadata $metadata")
     }

--- a/hq/test/aws/support/TrustedAdvisorExposedIAMKeysTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorExposedIAMKeysTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 
 class TrustedAdvisorExposedIAMKeysTest extends FreeSpec with Matchers with AttemptValues {
@@ -38,7 +39,7 @@ class TrustedAdvisorExposedIAMKeysTest extends FreeSpec with Matchers with Attem
         .withRegion("eu-west-1")
         .withStatus("ok")
         .withResourceId("abcdefz")
-      TrustedAdvisorExposedIAMKeys.parseExposedIamKeyDetail(detail).isFailedAttempt shouldEqual true
+      TrustedAdvisorExposedIAMKeys.parseExposedIamKeyDetail(badDetail).isFailedAttempt() shouldEqual true
     }
   }
 }

--- a/hq/test/aws/support/TrustedAdvisorExposedIAMKeysTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorExposedIAMKeysTest.scala
@@ -2,11 +2,12 @@ package aws.support
 
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
 import org.scalatest.{FreeSpec, Matchers}
+import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
 
 
-class TrustedAdvisorExposedIAMKeysTest extends FreeSpec with Matchers {
+class TrustedAdvisorExposedIAMKeysTest extends FreeSpec with Matchers with AttemptValues {
   "parseRDSSGDetail" - {
     val metadata = List("key-id", "username", "fraud-type", "case-id", "last-updated", "location", "deadline", "usage")
     val detail = new TrustedAdvisorResourceDetail()
@@ -17,7 +18,7 @@ class TrustedAdvisorExposedIAMKeysTest extends FreeSpec with Matchers {
       .withResourceId("abcdefz")
 
     "works on example data" in {
-      TrustedAdvisorExposedIAMKeys.parseExposedIamKeyDetail(detail) should have(
+      TrustedAdvisorExposedIAMKeys.parseExposedIamKeyDetail(detail).value() should have(
         'keyId ("key-id"),
         'username ("username"),
         'fraudType ("fraud-type"),
@@ -27,6 +28,17 @@ class TrustedAdvisorExposedIAMKeysTest extends FreeSpec with Matchers {
         'deadline ("deadline"),
         'usage ("usage")
       )
+    }
+
+    "returns a failure if it cannot parse the result" in {
+      val badMetadata: List[String] = Nil
+      val badDetail = new TrustedAdvisorResourceDetail()
+        .withIsSuppressed(false)
+        .withMetadata(badMetadata.asJava)
+        .withRegion("eu-west-1")
+        .withStatus("ok")
+        .withResourceId("abcdefz")
+      TrustedAdvisorExposedIAMKeys.parseExposedIamKeyDetail(detail).isFailedAttempt shouldEqual true
     }
   }
 }

--- a/hq/test/aws/support/TrustedAdvisorRDSSGsTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorRDSSGsTest.scala
@@ -1,10 +1,11 @@
 package aws.support
 
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 
 class TrustedAdvisorRDSSGsTest extends FreeSpec with Matchers with AttemptValues {
@@ -25,6 +26,17 @@ class TrustedAdvisorRDSSGsTest extends FreeSpec with Matchers with AttemptValues
         'alertLevel ("Yellow"),
         'isSuppressed (false)
       )
+    }
+
+    "returns a failure if it cannot parse the result" in {
+      val badMetadata: List[String] = Nil
+      val badDetail = new TrustedAdvisorResourceDetail()
+        .withIsSuppressed(false)
+        .withMetadata(badMetadata.asJava)
+        .withRegion("eu-west-1")
+        .withStatus("ok")
+        .withResourceId("abcdefz")
+      TrustedAdvisorRDSSGs.parseRDSSGDetail(badDetail).isFailedAttempt() shouldEqual true
     }
   }
 }

--- a/hq/test/aws/support/TrustedAdvisorRDSSGsTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorRDSSGsTest.scala
@@ -1,12 +1,13 @@
 package aws.support
 
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
 
 
-class TrustedAdvisorRDSSGsTest extends FreeSpec with Matchers {
+class TrustedAdvisorRDSSGsTest extends FreeSpec with Matchers with AttemptValues {
   "parseRDSSGDetail" - {
     val metadata = List("eu-west-1", "rds-sg-123456", "sg-12345a", "Yellow")
     val detail = new TrustedAdvisorResourceDetail()
@@ -17,7 +18,7 @@ class TrustedAdvisorRDSSGsTest extends FreeSpec with Matchers {
       .withResourceId("abcdefz")
 
     "works on example data" in {
-      TrustedAdvisorRDSSGs.parseRDSSGDetail(detail) should have(
+      TrustedAdvisorRDSSGs.parseRDSSGDetail(detail).value() should have(
         'region ("eu-west-1"),
         'rdsSgId ("rds-sg-123456"),
         'ec2SGId ("sg-12345a"),

--- a/hq/test/aws/support/TrustedAdvisorSGOpenPortsTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorSGOpenPortsTest.scala
@@ -2,11 +2,12 @@ package aws.support
 
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
 import org.scalatest.{FreeSpec, Matchers}
+import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
 
 
-class TrustedAdvisorSGOpenPortsTest extends FreeSpec with Matchers {
+class TrustedAdvisorSGOpenPortsTest extends FreeSpec with Matchers with AttemptValues {
   "parsing details" - {
     val metadata = List("eu-west-1", "launch-wizard-1", "sg-12345a (vpc-789abc)", "tcp", "Yellow", "22")
     val detail = new TrustedAdvisorResourceDetail()
@@ -17,7 +18,7 @@ class TrustedAdvisorSGOpenPortsTest extends FreeSpec with Matchers {
       .withResourceId("abcdefz")
 
     "works on example data" in {
-      TrustedAdvisorSGOpenPorts.parseSGOpenPortsDetail(detail) should have(
+      TrustedAdvisorSGOpenPorts.parseSGOpenPortsDetail(detail).value() should have(
         'region ("eu-west-1"),
         'name ("launch-wizard-1"),
         'id ("sg-12345a"),

--- a/hq/test/aws/support/TrustedAdvisorSGOpenPortsTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorSGOpenPortsTest.scala
@@ -10,15 +10,14 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class TrustedAdvisorSGOpenPortsTest extends FreeSpec with Matchers with AttemptValues {
   "parsing details" - {
-    val metadata = List("eu-west-1", "launch-wizard-1", "sg-12345a (vpc-789abc)", "tcp", "Yellow", "22")
-    val detail = new TrustedAdvisorResourceDetail()
-      .withIsSuppressed(false)
-      .withMetadata(metadata.asJava)
-      .withRegion("eu-west-1")
-      .withStatus("ok")
-      .withResourceId("abcdefz")
-
     "works on example data" in {
+      val metadata = List("eu-west-1", "launch-wizard-1", "sg-12345a (vpc-789abc)", "tcp", "Yellow", "22")
+      val detail = new TrustedAdvisorResourceDetail()
+        .withIsSuppressed(false)
+        .withMetadata(metadata.asJava)
+        .withRegion("eu-west-1")
+        .withStatus("ok")
+        .withResourceId("abcdefz")
       TrustedAdvisorSGOpenPorts.parseSGOpenPortsDetail(detail).value() should have(
         'region ("eu-west-1"),
         'name ("launch-wizard-1"),
@@ -39,9 +38,8 @@ class TrustedAdvisorSGOpenPortsTest extends FreeSpec with Matchers with AttemptV
         .withRegion("eu-west-1")
         .withStatus("ok")
         .withResourceId("abcdefz")
-      TrustedAdvisorSGOpenPorts.parseSGOpenPortsDetail(detailWithoutVpc).value().vpcId should be(
-        "EC2 classic"
-      )
+      val vpcId = TrustedAdvisorSGOpenPorts.parseSGOpenPortsDetail(detailWithoutVpc).value().vpcId
+      vpcId shouldEqual "EC2 classic"
     }
 
     "returns a failure if it cannot parse the result" in {

--- a/hq/test/utils/attempt/AttemptValues.scala
+++ b/hq/test/utils/attempt/AttemptValues.scala
@@ -2,14 +2,14 @@ package utils.attempt
 
 import org.scalatest.exceptions.TestFailedException
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
 
 trait AttemptValues {
   implicit class RichAttempt[A](attempt: Attempt[A]) {
-    def value(): A = {
-      Await.result(attempt.asFuture, 5.seconds).fold (
+    def value()(implicit ec: ExecutionContext): A = {
+      Await.result(attempt.asFuture, 5.seconds).fold[A] (
         { fa =>
           throw new TestFailedException(fa.logString, 10)
         },
@@ -17,7 +17,7 @@ trait AttemptValues {
       )
     }
 
-    def isFailedAttempt(): Boolean = {
+    def isFailedAttempt()(implicit ec: ExecutionContext): Boolean = {
       Await.result(attempt.asFuture, 5.seconds).fold (
         _ => true,
         _ => false

--- a/hq/test/utils/attempt/AttemptValues.scala
+++ b/hq/test/utils/attempt/AttemptValues.scala
@@ -1,0 +1,27 @@
+package utils.attempt
+
+import org.scalatest.exceptions.TestFailedException
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+
+trait AttemptValues {
+  implicit class RichAttempt[A](attempt: Attempt[A]) {
+    def value(): A = {
+      Await.result(attempt.asFuture, 5.seconds).fold (
+        { fa =>
+          throw new TestFailedException(fa.logString, 10)
+        },
+        identity
+      )
+    }
+
+    def isFailedAttempt(): Boolean = {
+      Await.result(attempt.asFuture, 5.seconds).fold (
+        _ => true,
+        _ => false
+      )
+    }
+  }
+}


### PR DESCRIPTION
Trusted Advisor was failing if the `SGIds` did not contain a `vpcId`, this adds a new case to handle `EC2 classic`, and updates the tests to include one for this issue.

This also moves away from using `throw new RuntimeException` when attempting to parse the metadata from Trusted Advisor