### PR TITLE
Expansion of the EC2 run readme, and addition of an example shell script

### DIFF
--- a/ssm-util.sh
+++ b/ssm-util.sh
@@ -47,7 +47,4 @@ function run {
     read_command_output
 }
 
-export command=$1
-export instance=$2
-
 run

--- a/ssm-util.sh
+++ b/ssm-util.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+function send_command {
+aws --region $region --profile $profile ssm send-command \
+   --document-name "AWS-RunShellScript" \
+   --comment "Shell command by $(whoami)" \
+   --instance-ids $instance \
+   --parameters commands="$command" \
+   | jq -r '.Command.CommandId'
+}
+
+
+function read_command_output {
+aws --region $region --profile $profile ssm list-command-invocations \
+   --command-id "$command_id" \
+   --details \
+   | jq -r '.CommandInvocations[].CommandPlugins[].Output'
+}
+
+
+function wait_for_command {
+result=0
+for this_instance in $instance; do
+   responseCode=-1
+   printf "$this_instance:"
+   while [[ $responseCode -eq -1 ]]; do
+      printf "."
+      sleep 1
+      responseCode=$(aws --region $region --profile $profile ssm list-command-invocations \
+         --command-id "$command_id" \
+          --instance-id "$this_instance" \
+         | jq -r '.ResponseCode')
+      if [[ $responseCode -ne -1 ]]; then
+         echo;
+      fi
+      if [[ $responseCode -gt -0 ]]; then
+         result=1
+      fi
+   done
+done
+return $result
+}
+
+function run {
+    command_id=$(send_command)
+    wait_for_command
+    echo "Return code was $?"
+    read_command_output
+}
+
+export command=$1
+export instance=$2
+
+run


### PR DESCRIPTION
## What does this change?

### 👉 Adding more links to external resources

Saving everyone a few clicks

<img width="844" alt="picture 137" src="https://user-images.githubusercontent.com/8607683/34676442-b6b84098-f484-11e7-8d8f-45774430a0da.png">

### 👉 Reordering content and adding expanding some sections

I think this order makes it easier to follow along and learn as you go. I ran through the guide and had some questions, so adding some verbosity for any AWS/EC2 beginners.

### 👉 Changing the command used in the wait_for_command function

Script was not working as expected but was giving the helpful error:

```
Invalid choice: 'get-command-invocation', maybe you meant:

  * list-command-invocations
```

### 👉 Copying the shell script into an example file

The docs can link out to the example, and this will make it easier for others to copy the content

<img width="771" alt="picture 138" src="https://user-images.githubusercontent.com/8607683/34676691-992a7ff4-f485-11e7-9c01-9d35ff97ee5a.png">

### 👉 Adding line breaks before triple backticks

No visible change to web view. Some markdown viewers require this to format correctly.


## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope
