### PR TITLE
Add name tag to Security HQ instances

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -280,6 +280,10 @@ Resources:
         Value:
           Fn::FindInMap: [ Constants, App, Value ]
         PropagateAtLaunch: true
+      - Key: Name
+        Value:
+          Fn::FindInMap: [ Constants, App, Value ]
+        PropagateAtLaunch: true
 
 Outputs:
   LoadBalancerUrl:


### PR DESCRIPTION
## What does this change?

Adds a `Name` tag to Security HQ instances

## What is the value of this?

`Name` is a "convention" tag in AWS and is prominently displayed in the EC2 console. This will make it easy to identity Security HQ's instances(s) at a glance.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

## Any additional notes?

This is a CloudFormation change for the application itself so we will need to manually update the CF stack in the AWS console.