### PR TITLE
Let the reports for exposed keys and credentials fail/success independently

### DIFF
--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -7,7 +7,6 @@ import play.api._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.CacheService
-import utils.attempt.Attempt
 import utils.attempt.PlayIntegration.attempt
 
 import scala.concurrent.ExecutionContext
@@ -32,7 +31,7 @@ class HQController (val config: Configuration, cacheService: CacheService)
       for {
         account <- AWS.lookupAccount(accountId, accounts)
         exposedIamKeys = cacheService.getExposedKeysForAccount(account)
-        credReport <- Attempt.fromEither(cacheService.getCredentialsForAccount(account))
+        credReport = cacheService.getCredentialsForAccount(account)
       } yield Ok(views.html.iam.iamAccount(account, exposedIamKeys, credReport))
     }
   }

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -31,7 +31,7 @@ class HQController (val config: Configuration, cacheService: CacheService)
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)
-        exposedIamKeys <- Attempt.fromEither(cacheService.getExposedKeysForAccount(account))
+        exposedIamKeys = cacheService.getExposedKeysForAccount(account)
         credReport <- Attempt.fromEither(cacheService.getCredentialsForAccount(account))
       } yield Ok(views.html.iam.iamAccount(account, exposedIamKeys, credReport))
     }

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -37,7 +37,7 @@ object Failure {
 
   def cacheServiceError(accountId: String, cacheContent: String): Failure = {
     val details = s"Cache service error; unable to retrieve $cacheContent for $accountId"
-    val friendlyMessage = s"No $cacheContent data available for $accountId"
+    val friendlyMessage = s"Missing $cacheContent data for $accountId"
     Failure(details, friendlyMessage, 500)
   }
 

--- a/hq/app/views/iam/exposedKeys.scala.html
+++ b/hq/app/views/iam/exposedKeys.scala.html
@@ -1,0 +1,55 @@
+@import model.ExposedIAMKeyDetail
+@(exposedIamKeys: List[ExposedIAMKeyDetail])
+
+@if(exposedIamKeys.nonEmpty) {
+    <div class="row">
+        <h2>Exposed IAM Keys</h2>
+        <div class="card-panel red white-text">
+
+            <p class="warning">
+                <i class="material-icons right">warning</i>
+                <b>URGENT:</b>
+                Keys that have been identified as 'exposed' are very likely being used in an ongoing attack.
+            </p>
+        </div>
+
+        @for(exposedIamKey <- exposedIamKeys) {
+        <div class="col s12 m6 l4">
+            <div class="card">
+                <div class="card-content card-content--title">
+                    <span class="card-title">@exposedIamKey.username</span>
+                </div>
+                <div class="card-content--border red darken-1"></div>
+                <div class="card-content card-content--body">
+                    <table class="sg-details__table">
+                        <tbody>
+                        <tr>
+                            <th>Fraud type</th>
+                            <td>@exposedIamKey.fraudType</td>
+                        </tr>
+                        <tr>
+                            <th>Usage</th>
+                            <td>@exposedIamKey.usage</td>
+                        </tr>
+                        <tr>
+                            <th>Case ID</th>
+                            <td>
+                                <a href="https://console.aws.amazon.com/support/home#/case/?displayId=@{exposedIamKey.caseId}&language=en">
+                                    @exposedIamKey.caseId
+                                </a>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="card-action">
+                    <a class="btn usage-cta" href="https://console.aws.amazon.com/iam/home?region=eu-west-1#/users/@{exposedIamKey.username}?section=security_credentials">
+                        <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="IAM user">person</i>
+                        @exposedIamKey.username
+                    </a>
+                </div>
+            </div>
+        </div>
+        }
+    </div>
+}

--- a/hq/app/views/iam/iamAccount.scala.html
+++ b/hq/app/views/iam/iamAccount.scala.html
@@ -1,8 +1,9 @@
 @import model.{AwsAccount, CredentialReportDisplay, ExposedIAMKeyDetail}
-@(awsAccount: AwsAccount, exposedIamKeys: Either[utils.attempt.FailedAttempt, List[ExposedIAMKeyDetail]], credentialsReport: Either[utils.attempt.FailedAttempt, CredentialReportDisplay])(implicit assets: AssetsFinder)
+@import utils.attempt.FailedAttempt
+@(awsAccount: AwsAccount, exposedIamKeys: Either[FailedAttempt, List[ExposedIAMKeyDetail]], credentialsReport: Either[FailedAttempt, CredentialReportDisplay])(implicit assets: AssetsFinder)
 
 
-@errorMessage(fa: utils.attempt.FailedAttempt) = {
+@errorMessage(fa: FailedAttempt) = {
     <div class="row">
         <div class="card-panel yellow black-text">
             @for(err <- fa.failures) {

--- a/hq/app/views/iam/iamAccount.scala.html
+++ b/hq/app/views/iam/iamAccount.scala.html
@@ -1,5 +1,5 @@
 @import model.{AwsAccount, CredentialReportDisplay, ExposedIAMKeyDetail}
-@(awsAccount: AwsAccount, exposedIamKeys: List[ExposedIAMKeyDetail], report: CredentialReportDisplay)(implicit assets: AssetsFinder)
+@(awsAccount: AwsAccount, exposedIamKeys: Either[utils.attempt.FailedAttempt, List[ExposedIAMKeyDetail]], report: CredentialReportDisplay)(implicit assets: AssetsFinder)
 
 
 @main(List(awsAccount.name, "IAM report")) { @* Header *@
@@ -19,63 +19,28 @@
 
 } { @* Main content *@
     <div class="container">
-    @if(exposedIamKeys.nonEmpty) {
-        <div class="row">
-            <h2>Exposed IAM Keys</h2>
-            <div class="card-panel red white-text">
 
-                <p class="warning">
-                    <i class="material-icons right">warning</i>
-                    <b>URGENT:</b>
-                    Keys that have been identified as 'exposed' are very likely being used in an ongoing attack.
-                </p>
-            </div>
-
-            @for(exposedIamKey <- exposedIamKeys) {
-                <div class="col s12 m6 l4">
-                    <div class="card">
-                        <div class="card-content card-content--title">
-                            <span class="card-title">@exposedIamKey.username</span>
-                        </div>
-                        <div class="card-content--border red darken-1"></div>
-                        <div class="card-content card-content--body">
-                            <table class="sg-details__table">
-                                <tbody>
-                                    <tr>
-                                        <th>Fraud type</th>
-                                        <td>@exposedIamKey.fraudType</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Usage</th>
-                                        <td>@exposedIamKey.usage</td>
-                                    </tr>
-                                    <tr>
-                                        <th>Case ID</th>
-                                        <td>
-                                            <a href="https://console.aws.amazon.com/support/home#/case/?displayId=@{exposedIamKey.caseId}&language=en">
-                                            @exposedIamKey.caseId
-                                            </a>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                        <div class="card-action">
-                            <a class="btn usage-cta" href="https://console.aws.amazon.com/iam/home?region=eu-west-1#/users/@{exposedIamKey.username}?section=security_credentials">
-                                <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="IAM user">person</i>
-                                @exposedIamKey.username
-                            </a>
-                        </div>
+        @exposedIamKeys match {
+            case Right(exposedIamKeys) => {
+                @views.html.iam.exposedKeys(exposedIamKeys)
+            }
+            case Left(fa) => {
+                <div class="row">
+                    <div class="card-panel yellow black-text">
+                        @for(err <- fa.failures) {
+                            <p class="warning">
+                                <i class="material-icons right">warning</i>
+                                    <b>WARNING:</b>
+                                    @err.friendlyMessage
+                            </p>
+                        }
                     </div>
                 </div>
             }
+        }
+        <div class="row">
+            <h2>Credential Report</h2>
         </div>
-    }
-        <div>
-            <div class="row">
-                <h2>Credential Report</h2>
-                @views.html.iam.iamCredReportBody(report)
-            </div>
-        </div>
+        @views.html.iam.iamCredReportBody(report)
     </div>
 }

--- a/hq/app/views/iam/iamAccount.scala.html
+++ b/hq/app/views/iam/iamAccount.scala.html
@@ -1,6 +1,20 @@
 @import model.{AwsAccount, CredentialReportDisplay, ExposedIAMKeyDetail}
-@(awsAccount: AwsAccount, exposedIamKeys: Either[utils.attempt.FailedAttempt, List[ExposedIAMKeyDetail]], report: CredentialReportDisplay)(implicit assets: AssetsFinder)
+@(awsAccount: AwsAccount, exposedIamKeys: Either[utils.attempt.FailedAttempt, List[ExposedIAMKeyDetail]], credentialsReport: Either[utils.attempt.FailedAttempt, CredentialReportDisplay])(implicit assets: AssetsFinder)
 
+
+@errorMessage(fa: utils.attempt.FailedAttempt) = {
+    <div class="row">
+        <div class="card-panel yellow black-text">
+            @for(err <- fa.failures) {
+            <p class="warning">
+                <i class="material-icons right">warning</i>
+                <b>WARNING:</b>
+                @err.friendlyMessage
+            </p>
+            }
+        </div>
+    </div>
+}
 
 @main(List(awsAccount.name, "IAM report")) { @* Header *@
 <div class="hq-sub-header">
@@ -25,22 +39,20 @@
                 @views.html.iam.exposedKeys(exposedIamKeys)
             }
             case Left(fa) => {
-                <div class="row">
-                    <div class="card-panel yellow black-text">
-                        @for(err <- fa.failures) {
-                            <p class="warning">
-                                <i class="material-icons right">warning</i>
-                                    <b>WARNING:</b>
-                                    @err.friendlyMessage
-                            </p>
-                        }
-                    </div>
-                </div>
+                @errorMessage(fa)
             }
         }
-        <div class="row">
-            <h2>Credential Report</h2>
-        </div>
-        @views.html.iam.iamCredReportBody(report)
+
+        @credentialsReport match {
+            case Right(report) => {
+                <div class="row">
+                    <h2>Credential Report</h2>
+                </div>
+                @views.html.iam.iamCredReportBody(report)
+            }
+            case Left(fa) => {
+                @errorMessage(fa)
+            }
+        }
     </div>
 }

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -3,56 +3,54 @@
 @import logic.ReportDisplay
 @(report: CredentialReportDisplay)
 
-<div class="container greedy-width">
-    <div class="row">
-        <div class="card-panel">
-            <span>Report generated at @{DateUtils.printTime(report.reportDate)} (refreshed every four hours)</span>
-        </div>
+<div class="row">
+    <div class="card-panel">
+        <span>Report generated at @{DateUtils.printTime(report.reportDate)} (refreshed every four hours)</span>
     </div>
-    <div class="row">
-        <div class="col s12">
-            <table class="striped responsive-table iam-report__table" >
-                <tr>
-                    <th>User name</th>
-                    <th>Access Keys</th>
-                    <th>Password/MFA</th>
-                    <th>Last Activity</th>
-                    <th>Status</th>
-                </tr>
-                @for(cred <- report.humanUsers) {
+</div>
+<div class="row">
+    <div class="col s12">
+        <table class="striped responsive-table iam-report__table" >
+            <tr>
+                <th>User name</th>
+                <th>Access Keys</th>
+                <th>Password/MFA</th>
+                <th>Last Activity</th>
+                <th>Status</th>
+            </tr>
+            @for(cred <- report.humanUsers) {
 
-                    <tr>
-                        <td>
-                            <a target="_blank" rel="noopener noreferrer"  href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">@views.html.fragments.username(cred.username)
-                                <i class="material-icons link_new_tab" >open_in_new</i>
-                            </a>
-                        </td>
-                        <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)</td>
-                        <td>@views.html.fragments.mfa(cred.hasMFA)</td>
-                        <td>
-                            <span>
-                                @ReportDisplay.toDayString(cred.lastActivityDay)
-                            </span>
-                        </td>
-                        <td>@views.html.fragments.humanReportStatus(cred.reportStatus)</td>
-                    </tr>
-                }
-                @for(cred <- report.machineUsers) {
-                    <tr>
-                        <td>
-                            <a target="_blank" rel="noopener noreferrer"  href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">@views.html.fragments.username(cred.username)
-                                <i class="material-icons link_new_tab" >open_in_new</i>
-                            </a>
-                        </td>
-                        <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)</td>
-                        <td><span>-</span></td>
-                        <td>
-                            <span>@ReportDisplay.toDayString(cred.lastActivityDay)</span>
-                        </td>
-                        <td>@views.html.fragments.machineReportStatus(cred.reportStatus)</td>
-                    </tr>
-                }
-            </table>
-        </div>
+                <tr>
+                    <td>
+                        <a target="_blank" rel="noopener noreferrer"  href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">@views.html.fragments.username(cred.username)
+                            <i class="material-icons link_new_tab" >open_in_new</i>
+                        </a>
+                    </td>
+                    <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)</td>
+                    <td>@views.html.fragments.mfa(cred.hasMFA)</td>
+                    <td>
+                        <span>
+                            @ReportDisplay.toDayString(cred.lastActivityDay)
+                        </span>
+                    </td>
+                    <td>@views.html.fragments.humanReportStatus(cred.reportStatus)</td>
+                </tr>
+            }
+            @for(cred <- report.machineUsers) {
+                <tr>
+                    <td>
+                        <a target="_blank" rel="noopener noreferrer"  href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">@views.html.fragments.username(cred.username)
+                            <i class="material-icons link_new_tab" >open_in_new</i>
+                        </a>
+                    </td>
+                    <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)</td>
+                    <td><span>-</span></td>
+                    <td>
+                        <span>@ReportDisplay.toDayString(cred.lastActivityDay)</span>
+                    </td>
+                    <td>@views.html.fragments.machineReportStatus(cred.reportStatus)</td>
+                </tr>
+            }
+        </table>
     </div>
 </div>


