### PR TITLE
A Better Security Groups Cache Refresh

### DIFF
--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -32,6 +32,7 @@ Resources:
             Action:
             # Analyse security groups
             - trustedadvisor:Describe*
+            - trustedadvisor:Refresh*
             - support:*
             - ec2:DescribeNetworkInterfaces
             - ec2:DescribeSecurityGroups

--- a/hq/app/aws/support/TrustedAdvisor.scala
+++ b/hq/app/aws/support/TrustedAdvisor.scala
@@ -59,6 +59,12 @@ object TrustedAdvisor {
     handleAWSErrs(awsToScala(client.describeTrustedAdvisorChecksAsync)(request).map(parseTrustedAdvisorChecksResult))
   }
 
+  def refreshTrustedAdvisorChecks(client: AWSSupportAsync, checkId: String)(implicit ec: ExecutionContext): Attempt[RefreshTrustedAdvisorCheckResult] = {
+    val request = new RefreshTrustedAdvisorCheckRequest()
+      .withCheckId(checkId)
+    handleAWSErrs(awsToScala(client.refreshTrustedAdvisorCheckAsync)(request))
+  }
+
   def parseTrustedAdvisorChecksResult(result: DescribeTrustedAdvisorChecksResult): List[TrustedAdvisorCheck] = {
     result.getChecks.asScala.toList.map { trustedAdvisorCheckResult =>
       TrustedAdvisorCheck(

--- a/hq/app/aws/support/TrustedAdvisorSGOpenPorts.scala
+++ b/hq/app/aws/support/TrustedAdvisorSGOpenPorts.scala
@@ -1,13 +1,16 @@
 package aws.support
 
-import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult}
+import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult, refreshTrustedAdvisorChecks}
 import com.amazonaws.services.support.AWSSupportAsync
-import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
+import com.amazonaws.services.support.model.{RefreshTrustedAdvisorCheckResult, TrustedAdvisorResourceDetail}
+import logic.Retry
 import model.{SGOpenPortsDetail, TrustedAdvisorDetailsResult}
 import utils.attempt.{Attempt, Failure}
 
+
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 
 object TrustedAdvisorSGOpenPorts {
@@ -60,4 +63,11 @@ object TrustedAdvisorSGOpenPorts {
         }
     }
   }
+
+  def refreshSGOpenPorts(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[RefreshTrustedAdvisorCheckResult] = {
+    val delay = 3.seconds
+    val checkId = AWS_SECURITY_GROUPS_PORTS_UNRESTRICTED_IDENTIFIER
+    Retry.until(refreshTrustedAdvisorChecks(client, checkId), _.getStatus.getStatus == "success", s"Failed to refresh $checkId report", delay)
+  }
+
 }

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -36,5 +36,4 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
     }
   }
 
-
 }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -15,6 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 
+
 class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, environment: Environment)(implicit ec: ExecutionContext) {
   private val accounts = Config.getAwsAccounts(config)
   private val startingCache = accounts.map(acc => (acc, Left(Failure.cacheServiceError(acc.id, "cache").attempt))).toMap
@@ -72,6 +73,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   private def refreshSgsBox(): Unit = {
     Logger.info("Started refresh of the Security Groups data")
     for {
+      _ <- EC2.refreshSGSReports(accounts)
       allFlaggedSgs <- EC2.allFlaggedSgs(accounts)
     } yield {
       Logger.info("Sending the refreshed data to the Security Groups Box")


### PR DESCRIPTION
## What does this change?

Currently the CacheService runs `refreshSgsBox()` every 5 minutes. This adds a step ( `EC2.refreshSGSReports` ) to that `refreshSgsBox()` by which we instruct AWS to update/refresh its security group open ports report. 

## What is the value of this?

Increase the correctness (up-to-date-ness if I may) of the cache.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes. watched-account.template.yaml has been update to allow Trusted Advisor to run `Refresh`.
