### PR TITLE
Expand the cache service to include Exposed Keys and Credentials Report

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -29,7 +29,7 @@ class AppComponents(context: Context)
 
   override def router: Router = new Routes(
     httpErrorHandler,
-    new HQController(configuration),
+    new HQController(configuration, cacheService),
     new SecurityGroupsController(configuration, cacheService),
     new AuthController(environment, configuration),
     new UtilityController(),

--- a/hq/app/aws/support/TrustedAdvisorExposedIAMKeys.scala
+++ b/hq/app/aws/support/TrustedAdvisorExposedIAMKeys.scala
@@ -3,21 +3,36 @@ package aws.support
 import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult}
 import com.amazonaws.services.support.AWSSupportAsync
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
-import model.{ExposedIAMKeyDetail, TrustedAdvisorDetailsResult}
-import utils.attempt.{Attempt, Failure}
+import model.{AwsAccount, ExposedIAMKeyDetail, TrustedAdvisorDetailsResult}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 
 object TrustedAdvisorExposedIAMKeys {
   val AWS_EXPOSED_ACCESS_KEYS_IDENTIFIER = "12Fnkpl8Y5"
 
-  def getExposedIAMKeys(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[ExposedIAMKeyDetail]] = {
+  def getAllExposedKeys(accounts: List[AwsAccount])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]])]] = {
+    Attempt.Async.Right {
+      Future.traverse(accounts) { account =>
+        exposedKeysForAccount(account).asFuture.map(account -> _)
+      }
+    }
+  }
+
+  private def getExposedIAMKeys(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[ExposedIAMKeyDetail]] = {
     getTrustedAdvisorCheckDetails(client, AWS_EXPOSED_ACCESS_KEYS_IDENTIFIER)
       .flatMap(parseTrustedAdvisorCheckResult(parseExposedIamKeyDetail, ec))
   }
 
+  private def exposedKeysForAccount(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[ExposedIAMKeyDetail]] = {
+    val supportClient = TrustedAdvisor.client(account)
+    for {
+        exposedIamKeysResult <- TrustedAdvisorExposedIAMKeys.getExposedIAMKeys(supportClient)
+        exposedIamKeys = exposedIamKeysResult.flaggedResources
+    } yield exposedIamKeys
+  }
 
   private[support] def parseExposedIamKeyDetail(detail: TrustedAdvisorResourceDetail): Attempt[ExposedIAMKeyDetail] = {
     detail.getMetadata.asScala.toList match {

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -1,9 +1,11 @@
 package services
 
 import aws.ec2.EC2
+import aws.iam.IAMClient
+import aws.support.TrustedAdvisorExposedIAMKeys
 import com.gu.Box
 import config.Config
-import model.{AwsAccount, SGInUse, SGOpenPortsDetail}
+import model._
 import play.api.inject.ApplicationLifecycle
 import play.api.{Configuration, Environment, Logger, Mode}
 import rx.lang.scala.Observable
@@ -14,16 +16,56 @@ import scala.concurrent.duration._
 
 
 class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, environment: Environment)(implicit ec: ExecutionContext) {
+  private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(Map.empty)
+  private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(Map.empty)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(Map.empty)
   private val accounts = Config.getAwsAccounts(config)
+
+  def getAllCredentials(): Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = credentialsBox.get()
+
+  def getCredentialsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, CredentialReportDisplay] = {
+    credentialsBox.get().getOrElse(
+      awsAccount,
+      Left(Failure.cacheServiceError(awsAccount.id, "credentials").attempt)
+    )
+  }
+
+  def getAllExposedKeys(): Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]] = exposedKeysBox.get()
+
+  def getExposedKeysForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[ExposedIAMKeyDetail]] = {
+    exposedKeysBox.get().getOrElse(
+      awsAccount,
+      Left(Failure.cacheServiceError(awsAccount.id, "exposed keys").attempt)
+    )
+  }
 
   def getAllSgs(): Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]] = sgsBox.get()
 
   def getSgsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]] = {
     sgsBox.get().getOrElse(
       awsAccount,
-      Left(Failure("unable to find account data in the cache", "No security group data available", 500, Some(awsAccount.id)).attempt)
+      Left(Failure.cacheServiceError(awsAccount.id, "security group").attempt)
     )
+  }
+
+  private def refreshCredentialsBox(): Unit = {
+    Logger.debug("Started refresh of the Credentials data")
+    for {
+      allCredentialReports <- IAMClient.getAllCredentialReports(accounts)
+    } yield {
+      Logger.debug("Sending the refreshed data to the Credentials Box")
+      credentialsBox.send(allCredentialReports.toMap)
+    }
+  }
+
+  private def refreshExposedKeysBox(): Unit = {
+    Logger.debug("Started refresh of the Exposed Keys data")
+    for {
+      allExposedKeys <- TrustedAdvisorExposedIAMKeys.getAllExposedKeys(accounts)
+    } yield {
+      Logger.debug("Sending the refreshed data to the Exposed Keys Box")
+      exposedKeysBox.send(allExposedKeys.toMap)
+    }
   }
 
   private def refreshSgsBox(): Unit = {
@@ -37,11 +79,21 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   }
 
   if (environment.mode != Mode.Test) {
+    val credentialsSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
+      refreshCredentialsBox()
+    }
+
+    val exposedKeysSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
+      refreshExposedKeysBox()
+    }
+
     val sgSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
       refreshSgsBox()
     }
 
     lifecycle.addStopHook { () =>
+      credentialsSubscription.unsubscribe()
+      exposedKeysSubscription.unsubscribe()
       sgSubscription.unsubscribe()
       Future.successful(())
     }

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -35,6 +35,12 @@ object Failure {
     Failure(details, friendlyMessage, 500)
   }
 
+  def cacheServiceError(accountId: String, cacheContent: String): Failure = {
+    val details = s"Cache service error; unable to retrieve $cacheContent for $accountId"
+    val friendlyMessage = s"No $cacheContent data available for $accountId"
+    Failure(details, friendlyMessage, 500)
+  }
+
   def expiredCredentials(serviceNameOpt: Option[String]): Failure = {
     val details = serviceNameOpt.fold("expired AWS credentials, unknown service") { serviceName =>
       s"expired AWS credentials, service: $serviceName"


### PR DESCRIPTION
## What does this change?


Adding methods to help get exposed keys for all accounts

Stores the AWS responses for Credentials and Exposed Keys into two separate [Boxes](https://github.com/guardian/box) 📦 📦

Adds a new Failure that can be reused across the cache service:

<img width="797" alt="picture 142" src="https://user-images.githubusercontent.com/8607683/34786685-c623c080-f62c-11e7-9d27-cb8234848dc3.png">


## What is the value of this?

Speeds up the page load for the IAM pages

Adding the startingCache to each Box means no more blank pages while waiting for each service to start:

<img width="674" alt="picture 150" src="https://user-images.githubusercontent.com/8607683/34786626-991a487a-f62c-11e7-8f4e-41a085be4554.png">



## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

Related PR: #53 


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
