### PR TITLE
Add initial PR template and contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Raising an issue
+
+Here is a template for raising an issue, copy and paste it into the text field and fill it:
+
+```
+## Steps to reproduce
+
+
+
+## Environment
+
+Device:
+Browser:
+OS:
+URL:
+```
+
+# Opening a pull request
+
+## General
+
+We welcome code submissions from other teams. Here are the rules of engagement:
+
+- The philosophy here is about communication, taking responsibility for your changes, and fast, incremental delivery.
+- Speak to the team before you decide to do anything major. We can probably help design the change to maximise the chances of it being accepted.
+- Our CSS and JS formatting conventions are enforced by [Prettier](https://prettier.io/).
+- Pull requests made to master assume the change is ready to be pushed to `PROD`.
+- Many small requests will be reviewed/merged quicker than a giant lists of changes.
+- If you have a proposal, or want feedback on a branch under development, prefix `[WIP]` to the pull request title.
+
+## Submission
+
+### Guardian employees
+
+This is applicable to [GMG employees](http://www.gmgplc.co.uk/).
+
+1. Fork or clone the repo and make your changes.
+2. Test your branch locally by running tests:
+    - `./sbt project <project>/test`
+3. Check and fix any formatting issues in the JS and CSS by running Prettier:
+    - `yarn run prettier`
+4. Open a pull request:
+    - Explain why you are making this change in the pull request
+5. A member of the team will review the changes. Once they are satisfied they will approve the pull request.
+6. If there are no broken or ongoing builds in [TeamCity](https://teamcity.gutools.co.uk/viewType.html?buildTypeId=Tools_SecurityHq), merge your branch and then ensure the master branch is built successfully.
+7. Deploy the build to `PROD` using our deployment platform - [Riff-Raff](https://riffraff.gutools.co.uk/).
+
+### External contributions
+
+Firstly, thanks for helping make our service better! Secondly, we'll try and make this as simple as possible.
+
+- Fork the project on GitHub, patch the code, and submit a pull request.
+- We will test, verify and merge your changes and then deploy the code.
+- Certain contributions may require a Contributor License Agreement.
+
+Finally, have you considered [working for us](https://workforus.theguardian.com/index.php/search-jobs-and-apply/?search_paths%5B%5D=&query=developer)?
+
+## The team is your conscience
+
+Here's some wise words from [@gklopper](https://github.com/gklopper).
+
+We only merge to master when the software is ready to go live. This will be different for each thing we do, it might be as simple as showing the person next to you that the typo has been fixed, or you might spend an afternoon with Security or InfoSec looking over your shoulder.
+
+If in doubt ask the team, **the team is your conscience**.
+
+Once deployed to `PROD` check that your software is doing what you expected.
+
+If it is a bit late in the day or it is nearly lunch and you do not want to deploy to PROD immediately then do not merge to master.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## What does this change?
+
+<!-- Screenshots may be helpful to demonstrate -->
+
+## What is the value of this?
+
+<!-- Why are these changes being made? -->
+
+## Any additional notes?
+
+
+<!-- Have CSS or JS changes been checked and fixed by Prettier? -->
+
+<!-- Does this PR meet the contributing guidelines? -->


### PR DESCRIPTION
## What does this change?

Adds a PR template and contributing guidelines inspired by (and adapted from) [Guardian frontend](https://github.com/guardian/frontend)

https://github.com/guardian/frontend/tree/master/.github

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

- Providing guidance on contributing
- Making me write less boilerplate with each PR

<!-- Why are these changes being made? -->

## Any additional notes?

Nope!

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? -->