### PR TITLE
Style Security Groups, move flagged resources to dropdowns, and add sass-lint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,88 @@
+files:
+  include: 'hq/public/stylesheets/**/*.css'
+  ignore:
+    # Do not lint external files.
+    - 'hq/public/materialize/**/*.css'
+options:
+  formatter: stylish
+  merge-default-rules: false
+rules:
+
+  # Extends
+  extends-before-declarations: 1
+  extends-before-mixins: 1
+  placeholder-in-extend: 1
+
+  # Mixins
+  mixins-before-declarations: 1
+
+  # Line Spacing
+  single-line-per-selector: 0
+  empty-line-between-blocks:
+    - 0
+    - ignore-single-line-rulesets: true
+
+  # Disallows
+  no-color-keywords: 1
+  no-css-comments: 0
+  no-debug: 1
+  no-duplicate-properties:
+    - 1
+    - exclude:
+        - font-size
+        - max-height
+        - src
+        - background
+        - display
+        - color
+  no-empty-rulesets: 0
+  no-invalid-hex: 1
+  no-mergeable-selectors: 0
+  no-misspelled-properties:
+    - 1
+    - extra-properties:
+        - overflow-scrolling
+        - osx-font-smoothing
+        - grid-column-gap
+  no-trailing-zero: 1
+  no-url-protocols: 0
+
+  # Name Formats
+  function-name-format: 0
+  mixin-name-format: 0
+  placeholder-name-format: 0
+  variable-name-format: 0
+
+  # Style Guide
+  border-zero: 1
+  final-newline:
+    - 1
+    - include: true
+  hex-length:
+    - 1
+    - style: long
+  indentation:
+    - 1
+    - size: 4
+  leading-zero:
+    - 1
+    - include: false
+  property-sort-order:
+    - 0
+    - order: 'margin,'
+  quotes:
+    - 1
+    - style: single
+  shorthand-values: 1
+  space-after-colon: 1
+  space-after-comma: 1
+  space-before-brace: 1
+  space-before-colon: 1
+  space-between-parens:
+    - 1
+    - include: false
+  url-quotes: 0
+  zero-unit: 0
+  nesting-depth:
+    - 1
+    - max-depth: 4

--- a/hq/app/views/fragments/openSecurityGroups.scala.html
+++ b/hq/app/views/fragments/openSecurityGroups.scala.html
@@ -2,8 +2,16 @@
 
 @(flaggedSgs: List[(SGOpenPortsDetail, Set[SGInUse])], shadow: Boolean)
 
+@resourceIcons(usages: Set[SGInUse]) = {
+    @usages.map {
+      case Instance(id) => { <i class="material-icons tooltipped" data-position="top" data-delay="50" data-tooltip="EC2 instance">computer</i> }
+      case ELB(description) => { <i class="material-icons tooltipped" data-position="top" data-delay="50" data-tooltip="Elastic Load Balancer">device_hub</i> }
+      case _ => { <i class="material-icons tooltipped" data-position="top" data-delay="50" data-tooltip="Unknown">report_problem</i> }
+    }
+}
 
