### PR TITLE
Update CloudFormation template and ask about CloudFormation in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,23 @@
 ## What does this change?
 
+
 <!-- Screenshots may be helpful to demonstrate -->
 
 ## What is the value of this?
 
+
 <!-- Why are these changes being made? -->
+
+## Will this require CloudFormation and/or updates to the AWS StackSet?
+
+
+<!-- Have you committed your changes to the CloudFormation templates? -->
+
+<!-- Has the CloudFormation or StackSet update been completed? -->
 
 ## Any additional notes?
 
 
 <!-- Have CSS or JS changes been checked and fixed by Prettier? -->
 
-<!-- Does this PR meet the contributing guidelines? -->
+<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->

--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -34,6 +34,7 @@ Resources:
             - trustedadvisor:Describe*
             - support:*
             - ec2:DescribeNetworkInterfaces
+            - ec2:DescribeSecurityGroups
             - ec2:DescribeVpcs
             # IAM credentials overview
             - iam:GenerateCredentialReport

--- a/hq/app/aws/AwsAsyncHandler.scala
+++ b/hq/app/aws/AwsAsyncHandler.scala
@@ -36,7 +36,7 @@ object AwsAsyncHandler {
         Failure.expiredCredentials(serviceNameOpt).attempt
       } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
         Failure.noCredentials(serviceNameOpt).attempt
-      } else if (e.getMessage.contains("is not authorized to perform")) {
+      } else if (e.getMessage.contains("not authorized to perform")) {
         Failure.insufficientPermissions(serviceNameOpt).attempt
       } else {
         Failure.awsError(serviceNameOpt).attempt


### PR DESCRIPTION
## What does this change?

- Adds required EC2 permission to the CloudFormation template
- Reduces specificity of matching on AWS error
- Adds question about CloudFormation to PR template
- Links PR template to the contributing guidelines

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

### 👉 CloudFormation:

Template is under source control and can be used to update the StackSet

### 👉 Errors:

AWS seems to swap between using "you are" and "is" when reporting authorisation errors, so this PR makes the matching less specific to handle the different subjects

### 👉 PR Template

This is a good place to add a check and reminder about CloudFormation and StackSetting

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Update to the CloudFormation template included since this is necessary if we are going to apply the changes from #34 

❗❗ The updated template will need to be applied to the watched-account StackSet. We can revert #47 once this has been done.

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? -->

  
  
  