### PR TITLE
Give Documentation page the new nav, add links to the docs in header and footer

### DIFF
--- a/hq/app/views/doc.scala.html
+++ b/hq/app/views/doc.scala.html
@@ -3,14 +3,13 @@
 @(file: String)(implicit assets: AssetsFinder)
 
 @main(Nil) { @* Header *@
-    <div class="container">
-        <div class="row">
-            <h1 class="header center-on-small-only grey-text text-lighten-5">Security HQ</h1>
-            <div class="col s12 m9">
-                <h4 class="grey-text text-darken-4 center-on-small-only">Documentation</h4>
-            </div>
-        </div>
-    </div>
+  <div class="hq-sub-header">
+      <div class="container hq-sub-header__row">
+          <div class="hq-sub-header__name">
+              <h4 class="header light grey-text text-lighten-5">Documentation</h4>
+          </div>
+      </div>
+  </div>
 
 } { @* Main content *@
 

--- a/hq/app/views/fragments/openSecurityGroups.scala.html
+++ b/hq/app/views/fragments/openSecurityGroups.scala.html
@@ -8,21 +8,21 @@
 @resourceList(flaggedSg: SGOpenPortsDetail, usages: Set[SGInUse]) = {
     @usages.map {
         case Ec2Instance(id) => {
-              <a target="_blank" rel="noopener noreferrer" class="btn usage-cta" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#Instances:search=@id">
+              <a target="_blank" rel="noopener noreferrer" class="btn usage-cta truncate" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#Instances:search=@id">
                 <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="EC2 instance">computer</i>
                 <i class="material-icons link_new_tab" >open_in_new</i>
                 @id
             </a>
         }
         case ELB(description) => {
-              <a target="_blank" rel="noopener noreferrer" class="btn usage-cta" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#LoadBalancers:search=@description">
+              <a target="_blank" rel="noopener noreferrer" class="btn usage-cta truncate" href="https://@{flaggedSg.region}.console.aws.amazon.com/ec2/v2/home?region=@{flaggedSg.region}#LoadBalancers:search=@description">
                 <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="Elastic Load Balancer">device_hub</i>
                 <i class="material-icons link_new_tab" >open_in_new</i>
                 @description
             </a>
         }
         case UnknownUsage(description: String, networkInterfaceId: String) => {
-              <a class="btn usage-cta">
+              <a class="btn usage-cta truncate">
                 <i class="material-icons right">report_problem</i>
                 Unknown usage: @description @networkInterfaceId
             </a>

--- a/hq/app/views/header.scala.html
+++ b/hq/app/views/header.scala.html
@@ -8,7 +8,8 @@
                     <h2 class="header grey-text text-lighten-5">Security HQ</h2>
                 </div>
                 <div class="hq-nav__menu">
-                    <ul class="main-nav">
+                    <a href="#" data-activates="mobile-nav" class="button-collapse"><i class="material-icons black-text">menu</i></a>
+                    <ul class="main-nav hide-on-med-and-down">
                         <li class="main-nav--home">
                             <a href="/"><i class="material-icons black-text">home</i></a>
                         </li>
@@ -18,7 +19,26 @@
                         <li class="main-nav">
                             <a href="/iam"><i class="material-icons black-text">vpn_key</i></a>
                         </li>
+                        <li class="main-nav">
+                            <a href="/documentation/"><i class="material-icons black-text">description</i></a>
+                        </li>
                     </ul>
+
+                    <ul id="mobile-nav" class="side-nav">
+                        <li class="main-nav--home">
+                            <a href="/"><i class="material-icons black-text">home</i>Home</a>
+                        </li>
+                        <li class="main-nav">
+                            <a href="/security-groups"><i class="material-icons black-text">vpn_lock</i>Security Groups</a>
+                        </li>
+                        <li class="main-nav">
+                            <a href="/iam"><i class="material-icons black-text">vpn_key</i>Credentials audits</a>
+                        </li>
+                        <li class="main-nav">
+                            <a href="/documentation"><i class="material-icons black-text">description</i>Documentation</a>
+                        </li>
+                    </ul>
+
                 </div>
                 <div class="hq-nav__image-wrapper">
                     <a href="/">

--- a/hq/app/views/main.scala.html
+++ b/hq/app/views/main.scala.html
@@ -22,10 +22,9 @@
 
         @views.html.header()
 
-        @pageHeader
-
         <main>
-        @content
+          @pageHeader
+          @content
         </main>
 
         <footer class="page-footer grey darken-4">
@@ -39,7 +38,12 @@
                     </div>
                     <div class="col l3 offset-l1 s12">
                         <ul>
-                            <li><a class="grey-text text-lighten-3" href="https://github.com/guardian/security-hq">GitHub</a></li>
+                            <li class="hq-footer__links">
+                              <a class="grey-text text-lighten-3" href="https://github.com/guardian/security-hq"><i class="material-icons left">link</i><span>GitHub</span></a>
+                            </li>
+                            <li class="hq-footer__links">
+                              <a class="grey-text text-lighten-3" href="/documentation/"><i class="material-icons left">description</i><span>Documentation</span></a>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -6,8 +6,11 @@ jQuery(function($) {
   }
 });
 
-// extensions to the security groups page
 $(document).ready(function() {
+  // initalizing the mobile nav
+  $('.button-collapse').sideNav();
+
+  // Extra interactions for the dropdowns on the Security Groups page
   $('.js-sg-details').hover(
     function() {
       $(this).collapsible('open', 0);
@@ -30,6 +33,7 @@ $(document).ready(function() {
     $(this).data('clicks', !clicks);
   });
 
+  // Functionality for the floating menus on the Security Groups page
   $('.js-sg-pin-close').click(function() {
     $('html, body')
       .stop()

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -305,3 +305,9 @@ table.iam-report__table th {
 .link_new_tab {
   vertical-align: bottom;
 }
+
+/* footer */
+
+.hq-footer__links {
+  height: 40px;
+}


### PR DESCRIPTION


#### 👉 Give the Docs page the new header added in #33 

- Consistent design, header and headings taking less vertical space

#### 👉 Link to the Docs in the header, and add a burger and side nav for mobile/tablet:

- Making documentation discoverable by linking to it in the header

<img width="994" alt="picture 115" src="https://user-images.githubusercontent.com/8607683/34203158-03f4e072-e572-11e7-9c51-c401da8a3e35.png">

![dec-19-2017 16-56-36](https://user-images.githubusercontent.com/8607683/34203168-0bab0e86-e572-11e7-84a0-8548246a0e78.gif)

#### 👉 Linking to the docs in the footer and adding icons for each link:

- Making documentation discoverable by linking to it in the footer

<img width="1044" alt="picture 116" src="https://user-images.githubusercontent.com/8607683/34202822-d3eae990-e570-11e7-9cea-3a24146437a9.png">

#### 👉 Truncating long resource names on the security groups page:

- Improving visual display at various breakpoints

<img width="389" alt="picture 117" src="https://user-images.githubusercontent.com/8607683/34203249-4cd92c44-e572-11e7-974f-111401bada50.png">
