### PR TITLE
Switch to CSS grid, and add icons to expandables

### DIFF
--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -18,6 +18,7 @@
         @for((account, report) <- reports) {
             <li>
                 <div class="collapsible-header">
+                    <i class="material-icons">keyboard_arrow_down</i>
                     @account.name
                     @report match {
                         case Left(fa) => {

--- a/hq/app/views/index.scala.html
+++ b/hq/app/views/index.scala.html
@@ -15,31 +15,27 @@
 
 } { @* Main content *@
     <div class="container">
-        <div class="row">
-            <div class="col s12 m6">
-                <div class="card">
-                    <div class="card-content">
-                        <a href="/security-groups">
-                            <i class="right material-icons">vpn_lock</i>
-                            <span class="card-title">Security Groups</span>
-                            <p>
-                                Analysis of Security Group configuration.
-                            </p>
-                        </a>
-                    </div>
+        <div class="row hp-reports">
+            <div class="card">
+                <div class="card-content">
+                    <a href="/security-groups">
+                        <i class="right material-icons">vpn_lock</i>
+                        <span class="card-title">Security Groups</span>
+                        <p>
+                            Analysis of Security Group configuration.
+                        </p>
+                    </a>
                 </div>
             </div>
-            <div class="col s12 m6">
-                <div class="card">
-                    <div class="card-content">
-                        <a href="/iam">
-                            <i class="right material-icons">vpn_key</i>
-                            <span class="card-title">Credentials audits</span>
-                            <p>
-                                IAM credentials reports.
-                            </p>
-                        </a>
-                    </div>
+            <div class="card">
+                <div class="card-content">
+                    <a href="/iam">
+                        <i class="right material-icons">vpn_key</i>
+                        <span class="card-title">Credentials audits</span>
+                        <p>
+                            IAM credentials reports.
+                        </p>
+                    </a>
                 </div>
             </div>
         </div>
@@ -48,7 +44,7 @@
         <div class="container">
             <div class="row">
                 <div class="accounts__header">
-                    <h2 class="white-text">All accounts</h2>
+                    <h2 class="white-text">Individual accounts</h2>
                 </div>
                 <div class="accounts__list">
                     @for(awsAccount <- awsAccounts) {
@@ -66,16 +62,8 @@
                             </div>
                         </div>
                     }
-                        <!-- flexbox hack -->
-                    <div class="accounts__account--padding"></div>
-                    <div class="accounts__account--padding"></div>
-                    <div class="accounts__account--padding"></div>
-                    <div class="accounts__account--padding"></div>
-                    <div class="accounts__account--padding"></div>
-                    <div class="accounts__account--padding"></div>
-                    <div class="accounts__account--padding"></div>
                 </div>
             </div>
         </div>
     </div>
-}§
+}

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -34,6 +34,7 @@
                                 <span class="new badge" data-badge-caption="flagged resources">@flaggedSgs.length</span>
                             }
                         }
+                        <i class="material-icons">keyboard_arrow_down</i>
                         @account.name
                     </div>
                     <div class="collapsible-body">

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -78,7 +78,19 @@ nav {
 .accounts__list {
   display: grid;
   grid-gap: 20px;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+@media (min-width: 740px) {
+  .accounts__list {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (min-width: 1140px) {
+  .accounts__list {
+    grid-template-columns: repeat(4, 1fr);
+  }
 }
 
 .accounts__account {

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -58,10 +58,17 @@ nav {
 
 /* homepage */
 
+.hp-reports {
+  display: grid;
+  grid-column-gap: 20px;
+  grid-template-columns: 1fr 1fr;
+}
+
 .accounts__container {
   background-color: #4e8098;
   margin-top: 10px;
   border-top: solid 1px #0b5351;
+  height: max-content;
 }
 
 .accounts__header {
@@ -69,31 +76,15 @@ nav {
 }
 
 .accounts__list {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: stretch;
-  align-content: stretch;
-}
-
-.grid:after {
-  content: '';
-  flex: auto;
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: 1fr 1fr 1fr;
 }
 
 .accounts__account {
-  flex-grow: 1;
-  margin: 10px;
   min-height: 100px;
   min-width: 200px;
   background-color: #f7f0f0;
-}
-
-.accounts__account--padding {
-  flex-grow: 1;
-  margin: 10px;
-  min-width: 200px;
 }
 
 .accounts__account-heading {
@@ -124,6 +115,8 @@ nav {
 .card-content--border {
   height: 3px;
 }
+
+/* security group pages */
 
 .sg-container {
   display: grid;
@@ -202,9 +195,7 @@ nav {
   white-space: nowrap;
 }
 
-.collapsible-body {
-  background-color: #ffffff;
-}
+/* IAM pages */
 
 .iam-key-disabled {
   opacity: 0.3;


### PR DESCRIPTION
### UX: icons for expandable menus

We need more visual cues that expandable menus are clickable, so first step is to add an icon:

<img width="806" alt="picture 84" src="https://user-images.githubusercontent.com/8607683/33572235-403e2f2e-d92a-11e7-88ab-12c9530b0305.png">

### CSS: Grid layout for accounts list

- Less flex, more CSS grid
- Less CSS overall 🎉 🔥
- Deleting some html since the elements are no longer needed