-@usagesList(flaggedSg: SGOpenPortsDetail, usages: Set[SGInUse]) = {
+
+@resourceList(flaggedSg: SGOpenPortsDetail, usages: Set[SGInUse]) = {
     @usages.map {
         case Instance(id) => {
               <a class="btn usage-cta" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#Instances:search=@id">
@@ -69,14 +77,14 @@
             } else {
                 @if(usages.size == 1) {
 
-                    @usagesList(flaggedSg, usages)
+                    @resourceList(flaggedSg, usages)
 
                 } else {
-                    <ul class="collapsible sg-details" data-collapsible="expandable">
+                    <ul class="collapsible sg-details js-sg-details" data-collapsible="expandable">
                       <li class="sg-details__list">
-                        <div class="collapsible-header sg-details__header"><i class="material-icons">expand_more</i>Show all...</div>
+                          <div class="collapsible-header sg-details__header"><i class="material-icons">expand_more</i>@usages.size @resourceIcons(usages)</div>
                         <div class="collapsible-body">
-                            @usagesList(flaggedSg, usages)
+                            @resourceList(flaggedSg, usages)
                         </div>
                       </li>
                     </ul>

--- a/hq/app/views/fragments/openSecurityGroups.scala.html
+++ b/hq/app/views/fragments/openSecurityGroups.scala.html
@@ -3,9 +3,32 @@
 @(flaggedSgs: List[(SGOpenPortsDetail, Set[SGInUse])], shadow: Boolean)
 
 
-<div class="row">
+@usagesList(flaggedSg: SGOpenPortsDetail, usages: Set[SGInUse]) = {
+    @usages.map {
+        case Instance(id) => {
+              <a class="btn usage-cta" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#Instances:search=@id">
+                <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="EC2 instance">computer</i>
+                @id
+            </a>
+        }
+        case ELB(description) => {
+              <a class="btn usage-cta" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#LoadBalancers:search=@description">
+                <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="Elastic Load Balancer">device_hub</i>
+                @description
+            </a>
+        }
+        case UnknownUsage(description: String, networkInterfaceId: String) => {
+              <a class="btn usage-cta">
+                <i class="material-icons right">report_problem</i>
+                Unknown usage: @description @networkInterfaceId
+            </a>
+        }
+    }
+}
+
+<div class="sg-container">
 @for((flaggedSg, usages) <- flaggedSgs) {
-    <div class="col s12 m6 l4">
+    <div class="sg-container__card">
         <div class="card @if(!shadow){z-depth-0}">
             <div class="card-content card-content--title">
                 <span class="card-title">@flaggedSg.name</span>
@@ -40,31 +63,28 @@
                 </table>
             </div>
             <div class="card-action">
+
             @if(usages.isEmpty) {
                 <a class="btn usage-cta" href="#" disabled>Not in use</a>
             } else {
-                @usages.map {
-                    case Instance(id) => {
-                        <a class="btn usage-cta" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#Instances:search=@id">
-                            <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="EC2 instance">computer</i>
-                            @id
-                        </a>
-                    }
-                    case ELB(description) => {
-                        <a class="btn usage-cta" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#LoadBalancers:search=@description">
-                            <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="Elastic Load Balancer">device_hub</i>
-                            @description
-                        </a>
-                    }
-                    case UnknownUsage(description: String, networkInterfaceId: String) => {
-                        <a class="btn usage-cta">
-                            <i class="material-icons right">report_problem</i>
-                            Unknown usage: @description @networkInterfaceId
-                        </a>
-                    }
+                @if(usages.size == 1) {
+
+                    @usagesList(flaggedSg, usages)
+
+                } else {
+                    <ul class="collapsible sg-details" data-collapsible="expandable">
+                      <li class="sg-details__list">
+                        <div class="collapsible-header sg-details__header"><i class="material-icons">expand_more</i>Show all...</div>
+                        <div class="collapsible-body">
+                            @usagesList(flaggedSg, usages)
+                        </div>
+                      </li>
+                    </ul>
                 }
             }
-            </div>
+
+          </div>
+
         </div>
     </div>
 }

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -14,7 +14,7 @@
     </div>
 
 } { @* Main content *@
-    <div class="container">
+    <div class="container greedy-width">
         <div class="row">
             <h2>Open Security Groups</h2>
             <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -7,3 +7,15 @@ jQuery(function($){
 
     $('.modal').modal();
 });
+
+// extensions to the security groups page
+$(document).ready(() => {
+    $('.js-sg-details').hover(
+        function() {
+            $(this).find('.collapsible-header').click();
+        },
+        function() {
+            $(this).find('.collapsible-header').click();
+        }
+    );
+});

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -16,7 +16,7 @@ body {
     display: flex;
     min-height: 100vh;
     flex-direction: column;
-    background-image: url("/assets/images/bg-texture.png");
+    background-image: url('/assets/images/bg-texture.png');
     background-repeat: repeat;
 }
 
@@ -76,7 +76,7 @@ nav {
 }
 
 .grid:after {
-    content: "";
+    content: '';
     flex: auto;
 }
 
@@ -102,8 +102,8 @@ nav {
 }
 
 .accounts__link {
-    padding: 0 0.5rem;
-    color: rgba(0, 0, 0, 0.87);
+    padding: 0 .5rem;
+    color: rgba(0, 0, 0, .87);
 }
 
 .accounts__account-actions {
@@ -112,6 +112,7 @@ nav {
 
 .card .card-content--title {
     padding-bottom: 10px;
+    word-wrap: break-word;
 }
 
 .card .card-content--body {
@@ -124,10 +125,10 @@ nav {
 
 .sg-container {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: 1fr;
     grid-column-gap: 10px;
     grid-row-gap: 10px;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: max-content;
     margin: 0 auto;
 }
 
@@ -154,31 +155,15 @@ nav {
 
 .sg-details__header {
     background-color: #009688;
-    color: #fff;
-}
-
-.sg-modal {
-    padding: 0 100px;
-}
-
-.sg-modal__trigger {
-    width: 100%;
-}
-
-.sg-modal__footer {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    grid-gap: 20px;
-    grid-auto-rows: minmax(100px, auto);
-    margin-bottom: 20px;
+    color: #ffffff;
 }
 
 .usage-cta {
     display: block;
     background-color: #4E8098;
-    padding: 0 0.6rem;
+    padding: 0 .6rem;
 }
 
 .collapsible-body {
-    background-color: #fff;
+    background-color: #ffffff;
 }

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -42,8 +42,12 @@ nav {
     display: none !important;
 }
 
-.greedy-width {
-    width: 90%;
+
+@media (min-width: 1140px) {
+    /* useful for when there are a lot of flagged resources */
+    .greedy-width {
+        width: 90%;
+    }
 }
 
 .main-icon {
@@ -127,9 +131,20 @@ nav {
     display: grid;
     grid-column-gap: 10px;
     grid-row-gap: 10px;
-    grid-template-columns: repeat(3, 1fr);
     grid-template-rows: max-content;
     margin: 0 auto;
+}
+
+@media (min-width: 740px) {
+    .sg-container {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 1140px) {
+    .sg-container {
+        grid-template-columns: repeat(3, 1fr);
+    }
 }
 
 .sg-container__card {
@@ -145,11 +160,13 @@ nav {
 
 .sg-details {
     margin-top: 0;
+    position: relative;
+    width: 100%;
 }
 
 .sg-details__list {
     position: absolute;
-    width: 90%;
+    width: 100%;
     z-index: 999;
 }
 

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -37,6 +37,15 @@ nav {
     box-shadow: none;
 }
 
+.is-hidden,
+[hidden] {
+    display: none !important;
+}
+
+.greedy-width {
+    width: 90%;
+}
+
 .main-icon {
 
 }
@@ -113,9 +122,55 @@ nav {
     height: 3px;
 }
 
-.sg-details__table td, .sg-details__table th {
+.sg-container {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-auto-rows: 1fr;
+    grid-column-gap: 10px;
+    grid-row-gap: 10px;
+    margin: 0 auto;
+}
+
+.sg-container__card {
+    min-width: 33%;
+    padding: 0 10px;
+}
+
+.sg-details__table td,
+.sg-details__table th {
     padding: 5px;
     word-wrap: break-word;
+}
+
+.sg-details {
+    margin-top: 0;
+}
+
+.sg-details__list {
+    position: absolute;
+    width: 90%;
+    z-index: 999;
+}
+
+.sg-details__header {
+    background-color: #009688;
+    color: #fff;
+}
+
+.sg-modal {
+    padding: 0 100px;
+}
+
+.sg-modal__trigger {
+    width: 100%;
+}
+
+.sg-modal__footer {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-gap: 20px;
+    grid-auto-rows: minmax(100px, auto);
+    margin-bottom: 20px;
 }
 
 .usage-cta {


### PR DESCRIPTION
Some changes for the Security Groups page! 

## Collapsibles and dropdowns 

If there are multiple flagged resources they now appear in a dropdown that will open and close on hover:

<img width="773" alt="picture 69" src="https://user-images.githubusercontent.com/8607683/32695613-8457d806-c758-11e7-8961-890d15cc4dd9.png">

The latest iteration is using numbers and icons on the dropdown. However, is still very much a hack / WIP.

<img width="171" alt="picture 72" src="https://user-images.githubusercontent.com/8607683/32695626-f55a8468-c758-11e7-81d0-956de495f242.png">

There is still an issue where hovering and clicking will invert the behaviour... (not desirable)

##### TODO:

- [ ] Add anchor tags around flagged resources
- [ ] Remove hover + click issue for resource dropdown, by removing the hover actions on click?

## Responsive-ish 📲 🖥

Security groups now wrap to 1, 2 or 3 columns depending on the width of the viewport

The CSS breakpoints are lovingly taken [from frontend](https://github.com/guardian/frontend/blob/8fc430776d9992afab47429db9e45826e57a5c6f/static/src/stylesheets/_vars.scss#L51)

Long security group names should now wrap rather than overflow

Rows should all be the minimum hight required to accommodate their tallest card

Greedy containers let the security groups fit as three columns sooner

## CSS conventions 😎 💅

The sass-lint rules are also lovingly taken [from frontend](https://github.com/guardian/frontend/blob/ca566a2ccefddc7c80056bc2c46eeaf99f234935/.sass-lint.yml)

..Except for the one about hexadecimals using lowercase, that rule is currently disabled in this project... go WilD!

sass-lint can be installed as a npm package: `npm install -g sass-lint` 

You can then check the css/sass for errors and warnings like so:

`sass-lint -v hq/public/stylesheets/main.css`

<img width="742" alt="picture 71" src="https://user-images.githubusercontent.com/8607683/32695512-2fa11932-c756-11e7-8b76-b73c6e7e9a57.png">

This PR includes removal of all the sass-lint warnings.

##### TODO:

- [ ] Should probably have added stuff on sass-lint to the readme...
- [ ] Git hook for sass-lint
