### PR TITLE
Upgrade AWS SDK version to latest release: 1.11.258

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-t
 
 // resolvers += "guardian-bintray" at "https://dl.bintray.com/guardian/sbt-plugins/"
 
-val awsSdkVersion = "1.11.185"
+val awsSdkVersion = "1.11.258"
 val playVersion = "2.6.7"
 
 lazy val hq = (project in file("hq")).


### PR DESCRIPTION
## What does this change?

Upgrade AWS SDK version to 1.11.258

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Stops the Credentials report breaking if it encounters `eu-west-3`

<img width="1218" alt="picture 134" src="https://user-images.githubusercontent.com/8607683/34681615-576b9792-f494-11e7-8ad7-398764a75a9e.png">


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

