### PR TITLE
Add a cache service and integrate it with Security Groups

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,8 @@ lazy val hq = (project in file("hq")).
       "com.amazonaws" % "aws-java-sdk-support" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
+      "io.reactivex" %% "rxscala" % "0.26.5",
+      "com.gu" %% "box" % "0.1.0",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -8,6 +8,7 @@ import play.api.mvc.{AnyContent, BodyParser, ControllerComponents}
 import play.api.routing.Router
 import play.filters.csrf.CSRFComponents
 import router.Routes
+import services.CacheService
 
 
 class AppComponents(context: Context)
@@ -24,10 +25,12 @@ class AppComponents(context: Context)
     new HstsFilter()
   )
 
+  val cacheService = new CacheService(configuration, applicationLifecycle, environment)
+
   override def router: Router = new Routes(
     httpErrorHandler,
     new HQController(configuration),
-    new SecurityGroupsController(configuration),
+    new SecurityGroupsController(configuration, cacheService),
     new AuthController(environment, configuration),
     new UtilityController(),
     assets

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -1,7 +1,5 @@
 package controllers
 
-import java.util.concurrent.Executors
-
 import auth.SecurityHQAuthActions
 import aws.AWS
 import aws.ec2.EC2
@@ -9,34 +7,31 @@ import config.Config
 import play.api._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
+import services.CacheService
+import utils.attempt.Attempt
 import utils.attempt.PlayIntegration.attempt
 
 import scala.concurrent.ExecutionContext
 
 
-class SecurityGroupsController(val config: Configuration)
+class SecurityGroupsController(val config: Configuration, cacheService: CacheService)
                               (implicit val ec: ExecutionContext, val wsClient: WSClient, val bodyParser: BodyParser[AnyContent], val controllerComponents: ControllerComponents, val assetsFinder: AssetsFinder)
   extends BaseController with SecurityHQAuthActions {
 
   private val accounts = Config.getAwsAccounts(config)
 
-  // highly parallel for making simultaneous requests across all AWS accounts
-  val highlyAsyncExecutionContext = ExecutionContext.fromExecutorService(Executors.newCachedThreadPool())
+  def securityGroups = authAction {
+    val allFlaggedSgs = cacheService.getAllSgs()
+    val sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs.toList)
 
-  def securityGroups = authAction.async {
-    attempt {
-      for {
-        allFlaggedSgs <- EC2.allFlaggedSgs(accounts)(highlyAsyncExecutionContext)
-        sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs)
-      } yield Ok(views.html.sgs.sgs(sortedFlaggedSgs))
-    }
+    Ok(views.html.sgs.sgs(sortedFlaggedSgs))
   }
 
   def securityGroupsAccount(accountId: String) = authAction.async {
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)
-        flaggedSgs <- EC2.flaggedSgsForAccount(account)
+        flaggedSgs <- Attempt.fromEither(cacheService.getSgsForAccount(account))
       } yield Ok(views.html.sgs.sgsAccount(account, flaggedSgs))
     }
   }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -1,0 +1,49 @@
+package services
+
+import aws.ec2.EC2
+import com.gu.Box
+import config.Config
+import model.{AwsAccount, SGInUse, SGOpenPortsDetail}
+import play.api.inject.ApplicationLifecycle
+import play.api.{Configuration, Environment, Mode}
+import rx.lang.scala.Observable
+import utils.attempt.{FailedAttempt, Failure}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+
+class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, environment: Environment)(implicit ec: ExecutionContext) {
+  private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(Map.empty)
+  private val accounts = Config.getAwsAccounts(config)
+
+  def getAllSgs(): Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]] = sgsBox.get()
+
+  def getSgsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]] = {
+    sgsBox.get().getOrElse(
+      awsAccount,
+      Left(Failure("unable to find account data in the cache", "No security group data available", 500, Some(awsAccount.id)).attempt)
+    )
+  }
+
+  private def refreshSgsBox(): Unit = {
+    println("Started refresh of the Security Groups")
+    for {
+      allFlaggedSgs <- EC2.allFlaggedSgs(accounts)
+    } yield {
+      println("Sending the refreshed data to the Security Groups Box")
+      sgsBox.send(allFlaggedSgs.toMap)
+    }
+  }
+
+  if (environment.mode != Mode.Test) {
+    val sgSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
+      refreshSgsBox()
+    }
+
+    lifecycle.addStopHook { () =>
+      sgSubscription.unsubscribe()
+      Future.successful(())
+    }
+  }
+}

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -5,7 +5,7 @@ import com.gu.Box
 import config.Config
 import model.{AwsAccount, SGInUse, SGOpenPortsDetail}
 import play.api.inject.ApplicationLifecycle
-import play.api.{Configuration, Environment, Mode}
+import play.api.{Configuration, Environment, Logger, Mode}
 import rx.lang.scala.Observable
 import utils.attempt.{FailedAttempt, Failure}
 
@@ -27,11 +27,11 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   }
 
   private def refreshSgsBox(): Unit = {
-    println("Started refresh of the Security Groups")
+    Logger.info("Started refresh of the Security Groups data")
     for {
       allFlaggedSgs <- EC2.allFlaggedSgs(accounts)
     } yield {
-      println("Sending the refreshed data to the Security Groups Box")
+      Logger.info("Sending the refreshed data to the Security Groups Box")
       sgsBox.send(allFlaggedSgs.toMap)
     }
   }

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -1,5 +1,3 @@
-
-
 @(flaggedSgsByAccount: List[(model.AwsAccount, Either[utils.attempt.FailedAttempt, List[(model.SGOpenPortsDetail, Set[model.SGInUse])]])])(implicit assets: AssetsFinder)
 
 @floatingNav = {


### PR DESCRIPTION
## What does this change?

Adds caching to the Security Groups

The service now stores the AWS response on flagged security groups into a [Box](https://github.com/guardian/box) 📦

Every 5 minutes, the service will refresh the Box content

The application can get the data from the Box, rather than running off to AWS each time. 

## What is the value of this?

Speeds up the page load for the all accounts security groups page, and for the single account pages

No long trips over the wire delaying page load of the Security Groups 🏃💨

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