### PR DESCRIPTION
## What does this change?

#### 👉 New logic to show warning(s) on IAM page if one or both of the datasets is unavailable

This PR allows the IAM account pages on Security HQ to show a warning if either the credentials or exposed keys results in a failed attempt, while still showing the other report it that succeeds. 

For example, if the Exposed Keys cache service does not start, or fails to fetch data from AWS, the error makes it to the dashboard along with the available data (credentials report):

##### BEFORE
<img width="1232" alt="picture 155" src="https://user-images.githubusercontent.com/8607683/34838422-eaec3e00-f6f5-11e7-8f00-d1ac534ae6f6.png">

##### AFTER
<img width="1232" alt="picture 153" src="https://user-images.githubusercontent.com/8607683/34837365-7cbfbf04-f6f2-11e7-90c6-2aad85ce2ee3.png">

Worst case scenario, the user gets two bright error messages:

<img width="1223" alt="picture 154" src="https://user-images.githubusercontent.com/8607683/34837993-6bbdf28c-f6f4-11e7-9db5-29c32412ef3d.png">

#### 👉 Refactoring templates
- Making a new fragment since the pattern matching adds noise
- Deleting some extra rows from the templates, and fixing indents to match other pages


## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

## Any additional notes?

Tested with demo exposed keys, hence the template changes to make the page layouts more consistent and aesthetically pleasing 💅
