### PR TITLE
Add Snyk report and Configraun

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ scalaVersion in ThisBuild := "2.12.3"
 scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
 
 // resolvers += "guardian-bintray" at "https://dl.bintray.com/guardian/sbt-plugins/"
+resolvers += DefaultMavenRepository
 
 val awsSdkVersion = "1.11.258"
 val playVersion = "2.6.7"
@@ -22,10 +23,11 @@ lazy val hq = (project in file("hq")).
     libraryDependencies ++= Seq(
       ws,
       filters,
-      "com.gu" %% "play-googleauth" % "0.7.0",
+      "com.gu" %% "play-googleauth" % "0.7.1",
       "joda-time" % "joda-time" % "2.9.9",
-      "org.typelevel" %% "cats" % "0.8.1",
+      "org.typelevel" %% "cats-core" % "1.0.1",
       "com.github.tototoshi" %% "scala-csv" % "1.3.5",
+      "com.gu" %% "configraun" % "0.2",
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-support" % awsSdkVersion,

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -98,6 +98,12 @@ Resources:
             - s3:ListBucket
             - s3:GetObjectVersion
             - s3:GetObject
+          # Describe instance tags, to find out its own stack, app, stage.
+          - Effect: Allow
+            Resource:
+            - *
+            Action:
+            - ec2:DescribeTags
           # allow security HQ to assume roles in watched accounts
           - Effect: Allow
             Resource: "*"

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -1,7 +1,11 @@
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
+import com.gu.configraun.Configraun
+import com.gu.configraun.aws.AWSSimpleSystemsManagementFactory
+import com.gu.configraun.models._
 import controllers._
 import filters.HstsFilter
 import play.api.ApplicationLoader.Context
-import play.api.BuiltInComponentsFromContext
+import play.api.{BuiltInComponentsFromContext, Logger}
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.{AnyContent, BodyParser, ControllerComponents}
@@ -24,13 +28,40 @@ class AppComponents(context: Context)
     csrfFilter,
     new HstsFilter()
   )
+  implicit val awsClient: AWSSimpleSystemsManagement = AWSSimpleSystemsManagementFactory("eu-west-1", "security")
+
+  val configraun: Configuration = {
+
+    configuration.getOptional[String]("stage") match {
+      case Some("DEV") => {
+        val stack = configuration.get[String]("stack")
+        val app = configuration.get[String]("app")
+        val stage = "DEV"
+        Configraun.loadConfig(Identifier(Stack(stack), App(app), Stage.fromString(stage).get)) match {
+          case Left(a) => {
+            Logger.error(s"Unable to load Configraun configuration from AWS (${a.message})")
+            sys.exit(1)
+          }
+          case Right(a: com.gu.configraun.models.Configuration) => a
+        }
+      }
+      case _ => Configraun.loadConfig match {
+        case Left(a) => {
+          Logger.error(s"Unable to load Configraun configuration from AWS tags (${a.message})")
+          sys.exit(1)
+        }
+        case Right(a: com.gu.configraun.models.Configuration) => a
+      }
+    }
+  }
 
   val cacheService = new CacheService(configuration, applicationLifecycle, environment)
 
   override def router: Router = new Routes(
     httpErrorHandler,
-    new HQController(configuration, cacheService),
+  new HQController(configuration, cacheService),
     new SecurityGroupsController(configuration, cacheService),
+    new SnykController(configuration, configraun),
     new AuthController(environment, configuration),
     new UtilityController(),
     assets

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -41,7 +41,7 @@ class AppComponents(context: Context)
           case Left(a) =>
             Logger.error(s"Unable to load Configraun configuration from AWS (${a.message})")
             sys.exit(1)
-          case Right(a: com.gu.configraun.models.Configuration) => a
+          case Right(a) => a
         }
       case _ => Configraun.loadConfig match {
         case Left(a) =>

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -33,23 +33,20 @@ class AppComponents(context: Context)
   val configraun: Configuration = {
 
     configuration.getOptional[String]("stage") match {
-      case Some("DEV") => {
+      case Some("DEV") =>
         val stack = configuration.get[String]("stack")
         val app = configuration.get[String]("app")
         val stage = "DEV"
         Configraun.loadConfig(Identifier(Stack(stack), App(app), Stage.fromString(stage).get)) match {
-          case Left(a) => {
+          case Left(a) =>
             Logger.error(s"Unable to load Configraun configuration from AWS (${a.message})")
             sys.exit(1)
-          }
           case Right(a: com.gu.configraun.models.Configuration) => a
         }
-      }
       case _ => Configraun.loadConfig match {
-        case Left(a) => {
+        case Left(a) =>
           Logger.error(s"Unable to load Configraun configuration from AWS tags (${a.message})")
           sys.exit(1)
-        }
         case Right(a: com.gu.configraun.models.Configuration) => a
       }
     }

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -59,7 +59,7 @@ class AppComponents(context: Context)
 
   override def router: Router = new Routes(
     httpErrorHandler,
-  new HQController(configuration, cacheService),
+    new HQController(configuration, cacheService),
     new SecurityGroupsController(configuration, cacheService),
     new SnykController(configuration, configraun),
     new AuthController(environment, configuration),

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
 
 object Snyk {
 
-  def getSnykOrganisations(token: Token, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[WSResponse] = {
+  def getSnykOrganisations(token: SnykToken, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[WSResponse] = {
 
     val snykOrgUrl = "https://snyk.io/api/v1/orgs"
 
@@ -24,7 +24,7 @@ object Snyk {
     }
   }
 
-  def getProjects(token: Token, id: String, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[WSResponse] = {
+  def getProjects(token: SnykToken, id: String, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[WSResponse] = {
     val snykProjectsUrl = s"https://snyk.io/api/v1/org/$id/projects"
     val a = wsClient.url(snykProjectsUrl)
         .addHttpHeaders("Authorization" -> s"token ${token.value}")
@@ -36,7 +36,7 @@ object Snyk {
     }
   }
 
-  def getProjectVulnerabilities(id: String, projects: List[SnykProject], token: Token, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[List[WSResponse]] = {
+  def getProjectVulnerabilities(id: String, projects: List[SnykProject], token: SnykToken, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[List[WSResponse]] = {
     val projectVulnerabilityResponses = projects
       .map(project => {
         val snykProjectUrl = s"https://snyk.io/api/v1/org/$id/project/${project.id}/issues"

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -25,10 +25,10 @@ object Snyk {
   }
 
   def getProjects(token: Token, id: String, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[WSResponse] = {
-        val snykProjectsUrl = s"https://snyk.io/api/v1/org/$id/projects"
-        val a = wsClient.url(snykProjectsUrl)
-          .addHttpHeaders("Authorization" -> s"token ${token.value}")
-          .get()
+    val snykProjectsUrl = s"https://snyk.io/api/v1/org/$id/projects"
+    val a = wsClient.url(snykProjectsUrl)
+        .addHttpHeaders("Authorization" -> s"token ${token.value}")
+        .get()
 
     Attempt.fromFuture(a) { case NonFatal(e) =>
       val failure = Failure(e.getMessage, "Could not read projects from Snyk", 502, None, Some(e))

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -1,0 +1,71 @@
+package api
+
+import model._
+import play.api.libs.json._
+import play.api.libs.ws.{WSClient, WSResponse}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
+
+import scala.concurrent.ExecutionContext
+import scala.util.control.NonFatal
+
+object Snyk {
+
+  def getSnykOrganisations(token: Token, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[WSResponse] = {
+
+    val snykOrgUrl = "https://snyk.io/api/v1/orgs"
+
+    val futureResponse = wsClient.url(snykOrgUrl)
+      .addHttpHeaders("Authorization" -> s"token ${token.value}")
+      .get
+
+    Attempt.fromFuture(futureResponse) { case NonFatal(e) =>
+      val failure = Failure(e.getMessage, "Could not read organisations from Snyk", 502, None, Some(e))
+      FailedAttempt(failure)
+    }
+  }
+
+  def getProjects(token: Token, id: String, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[WSResponse] = {
+        val snykProjectsUrl = s"https://snyk.io/api/v1/org/$id/projects"
+        val a = wsClient.url(snykProjectsUrl)
+          .addHttpHeaders("Authorization" -> s"token ${token.value}")
+          .get()
+
+    Attempt.fromFuture(a) { case NonFatal(e) =>
+      val failure = Failure(e.getMessage, "Could not read projects from Snyk", 502, None, Some(e))
+      FailedAttempt(failure)
+    }
+  }
+
+  def getProjectVulnerabilities(id: String, projects: List[SnykProject], token: Token, wsClient: WSClient)(implicit ec:ExecutionContext): Attempt[List[WSResponse]] = {
+    val projectVulnerabilityResponses = projects
+      .map(project => {
+        val snykProjectUrl = s"https://snyk.io/api/v1/org/$id/project/${project.id}/issues"
+
+        val projectIssuesFilter = Json.obj(
+          "filters" -> Json.obj(
+            "severity" -> JsArray(List(
+              JsString("high"), JsString("medium"), JsString("low")
+            )),
+            "types" -> JsArray(List(
+              JsString("vuln")
+            )),
+            "ignored" -> "false",
+            "patched" -> "false"
+          )
+        )
+
+        wsClient.url(snykProjectUrl)
+          .addHttpHeaders("Authorization" -> s"token ${token.value}")
+          .post(projectIssuesFilter)
+
+      })
+    Attempt.traverse(projectVulnerabilityResponses) {
+      projectVulnerabilityResponse =>
+        Attempt.fromFuture(projectVulnerabilityResponse) {
+          case NonFatal(e) =>
+            val failure = Failure(e.getMessage, "Could not read project vulnerabilities from Snyk", 502, None, Some(e))
+            FailedAttempt(failure)
+        }
+    }
+  }
+}

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -29,8 +29,8 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
     Action.async {
       attempt {
         for {
-          token <- getToken
-          organisation <- getOrganisation
+          token <- getSnykToken
+          organisation <- getSnykOrganisation
 
           organisationResponse <- Snyk.getSnykOrganisations(token, wsClient)
           organisationId <- SnykDisplay.getOrganisationId(organisationResponse.body, organisation)
@@ -50,18 +50,18 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
 
   }
 
-  def getToken: Attempt[Token] = configraun.getAsString("/snyk/token") match {
+  def getSnykToken: Attempt[SnykToken] = configraun.getAsString("/snyk/token") match {
     case Left(a:ConfigraunError) =>
       val failure = Failure(a.message, "Could not read Snyk token from aws parameter store", 500, None, Some(a.e))
       Attempt.Left(failure)
-    case Right(a:String) => Attempt.Right(Token(a))
+    case Right(a:String) => Attempt.Right(SnykToken(a))
   }
 
-  def getOrganisation: Attempt[Organisation] = configraun.getAsString("/snyk/organisation") match {
+  def getSnykOrganisation: Attempt[SnykOrganisation] = configraun.getAsString("/snyk/organisation") match {
     case Left(a:ConfigraunError) =>
       val failure = Failure(a.message, "Could not read Snyk organisation from aws parameter store", 500, None, Some(a.e))
       Attempt.Left(failure)
-    case Right(a:String) => Attempt.Right(Organisation(a))
+    case Right(a:String) => Attempt.Right(SnykOrganisation(a))
   }
 
 }

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -1,0 +1,70 @@
+package controllers
+
+
+import auth.SecurityHQAuthActions
+import play.api.Configuration
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext
+import logic.SnykDisplay
+import api.Snyk
+import com.gu.configraun.Errors.ConfigraunError
+import utils.attempt.{Attempt, Failure}
+import utils.attempt.PlayIntegration.attempt
+import model._
+
+class SnykController(val config: Configuration, val configraun: com.gu.configraun.models.Configuration)
+                    (implicit
+                     val ec: ExecutionContext,
+                     val wsClient: WSClient,
+                     val bodyParser: BodyParser[AnyContent],
+                     val controllerComponents: ControllerComponents,
+                     val assetsFinder: AssetsFinder)
+  extends BaseController  with SecurityHQAuthActions
+{
+
+  def snyk: Action[AnyContent] = {
+
+    Action.async {
+      attempt {
+        for {
+          token <- getToken
+          organisation <- getOrganisation
+
+          organisationResponse <- Snyk.getSnykOrganisations(token, wsClient)
+          organisationId <- SnykDisplay.getOrganisationId(organisationResponse.body, organisation)
+
+          projectResponse <- Snyk.getProjects(token, organisationId, wsClient)
+          projects <- SnykDisplay.getProjectIdList(projectResponse.body)
+
+          vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(organisationId, projects, token, wsClient)
+          vulnerabilitiesResponseBodies = vulnerabilitiesResponse.map(a => a.body)
+          parsedVulnerabilitiesResponse <- SnykDisplay.parseProjectVulnerabilities(vulnerabilitiesResponseBodies)
+
+          results = SnykDisplay.labelProjects(projects, parsedVulnerabilitiesResponse)
+          sortedResult = SnykDisplay.sortProjects(results)
+        } yield Ok(views.html.snyk.snyk(sortedResult))
+      }
+    }
+
+  }
+
+  def getToken: Attempt[Token] = configraun.getAsString("/snyk/token") match {
+    case Left(a:ConfigraunError) =>
+      val failure = Failure(a.message, "Could not read Snyk token from aws parameter store", 500, None, Some(a.e))
+      Attempt.Left(failure)
+    case Right(a:String) => Attempt.Right(Token(a))
+  }
+
+  def getOrganisation: Attempt[Organisation] = configraun.getAsString("/snyk/organisation") match {
+    case Left(a:ConfigraunError) =>
+      val failure = Failure(a.message, "Could not read Snyk organisation from aws parameter store", 500, None, Some(a.e))
+      Attempt.Left(failure)
+    case Right(a:String) => Attempt.Right(Organisation(a))
+  }
+
+}
+
+
+

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -10,7 +10,7 @@ import model.Serializers._
 
 object SnykDisplay {
 
-  def getOrganisationId(s: String, organisation: Organisation): Attempt[String] = {
+  def getOrganisationId(s: String, organisation: SnykOrganisation): Attempt[String] = {
     val id = for {
       orglist <- (Json.parse(s) \ "orgs").asOpt[List[SnykOrg]]
       org <- orglist.find(_.name == organisation.value)

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -6,8 +6,9 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 import scala.concurrent.ExecutionContext
 
 import model._
+import model.Serializers._
 
-object SnykDisplay extends Serializers {
+object SnykDisplay {
 
   def getOrganisationId(s: String, organisation: Organisation): Attempt[String] = {
     val id = for {

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -1,0 +1,45 @@
+package logic
+
+import play.api.libs.json._
+import utils.attempt.{Attempt, FailedAttempt, Failure}
+
+import scala.concurrent.ExecutionContext
+
+import model._
+
+object SnykDisplay extends Serializers {
+
+  def getOrganisationId(s: String, organisation: Organisation): Attempt[String] = {
+    val id = for {
+      orglist <- (Json.parse(s) \ "orgs").asOpt[List[SnykOrg]]
+      org <- orglist.find(_.name == organisation.value)
+    } yield org.id
+    val error = Json.parse(s).asOpt[SnykError].getOrElse(SnykError(s))
+    val f = Failure(s"Unable to find organisation from $s", s"Could not read Snyk response (${error.error})", 502, None, None)
+    Attempt.fromOption(id, FailedAttempt(f))
+  }
+
+  def getProjectIdList(s: String): Attempt[List[SnykProject]] = {
+    val projectIds = (Json.parse(s) \ "projects").asOpt[List[SnykProject]]
+    val error = Json.parse(s).asOpt[SnykError].getOrElse(SnykError(s))
+    val f = Failure(s"Unable to find project ids from $s", s"Could not read Snyk response (${error.error})", 502, None, None)
+    Attempt.fromOption(projectIds, FailedAttempt(f))
+  }
+
+  def parseProjectVulnerabilities(projects: List[String])(implicit ec:ExecutionContext): Attempt[List[SnykProjectIssues]] = {
+    val b = projects.map( s => {
+      val projectVulnerabilities = Json.parse(s).asOpt[SnykProjectIssues]
+      val error = Json.parse(s).asOpt[SnykError].getOrElse(SnykError(s))
+      val f = Failure(s"Unable to find project vulnerabilities from $s", s"Could not read Snyk response (${error.error})", 502, None, None)
+      Attempt.fromOption(projectVulnerabilities, FailedAttempt(f))
+    })
+    Attempt.traverse(b)(a => a)
+  }
+
+  def labelProjects(projects: List[SnykProject], responses: List[SnykProjectIssues]): List[SnykProjectIssues] = {
+    projects.zip(responses).map(a => a._2.copy(name = a._1.name).copy(id = a._1.id))
+  }
+
+  def sortProjects(projects: List[SnykProjectIssues]): List[SnykProjectIssues] =
+    projects.sortBy(spi => (-spi.high, -spi.medium, -spi.low, spi.name))  //Negations to produce maximum-first sort.
+}

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -27,13 +27,13 @@ object SnykDisplay extends Serializers {
   }
 
   def parseProjectVulnerabilities(projects: List[String])(implicit ec:ExecutionContext): Attempt[List[SnykProjectIssues]] = {
-    val b = projects.map( s => {
+    val projectVulnerabilitiesList = projects.map( s => {
       val projectVulnerabilities = Json.parse(s).asOpt[SnykProjectIssues]
       val error = Json.parse(s).asOpt[SnykError].getOrElse(SnykError(s))
       val f = Failure(s"Unable to find project vulnerabilities from $s", s"Could not read Snyk response (${error.error})", 502, None, None)
       Attempt.fromOption(projectVulnerabilities, FailedAttempt(f))
     })
-    Attempt.traverse(b)(a => a)
+    Attempt.traverse(projectVulnerabilitiesList)(a => a)
   }
 
   def labelProjects(projects: List[SnykProject], responses: List[SnykProjectIssues]): List[SnykProjectIssues] = {

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -10,21 +10,21 @@ import model.Serializers._
 
 object SnykDisplay {
 
-  def getOrganisationId(s: String, organisation: SnykOrganisation): Attempt[String] = {
-    val id = for {
-      orglist <- (Json.parse(s) \ "orgs").asOpt[List[SnykOrg]]
-      org <- orglist.find(_.name == organisation.value)
-    } yield org.id
+  def getOrganisation(s: String, requiredOrganisation: SnykOrganisationName): Attempt[SnykOrganisation] = {
+    val organisation = for {
+      orglist <- (Json.parse(s) \ "orgs").asOpt[List[SnykOrganisation]]
+      org <- orglist.find(_.name == requiredOrganisation.value)
+    } yield org
     val error = Json.parse(s).asOpt[SnykError].getOrElse(SnykError(s))
     val f = Failure(s"Unable to find organisation from $s", s"Could not read Snyk response (${error.error})", 502, None, None)
-    Attempt.fromOption(id, FailedAttempt(f))
+    Attempt.fromOption(organisation, FailedAttempt(f))
   }
 
   def getProjectIdList(s: String): Attempt[List[SnykProject]] = {
-    val projectIds = (Json.parse(s) \ "projects").asOpt[List[SnykProject]]
+    val projects = (Json.parse(s) \ "projects").asOpt[List[SnykProject]]
     val error = Json.parse(s).asOpt[SnykError].getOrElse(SnykError(s))
     val f = Failure(s"Unable to find project ids from $s", s"Could not read Snyk response (${error.error})", 502, None, None)
-    Attempt.fromOption(projectIds, FailedAttempt(f))
+    Attempt.fromOption(projects, FailedAttempt(f))
   }
 
   def parseProjectVulnerabilities(projects: List[String])(implicit ec:ExecutionContext): Attempt[List[SnykProjectIssues]] = {
@@ -37,10 +37,14 @@ object SnykDisplay {
     Attempt.traverse(projectVulnerabilitiesList)(a => a)
   }
 
+  def labelOrganisations(projects: List[SnykProject], snykOrg: SnykOrganisation): List[SnykProject] = {
+    projects.map(project => project.copy(organisation = Some(snykOrg)))
+  }
+
   def labelProjects(projects: List[SnykProject], responses: List[SnykProjectIssues]): List[SnykProjectIssues] = {
-    projects.zip(responses).map(a => a._2.copy(name = a._1.name).copy(id = a._1.id))
+    projects.zip(responses).map(a => a._2.copy(project = Some(a._1)))
   }
 
   def sortProjects(projects: List[SnykProjectIssues]): List[SnykProjectIssues] =
-    projects.sortBy(spi => (-spi.high, -spi.medium, -spi.low, spi.name))  //Negations to produce maximum-first sort.
+    projects.sortBy(spi => (-spi.high, -spi.medium, -spi.low, spi.project.get.name))  //Negations to produce maximum-first sort.
 }

--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -7,35 +7,17 @@ object Serializers {
 
   implicit val snykErrorFormat: Reads[SnykError] = Json.reads[SnykError]
 
-  implicit val snykOrgFormat: Format[SnykOrg] = (
-    (JsPath \ "name").format[String]
-      and
-      (JsPath \ "id").format[String]
-    )(SnykOrg.apply, unlift(SnykOrg.unapply))
+  implicit val snykOrgFormat: Format[SnykOrg] = Json.format[SnykOrg]
 
-  implicit val snykProjectFormat: Format[SnykProject] = (
-    (JsPath \ "name").format[String]
-      and
-      (JsPath \ "id").format[String]
-    )(SnykProject.apply, unlift(SnykProject.unapply))
+  implicit val snykProjectFormat: Format[SnykProject] = Json.format[SnykProject]
 
-  implicit val snykIssueReads: Reads[SnykIssue] = (
-    (JsPath \ "title").read[String]
-      and
-      (JsPath \ "id").read[String]
-      and
-      (JsPath \ "severity").read[String]
-    )(SnykIssue.apply _)
+  implicit val snykIssueReads: Format[SnykIssue] = Json.format[SnykIssue]
 
   implicit val snykProjectIssuesReads: Reads[SnykProjectIssues] = (
     Reads.pure("Unknown")
-      and
-      Reads.pure("Unknown")
-      and
-      (JsPath \ "ok").read[Boolean]
-      and
-      (JsPath \ "issues" \ "vulnerabilities").read[List[SnykIssue]]
+    and Reads.pure("Unknown")
+    and (JsPath \ "ok").read[Boolean]
+    and (JsPath \ "issues" \ "vulnerabilities").read[List[SnykIssue]]
     )(SnykProjectIssues.apply _)
-
 
 }

--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -7,17 +7,24 @@ object Serializers {
 
   implicit val snykErrorFormat: Reads[SnykError] = Json.reads[SnykError]
 
-  implicit val snykOrgFormat: Format[SnykOrg] = Json.format[SnykOrg]
+  implicit val snykOrgFormat: Reads[SnykOrganisation] = Json.reads[SnykOrganisation]
 
-  implicit val snykProjectFormat: Format[SnykProject] = Json.format[SnykProject]
+  implicit val snykProjectFormat: Reads[SnykProject] = (
+    (JsPath \ "name").read[String]
+      and
+      (JsPath \ "id").read[String]
+      and
+      Reads.pure(None)
+    )(SnykProject.apply _)
 
   implicit val snykIssueReads: Format[SnykIssue] = Json.format[SnykIssue]
 
   implicit val snykProjectIssuesReads: Reads[SnykProjectIssues] = (
-    Reads.pure("Unknown")
-    and Reads.pure("Unknown")
-    and (JsPath \ "ok").read[Boolean]
-    and (JsPath \ "issues" \ "vulnerabilities").read[List[SnykIssue]]
+    Reads.pure(None)
+      and
+      (JsPath \ "ok").read[Boolean]
+      and
+      (JsPath \ "issues" \ "vulnerabilities").read[List[SnykIssue]]
     )(SnykProjectIssues.apply _)
 
 }

--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -3,7 +3,7 @@ package model
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Format, JsPath, Json, Reads}
 
-trait Serializers {
+object Serializers {
 
   implicit val snykErrorFormat: Reads[SnykError] = Json.reads[SnykError]
 

--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -1,0 +1,41 @@
+package model
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Format, JsPath, Json, Reads}
+
+trait Serializers {
+
+  implicit val snykErrorFormat: Reads[SnykError] = Json.reads[SnykError]
+
+  implicit val snykOrgFormat: Format[SnykOrg] = (
+    (JsPath \ "name").format[String]
+      and
+      (JsPath \ "id").format[String]
+    )(SnykOrg.apply, unlift(SnykOrg.unapply))
+
+  implicit val snykProjectFormat: Format[SnykProject] = (
+    (JsPath \ "name").format[String]
+      and
+      (JsPath \ "id").format[String]
+    )(SnykProject.apply, unlift(SnykProject.unapply))
+
+  implicit val snykIssueReads: Reads[SnykIssue] = (
+    (JsPath \ "title").read[String]
+      and
+      (JsPath \ "id").read[String]
+      and
+      (JsPath \ "severity").read[String]
+    )(SnykIssue.apply _)
+
+  implicit val snykProjectIssuesReads: Reads[SnykProjectIssues] = (
+    Reads.pure("Unknown")
+      and
+      Reads.pure("Unknown")
+      and
+      (JsPath \ "ok").read[Boolean]
+      and
+      (JsPath \ "issues" \ "vulnerabilities").read[List[SnykIssue]]
+    )(SnykProjectIssues.apply _)
+
+
+}

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -135,3 +135,21 @@ case class MachineUser  (
   reportStatus: ReportStatus,
   lastActivityDay : Option[Long]
 )
+
+case class Token(value: String) extends AnyVal
+
+case class Organisation(value: String) extends AnyVal
+
+case class SnykOrg(name: String, id: String)
+
+case class SnykProject(name: String, id: String)
+
+case class SnykIssue(title: String, id: String, severity: String)
+
+case class SnykProjectIssues(name: String, id: String, ok: Boolean, vulnerabilities: List[SnykIssue])  {
+  def high: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("high"))
+  def medium: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("medium"))
+  def low: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("low"))
+}
+
+case class SnykError(error: String)

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -136,9 +136,9 @@ case class MachineUser  (
   lastActivityDay : Option[Long]
 )
 
-case class Token(value: String) extends AnyVal
+case class SnykToken(value: String) extends AnyVal
 
-case class Organisation(value: String) extends AnyVal
+case class SnykOrganisation(value: String) extends AnyVal
 
 case class SnykOrg(name: String, id: String)
 

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -138,15 +138,15 @@ case class MachineUser  (
 
 case class SnykToken(value: String) extends AnyVal
 
-case class SnykOrganisation(value: String) extends AnyVal
+case class SnykOrganisationName(value: String) extends AnyVal
 
-case class SnykOrg(name: String, id: String)
+case class SnykOrganisation(name: String, id: String)
 
-case class SnykProject(name: String, id: String)
+case class SnykProject(name: String, id: String, organisation: Option[SnykOrganisation])
 
 case class SnykIssue(title: String, id: String, severity: String)
 
-case class SnykProjectIssues(name: String, id: String, ok: Boolean, vulnerabilities: List[SnykIssue])  {
+case class SnykProjectIssues(project: Option[SnykProject], ok: Boolean, vulnerabilities: List[SnykIssue])  {
   def high: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("high"))
   def medium: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("medium"))
   def low: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("low"))

--- a/hq/app/views/header.scala.html
+++ b/hq/app/views/header.scala.html
@@ -22,6 +22,9 @@
                             <a href="/iam"><i class="material-icons black-text">vpn_key</i></a>
                         </li>
                         <li class="main-nav">
+                            <a href="/snyk"><i class="material-icons black-text">lock_open</i></a>
+                        </li>
+                        <li class="main-nav">
                             <a href="/documentation/"><i class="material-icons black-text">description</i></a>
                         </li>
                     </ul>
@@ -35,6 +38,9 @@
                         </li>
                         <li class="main-nav">
                             <a href="/iam"><i class="material-icons black-text">vpn_key</i>Credentials audits</a>
+                        </li>
+                        <li class="main-nav">
+                            <a href="/snyk"><i class="material-icons black-text">lock_open</i>Snyk</a>
                         </li>
                         <li class="main-nav">
                             <a href="/documentation/"><i class="material-icons black-text">description</i>Documentation</a>

--- a/hq/app/views/index.scala.html
+++ b/hq/app/views/index.scala.html
@@ -37,6 +37,17 @@
                     </a>
                 </div>
             </div>
+            <div class="card">
+                <div class="card-content">
+                    <a class="hp__link" href="/snyk">
+                        <i class="right material-icons">lock_open</i>
+                        <span class="card-title">Snyk audits</span>
+                        <p>
+                            Snyk vulnerability reports.
+                        </p>
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
     <div class="accounts__container">

--- a/hq/app/views/main.scala.html
+++ b/hq/app/views/main.scala.html
@@ -53,5 +53,6 @@
         <script src='@routes.Assets.versioned("javascripts/jquery-3.1.1.min.js")'></script>
         <script src='@routes.Assets.versioned("materialize/js/materialize.min.js")'></script>
         <script src='@routes.Assets.versioned("javascripts/app.js")'></script>
+        <script src='@routes.Assets.versioned("javascripts/jquery.filtertable.js")'></script>
     </body>
 </html>

--- a/hq/app/views/snyk/snyk.scala.html
+++ b/hq/app/views/snyk/snyk.scala.html
@@ -4,7 +4,7 @@
 
 @(results: List[SnykProjectIssues])(implicit assets: AssetsFinder)
 
-@main(Nil) { @* Header *@
+@main(List("Snyk")) { @* Header *@
     <div class="container">
         <div class="row">
             <h1 class="header center-on-small-only grey-text text-lighten-5">Security HQ</h1>
@@ -29,21 +29,19 @@
             </thead>
 
             <tbody>
-            @for(project <- results) {
+            @for(projectIssues <- results) {
                 <tr>
                     <td>
-                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/">@project.name</a>
+                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/">@projectIssues.project.get.name</a>
                     </td>
                     <td>
-                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/?disclosure=all&severity=high">
-                            @project.high
-                        </a>
+                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/?disclosure=all&severity=high">@projectIssues.high</a>
                     </td>
                     <td>
-                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/?disclosure=all&severity=medium">@project.medium</a>
+                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/?disclosure=all&severity=medium">@projectIssues.medium</a>
                     </td>
                     <td>
-                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/?disclosure=all&severity=low">@project.low</a>
+                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/?disclosure=all&severity=low">@projectIssues.low</a>
                     </td>
                 </tr>
             }

--- a/hq/app/views/snyk/snyk.scala.html
+++ b/hq/app/views/snyk/snyk.scala.html
@@ -1,0 +1,56 @@
+@import logic.SnykDisplay
+@import logic._
+@import model._
+
+@(results: List[SnykProjectIssues])(implicit assets: AssetsFinder)
+
+@main(Nil) { @* Header *@
+    <div class="container">
+        <div class="row">
+            <h1 class="header center-on-small-only grey-text text-lighten-5">Security HQ</h1>
+            <div class="col s12 m9">
+                <h4 class="grey-text text-darken-4 center-on-small-only">Snyk Results</h4>
+            </div>
+        </div>
+    </div>
+
+} { @* Main content *@
+
+    <div class="container">
+
+        <table class="striped responsive-table filterable-table">
+            <thead>
+                <tr>
+                    <th>Project Name</th>
+                    <th>High</th>
+                    <th>Medium</th>
+                    <th>Low</th>
+                </tr>
+            </thead>
+
+            <tbody>
+            @for(project <- results) {
+                <tr>
+                    <td>
+                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/">@project.name</a>
+                    </td>
+                    <td>
+                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/?disclosure=all&severity=high">
+                            @project.high
+                        </a>
+                    </td>
+                    <td>
+                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/?disclosure=all&severity=medium">@project.medium</a>
+                    </td>
+                    <td>
+                        <a class="black-text" href="https://snyk.io/org/guardian/project/@project.id/?disclosure=all&severity=low">@project.low</a>
+                    </td>
+                </tr>
+            }
+
+        </table>
+
+    </div>
+    </div>
+
+}

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -27,6 +27,9 @@ stage = ${STAGE}
 
 host=${HOST}
 
+stack = security
+app = security-hq
+
 hq {
   # default to empty list if the config is missing (for now)
   account = []

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -9,6 +9,7 @@ GET        /iam                                       controllers.HQController.i
 GET        /iam/:accountId                            controllers.HQController.iamAccount(accountId)
 GET        /security-groups                           controllers.SecurityGroupsController.securityGroups
 GET        /security-groups/:accountId                controllers.SecurityGroupsController.securityGroupsAccount(accountId)
+GET        /snyk                                      controllers.SnykController.snyk
 GET        /login                                     controllers.AuthController.login
 GET        /loginError                                controllers.AuthController.loginError
 GET        /oauthCallback                             controllers.AuthController.oauthCallback

--- a/hq/markdown/index.md
+++ b/hq/markdown/index.md
@@ -2,3 +2,4 @@
 
    1. How to implement [Snyk](snyk) Vulnerability Analysis to check library dependencies.
    1. How to implement [AWS run command (tutorial)](run-command) and remove the need for ssh/bastions.
+   1. How to use [Temporary SSH credentials](temporary-ssh).

--- a/hq/markdown/parameter-store.md
+++ b/hq/markdown/parameter-store.md
@@ -1,0 +1,57 @@
+# SSM Parameters
+
+This is a secure process for writing and reading (and auditing reads of) sensitive information.
+
+Using SSM Parameter store provides a trivial way to push sensitive information into AWS systems
+without GPG and/or S3 file stores.  
+
+## Prerequisites for this tutorial
+
+ * aws - the command line amazon tool
+ * trivial bash knowledge
+ * Some Scala knowledge
+
+We will use the most trivial example: a String.
+
+## Installation
+
+Choose the target account and region.  For example:
+```
+export region="eu-west-1"
+export profile="security"
+```
+
+## Create Parameters
+
+For Configraun compatibility, keys should have the form: `/$stack/$app/$stage/domain/value`
+
+```
+aws --region $region --profile $profile ssm put-parameter --name '/mystack/myapp/PROD/snyk/token' --value 'mysnyktoken' --type String
+```
+
+Ideally, at create time, each key will be given a regex defining allowed values.  This will help prevent overwriting with 
+bad values later.
+
+## List Parameters
+
+```
+aws --region $region --profile $profile ssm describe-parameters
+```
+
+## List a Specific Parameter
+
+```
+aws --region $region --profile $profile ssm get-parameter --name /justin/testing
+```
+
+## Delete a Specific Parameter
+
+```
+aws --region $region --profile $profile ssm delete-parameter --name '/mystack/myapp/PROD/snyk/token' 
+
+```
+
+## Fetch Parameters from Application
+
+See [Configraun](https://github.com/guardian/configraun) read me.
+

--- a/hq/markdown/snyk.md
+++ b/hq/markdown/snyk.md
@@ -7,7 +7,11 @@ vulnerabilities in your application.
 
 ## Installing
 
-Snyk requires node, and `npm`.  To install on a mac, please use:
+Snyk requires node, and `npm`.
+
+### Developer Install
+
+To install on a mac, please use:
 
 ```
 brew install npm
@@ -18,6 +22,52 @@ Snyk then requires an authentication token to be set up.  Github auth is almost 
 
 ```
 snyk auth
+```
+
+## Build Server Install
+
+Build servers will not have Snyk installed.  The project must declare it as a development dependency.
+
+This can be achieved by merging the entries from the following content into package.json:
+
+### Scala Builds
+
+As the invocation will be via an npm plugin (Snyk is a node tool), build servers may not expose the sbt executable
+on the PATH.  As a result it is necessary to pre-pend the sbt location onto the PATH so that Snyk can invoke it.
+
+```
+  "devDependencies": {
+    "snyk": "1.69.3"
+  },
+  "scripts": {
+    "snyk-test": "PATH=/path/to/sbt/executable/folder:$PATH snyk test --debug --org=guardian --json --file=build.sbt",
+    "snyk-monitor": "PATH=/path/to/sbt/executable/folder:$PATH snyk monitor --debug --org=guardian --file=build.sbt",
+  }
+```
+
+### Node Builds
+
+```
+  "devDependencies": {
+    "snyk": "1.68.0"
+  },
+  "scripts": {
+    "snyk-test": "snyk test --debug --org=guardian --json --file=package.json",
+    "snyk-monitor": "snyk monitor --debug --org=guardian --file=package.json"
+  }
+```
+
+## Build Server Invocation
+
+A SNYK_TOKEN environment variable will be exposed which will permit invocation of `snyk test` and `snyk monitor`,
+with the results being pushed to the `guardian` organisation on Snyk, and visible via security-hq.
+
+The build process will require a build step with the following:
+
+```
+npm install --only=dev
+npm run snyk-test
+npm run snyk-monitor
 ```
 
 # Usage
@@ -36,21 +86,39 @@ code is non-zero (ie at least one vulnerability found or error).
 Snyk needs to first create a dependency tree for your project (based on the sbt dependencies), then check with the
 Snyk database.
 
-Dependency graph creation is via an sbt plugin.  Add the following line to your project plugins file or your `.sbt/plugins`
-directory:
+Dependency graph creation is via an sbt plugin.
 
+### Project
 
-```
-/Users/<you>/.sbt/<sbt-version>/plugins/snyk.sbt
-or
-<projectroot>/project/plugins.sbt
-```
+To add directly to a project, add the following line to your project plugins (<projectroot>/project/plugins.sbt):
 
 ```
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 ```
 
-### Invocation
+If you are using SBT 1.0, you will also need to add the following line to your build.sbt:
+
+```
+addCommandAlias("dependency-tree", "dependencyTree")
+```
+
+### User
+
+To add for your personal user, which will make snyk available for any project, add the following line to your
+.sbt plugins (~/.sbt/<sbt-version>/plugins/snyk.sbt):
+
+
+```
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+```
+
+If you are using SBT 1.0, you will also need to add the following line to your user.sbt (~/.sbt/1.0/user.sbt):
+
+```
+addCommandAlias("dependency-tree", "dependencyTree")
+```
+
+### Manual Invocation
 
 It is recommended that `sbt` itself is invoked first, to confirm that the build file is good.  You
 can then invoke `snyk` as follows.  If you are working on a new snyk implementation, then it is often
@@ -61,22 +129,14 @@ sbt test
 snyk test --file=build.sbt [--show-vulnerable-paths=(true|false)]
 ```
 
+If you also wish to send your dependencies to Snyk, where they will be monitored for new vulnerabilities, found after the
+build, then you should also add:
+
+```
+snyk monitor
+```
+
 ### Gotchas
-
-#### With SBT 1.0.0+
-
-It appears that sbt expects to invoke `dependency-tree`.  After sbt 1.0, this command appears to be `dependencyTree`.
-
-As Snyk is written in an interpreted script, this can be 'fixed' for now (if you use sbt > 1.0.0) using the following (mac) command:
-
-```
-sed -i '' 's/dependency-tree/dependencyTree/g' $(grep -wrl 'dependency-tree' /usr/local/lib/node_modules/snyk/node_modules/snyk-sbt-plugin/)
-```
-
-And to revert:
-```
-sed -i '' 's/dependencyTree/dependency-tree/g' $(grep -wrl 'dependencyTree' /usr/local/lib/node_modules/snyk/node_modules/snyk-sbt-plugin/)
-```
 
 #### With bugs in build.sbt
 
@@ -98,7 +158,7 @@ or
 yarn upgrade
 ```
 
-### Invocation
+### Manual Invocation
 
 Scan for vulnerabilities with:
 
@@ -112,6 +172,13 @@ the `--dev` flag:
 
 ```
 snyk test --file=package.json --dev
+```
+
+If you also wish to send your dependencies to Snyk, where they will be monitored for new vulnerabilities, found after the
+build, then you should also add:
+
+```
+snyk monitor
 ```
 
 ### Optional Magic
@@ -185,10 +252,13 @@ The worst case scenario is that the library is still vulnerable, has no alternat
 may wish to build and release anyway, ideally reporting the situation to a risk register. This is most likely to happen when
 a new vulnerability is discovered and the library publisher has not had chance to respond.
 
-This is cleanly achieved by creating a `.snyk` file which can act both as an exemption and the risk register itself.
+For private repositories, this is cleanly achieved by creating a `.snyk` file which can act both as an exemption and the risk register itself.
 Please try to give meaningful reasons for allowing the exemption.
 
 The `.snyk` file can then be added to the repository and the build should continue.
+
+__However, for public repositories, this would mean that the vulnerability is effectively advertised right in
+the project!  This is therefore not an acceptable approach for public repositories.__
 
 When an exemption expires, the build will start to fail again (see Reviewing Expired Exemptions below).
 If a review still finds no mitigation available, then it is trivial to extend by changing the date and committing.

--- a/hq/markdown/temporary-ssh.md
+++ b/hq/markdown/temporary-ssh.md
@@ -26,4 +26,4 @@ The instance must
 
 # Download
 
-The application is available to download at https://github.com/guardian/ssm-scala/
+The application is available to download at [github](https://github.com/guardian/ssm-scala/)

--- a/hq/markdown/temporary-ssh.md
+++ b/hq/markdown/temporary-ssh.md
@@ -19,7 +19,7 @@ The mechanism is via AWS run-command.  Please see AWS documentation for details.
 
 The instance must 
 
-  * be set up to use run-command
+  * be set up to use [run-command](run-command)
   * have sshd running
   * have a public IP address
   * have ssh access permitted (port 22 open)

--- a/hq/markdown/temporary-ssh.md
+++ b/hq/markdown/temporary-ssh.md
@@ -1,0 +1,29 @@
+# Temporary SSH
+
+In order to move towards use of temporary credentials, a facility has been provided to locally generate a keypair and push the
+public key to the instance of your choice, all using your own AWS credentials.  A standard ssh command can then be used to 
+connect to the instance, within a timeout period.
+
+After the timeout period, the public key is removed from the instance and the private key is therefore useless and can be 
+deleted.
+
+The box will be marked as 'tainted' both in the motd login screen and via a tag on the instance.   'Tainted' instances should
+be terminated at the end of a support process and replaced with cleanly built instances to prove that the build is good 
+without manual intervention.
+
+## Implementation
+
+The mechanism is via AWS run-command.  Please see AWS documentation for details.
+
+## Pre-requisites
+
+The instance must 
+
+  * be set up to use run-command
+  * have sshd running
+  * have a public IP address
+  * have ssh access permitted (port 22 open)
+
+# Download
+
+The application is available to download at https://github.com/guardian/ssm-scala/

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -10,6 +10,8 @@ jQuery(function($) {
 $(document).ready(function() {
   // initalizing the mobile nav
   $('.button-collapse').sideNav();
+  // Make any tables with the filter class filterable
+  $('.filterable-table').filterTable();
 
   // Extra interactions for the dropdowns on the Security Groups page
   $('.js-sg-details').hover(

--- a/hq/public/javascripts/jquery.filtertable.js
+++ b/hq/public/javascripts/jquery.filtertable.js
@@ -1,0 +1,525 @@
+/**
+ * jquery.filterTable
+ *
+ * This plugin will add a search filter to tables. When typing in the filter,
+ * any rows that do not contain the filter will be hidden.
+ *
+ * Utilizes bindWithDelay() if available. https://github.com/bgrins/bindWithDelay
+ *
+ * @version v1.5.7
+ * @author Sunny Walker, swalker@hawaii.edu
+ * @license MIT
+ */
+(function($) {
+  var jversion = $.fn.jquery.split('.'),
+    jmajor = parseFloat(jversion[0]),
+    jminor = parseFloat(jversion[1]);
+  // build the pseudo selector for jQuery < 1.8
+  if (jmajor < 2 && jminor < 8) {
+    // build the case insensitive filtering functionality as a pseudo-selector expression
+    $.expr[':'].filterTableFind = function(a, i, m) {
+      return (
+        $(a)
+          .text()
+          .toUpperCase()
+          .indexOf(
+            m[3]
+              .toUpperCase()
+              .replace(/"""/g, '"')
+              .replace(/"\\"/g, '\\')
+          ) >= 0
+      );
+    };
+    // build the case insensitive all-words filtering functionality as a pseudo-selector expression
+    $.expr[':'].filterTableFindAny = function(a, i, m) {
+      // build an array of each non-falsey value passed
+      var raw_args = m[3].split(/[\s,]/),
+        args = [];
+      $.each(raw_args, function(j, v) {
+        var t = v.replace(/^\s+|\s$/g, '');
+        if (t) {
+          args.push(t);
+        }
+      });
+      // if there aren't any non-falsey values to search for, abort
+      if (!args.length) {
+        return false;
+      }
+      return function(a) {
+        var found = false;
+        $.each(args, function(j, v) {
+          if (
+            $(a)
+              .text()
+              .toUpperCase()
+              .indexOf(
+                v
+                  .toUpperCase()
+                  .replace(/"""/g, '"')
+                  .replace(/"\\"/g, '\\')
+              ) >= 0
+          ) {
+            found = true;
+            return false;
+          }
+        });
+        return found;
+      };
+    };
+    // build the case insensitive all-words filtering functionality as a pseudo-selector expression
+    $.expr[':'].filterTableFindAll = function(a, i, m) {
+      // build an array of each non-falsey value passed
+      var raw_args = m[3].split(/[\s,]/),
+        args = [];
+      $.each(raw_args, function(j, v) {
+        var t = v.replace(/^\s+|\s$/g, '');
+        if (t) {
+          args.push(t);
+        }
+      });
+      // if there aren't any non-falsey values to search for, abort
+      if (!args.length) {
+        return false;
+      }
+      return function(a) {
+        // how many terms were found?
+        var found = 0;
+        $.each(args, function(j, v) {
+          if (
+            $(a)
+              .text()
+              .toUpperCase()
+              .indexOf(
+                v
+                  .toUpperCase()
+                  .replace(/"""/g, '"')
+                  .replace(/"\\"/g, '\\')
+              ) >= 0
+          ) {
+            // found another term
+            found++;
+          }
+        });
+        return found === args.length; // did we find all of them in this cell?
+      };
+    };
+  } else {
+    // build the pseudo selector for jQuery >= 1.8
+    $.expr[':'].filterTableFind = jQuery.expr.createPseudo(function(arg) {
+      return function(el) {
+        return (
+          $(el)
+            .text()
+            .toUpperCase()
+            .indexOf(
+              arg
+                .toUpperCase()
+                .replace(/"""/g, '"')
+                .replace(/"\\"/g, '\\')
+            ) >= 0
+        );
+      };
+    });
+    $.expr[':'].filterTableFindAny = jQuery.expr.createPseudo(function(arg) {
+      // build an array of each non-falsey value passed
+      var raw_args = arg.split(/[\s,]/),
+        args = [];
+      $.each(raw_args, function(i, v) {
+        // trim the string
+        var t = v.replace(/^\s+|\s$/g, '');
+        if (t) {
+          args.push(t);
+        }
+      });
+      // if there aren't any non-falsey values to search for, abort
+      if (!args.length) {
+        return false;
+      }
+      return function(el) {
+        var found = false;
+        $.each(args, function(i, v) {
+          if (
+            $(el)
+              .text()
+              .toUpperCase()
+              .indexOf(
+                v
+                  .toUpperCase()
+                  .replace(/"""/g, '"')
+                  .replace(/"\\"/g, '\\')
+              ) >= 0
+          ) {
+            found = true;
+            // short-circuit the searching since this cell has one of the terms
+            return false;
+          }
+        });
+        return found;
+      };
+    });
+    $.expr[':'].filterTableFindAll = jQuery.expr.createPseudo(function(arg) {
+      // build an array of each non-falsey value passed
+      var raw_args = arg.split(/[\s,]/),
+        args = [];
+      $.each(raw_args, function(i, v) {
+        // trim the string
+        var t = v.replace(/^\s+|\s$/g, '');
+        if (t) {
+          args.push(t);
+        }
+      });
+      // if there aren't any non-falsey values to search for, abort
+      if (!args.length) {
+        return false;
+      }
+      return function(el) {
+        // how many terms were found?
+        var found = 0;
+        $.each(args, function(i, v) {
+          if (
+            $(el)
+              .text()
+              .toUpperCase()
+              .indexOf(
+                v
+                  .toUpperCase()
+                  .replace(/"""/g, '"')
+                  .replace(/"\\"/g, '\\')
+              ) >= 0
+          ) {
+            // found another term
+            found++;
+          }
+        });
+        // did we find all of them in this cell?
+        return found === args.length;
+      };
+    });
+  }
+  // define the filterTable plugin
+  $.fn.filterTable = function(options) {
+    // start off with some default settings
+    var defaults = {
+        // make the filter input field autofocused (not recommended for accessibility)
+        autofocus: false,
+
+        // callback function: function (term, table){}
+        callback: null,
+
+        // class to apply to the container
+        containerClass: 'filter-table',
+
+        // tag name of the container
+        containerTag: 'p',
+
+        // jQuery expression method to use for filtering
+        filterExpression: 'filterTableFind',
+
+        // if true, the table's tfoot(s) will be hidden when the table is filtered
+        hideTFootOnFilter: false,
+
+        // class applied to cells containing the filter term
+        highlightClass: 'alt',
+
+        // don't filter the contents of cells with this class
+        ignoreClass: '',
+
+        // don't filter the contents of these columns
+        ignoreColumns: [],
+
+        // use the element with this selector for the filter input field instead of creating one
+        inputSelector: null,
+
+        // name of filter input field
+        inputName: '',
+
+        // tag name of the filter input tag
+        inputType: 'search',
+
+        // text to precede the filter input tag
+        label: 'Filter:',
+
+        // filter only when at least this number of characters are in the filter input field
+        minChars: 1,
+
+        // don't show the filter on tables with at least this number of rows
+        minRows: 8,
+
+        // HTML5 placeholder text for the filter field
+        placeholder: 'search this table',
+
+        // prevent the return key in the filter input field from trigger form submits
+        preventReturnKey: true,
+
+        // list of phrases to quick fill the search
+        quickList: [],
+
+        // class of each quick list item
+        quickListClass: 'quick',
+
+        // quick list item label to clear the filter (e.g., '&times; Clear filter')
+        quickListClear: '',
+
+        // tag surrounding quick list items (e.g., ul)
+        quickListGroupTag: '',
+
+        // tag type of each quick list item (e.g., a or li)
+        quickListTag: 'a',
+
+        // class applied to visible rows
+        visibleClass: 'visible'
+      },
+      // mimic PHP's htmlspecialchars() function
+      hsc = function(text) {
+        return text
+          .replace(/&/g, '&amp;')
+          .replace(/"/g, '&quot;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+      },
+      // merge the user's settings into the defaults
+      settings = $.extend({}, defaults, options);
+
+    // handle the actual table filtering
+    var doFiltering = function(table, q) {
+      // cache the tbody element
+      var tbody = table.find('tbody');
+      // if the filtering query is blank or the number of chars is less than the minChars option
+      if (q === '' || q.length < settings.minChars) {
+        // show all rows
+        tbody
+          .find('tr')
+          .show()
+          .addClass(settings.visibleClass);
+        // remove the row highlight from all cells
+        tbody.find('td').removeClass(settings.highlightClass);
+        // show footer if the setting was specified
+        if (settings.hideTFootOnFilter) {
+          table.find('tfoot').show();
+        }
+      } else {
+        // if the filter query is not blank
+        var all_tds = tbody.find('td');
+        // hide all rows, assuming none were found
+        tbody
+          .find('tr')
+          .hide()
+          .removeClass(settings.visibleClass);
+        // remove previous highlights
+        all_tds.removeClass(settings.highlightClass);
+        // hide footer if the setting was specified
+        if (settings.hideTFootOnFilter) {
+          table.find('tfoot').hide();
+        }
+        if (settings.ignoreColumns.length) {
+          var tds = [];
+          if (settings.ignoreClass) {
+            all_tds = all_tds.not('.' + settings.ignoreClass);
+          }
+          tds = all_tds.filter(
+            ':' + settings.filterExpression + '("' + q + '")'
+          );
+          tds.each(function() {
+            var t = $(this),
+              col = t
+                .parent()
+                .children()
+                .index(t);
+            if ($.inArray(col, settings.ignoreColumns) === -1) {
+              t
+                .addClass(settings.highlightClass)
+                .closest('tr')
+                .show()
+                .addClass(settings.visibleClass);
+            }
+          });
+        } else {
+          if (settings.ignoreClass) {
+            all_tds = all_tds.not('.' + settings.ignoreClass);
+          }
+          // highlight (class=alt) only the cells that match the query and show their rows
+          all_tds
+            .filter(':' + settings.filterExpression + '("' + q + '")')
+            .addClass(settings.highlightClass)
+            .closest('tr')
+            .show()
+            .addClass(settings.visibleClass);
+        }
+      }
+      // call the callback function
+      if (settings.callback) {
+        settings.callback(q, table);
+      }
+    }; // doFiltering()
+
+    return this.each(function() {
+      // cache the table
+      var t = $(this),
+        // cache the tbody
+        tbody = t.find('tbody'),
+        // placeholder for the filter field container DOM node
+        container = null,
+        // placeholder for the quick list items
+        quicks = null,
+        // placeholder for the field field DOM node
+        filter = null,
+        // was the filter created or chosen from an existing element?
+        created_filter = true;
+
+      // only if object is a table and there's a tbody and at least minRows trs and hasn't already had a filter added
+      if (
+        t[0].nodeName === 'TABLE' &&
+        tbody.length > 0 &&
+        (settings.minRows === 0 ||
+          (settings.minRows > 0 &&
+            tbody.find('tr').length >= settings.minRows)) &&
+        !t.prev().hasClass(settings.containerClass)
+      ) {
+        // use a single existing field as the filter input field
+        if (settings.inputSelector && $(settings.inputSelector).length === 1) {
+          filter = $(settings.inputSelector);
+          // container to hold the quick list options
+          container = filter.parent();
+          created_filter = false;
+        } else {
+          // create the filter input field (and container)
+          // build the container tag for the filter field
+          container = $('<' + settings.containerTag + ' />');
+          // add any classes that need to be added
+          if (settings.containerClass !== '') {
+            container.addClass(settings.containerClass);
+          }
+          // add the label for the filter field
+          container.prepend(settings.label + ' ');
+          // build the filter field
+          filter = $(
+            '<input type="' +
+              settings.inputType +
+              '" placeholder="' +
+              settings.placeholder +
+              '" name="' +
+              settings.inputName +
+              '" />'
+          );
+          // prevent return in the filter field from submitting any forms
+          if (settings.preventReturnKey) {
+            filter.on('keydown', function(ev) {
+              if ((ev.keyCode || ev.which) === 13) {
+                ev.preventDefault();
+                return false;
+              }
+            });
+          }
+        }
+
+        // add the autofocus attribute if requested
+        if (settings.autofocus) {
+          filter.attr('autofocus', true);
+        }
+
+        // does bindWithDelay() exist?
+        if ($.fn.bindWithDelay) {
+          // bind doFiltering() to keyup (delayed)
+          filter.bindWithDelay(
+            'keyup',
+            function() {
+              doFiltering(t, $(this).val());
+            },
+            200
+          );
+        } else {
+          // just bind to onKeyUp
+          // bind doFiltering() to keyup
+          filter.bind('keyup', function() {
+            doFiltering(t, $(this).val());
+          });
+        }
+
+        // bind doFiltering() to additional events
+        filter.bind('click search input paste blur', function() {
+          doFiltering(t, $(this).val());
+        });
+
+        // add the filter field to the container if it was created by the plugin
+        if (created_filter) {
+          container.append(filter);
+        }
+
+        // are there any quick list items to add?
+        if (settings.quickList.length > 0 || settings.quickListClear) {
+          quicks = settings.quickListGroupTag
+            ? $('<' + settings.quickListGroupTag + ' />')
+            : container;
+          // for each quick list item...
+          $.each(settings.quickList, function(index, value) {
+            // build the quick list item link
+            var q = $(
+              '<' +
+                settings.quickListTag +
+                ' class="' +
+                settings.quickListClass +
+                '" />'
+            );
+            // add the item's text
+            q.text(hsc(value));
+            if (q[0].nodeName === 'A') {
+              // add a (worthless) href to the item if it's an anchor tag so that it gets the browser's link treatment
+              q.attr('href', '#');
+            }
+            // bind the click event to it
+            q.bind('click', function(e) {
+              // stop the normal anchor tag behavior from happening
+              e.preventDefault();
+              // send the quick list value over to the filter field and trigger the event
+              filter
+                .val(value)
+                .focus()
+                .trigger('click');
+            });
+            // add the quick list link to the quick list groups container
+            quicks.append(q);
+          });
+
+          // add the quick list clear item if a label has been specified
+          if (settings.quickListClear) {
+            // build the clear item
+            var q = $(
+              '<' +
+                settings.quickListTag +
+                ' class="' +
+                settings.quickListClass +
+                '" />'
+            );
+            // add the label text
+            q.html(settings.quickListClear);
+            if (q[0].nodeName === 'A') {
+              // add a (worthless) href to the item if it's an anchor tag so that it gets the browser's link treatment
+              q.attr('href', '#');
+            }
+            // bind the click event to it
+            q.bind('click', function(e) {
+              e.preventDefault();
+              // clear the quick list value and trigger the event
+              filter
+                .val('')
+                .focus()
+                .trigger('click');
+            });
+            // add the clear item to the quick list groups container
+            quicks.append(q);
+          }
+
+          // add the quick list groups container to the DOM if it isn't already there
+          if (quicks !== container) {
+            container.append(quicks);
+          }
+        }
+
+        // add the filter field and quick list container to just before the table if it was created by the plugin
+        if (created_filter) {
+          t.before(container);
+        }
+      }
+    }); // return this.each
+  }; // $.fn.filterTable
+})(jQuery);

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -1,0 +1,211 @@
+package logic
+
+import model._
+import org.scalatest.{FreeSpec, Matchers}
+import utils.attempt.{AttemptValues}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
+
+  "find organisationId" in {
+    val organisationId = SnykDisplay.getOrganisationId(SnykDisplayTest.mockGoodOrganisationResponse, Organisation("guardian"))
+    organisationId.value() shouldBe "1111111111"
+  }
+
+  "fail to find organisationId (nice)" in {
+    val organisationId = SnykDisplay.getOrganisationId(SnykDisplayTest.mockBadResponseWithMessage, Organisation("guardian"))
+    organisationId.isFailedAttempt shouldBe true
+    organisationId.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
+  }
+
+  "fail to find organisationId (not nice)" in {
+    val organisationId = SnykDisplay.getOrganisationId(SnykDisplayTest.mockBadResponseWithoutMessage, Organisation("guardian"))
+    organisationId.isFailedAttempt shouldBe true
+    organisationId.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
+  }
+
+  "find project id list" in {
+    val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockGoodProjectResponse)
+    !projects.value().exists(p => p.name == "project1") shouldBe false
+    !projects.value().exists(p => p.name == "project2") shouldBe false
+  }
+
+  "fail to find project id list (nice)" in {
+    val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithMessage)
+    projects.isFailedAttempt shouldBe true
+    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
+  }
+
+  "fail to find project id list (not nice)" in {
+    val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithoutMessage)
+    projects.isFailedAttempt shouldBe true
+    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
+  }
+
+  "find empty vulnerability list" in {
+    val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockGoodAndNotVulnerableResponse))
+    projects.value().head.ok shouldBe true
+  }
+
+  "find non-empty vulnerability list" in {
+    val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockGoodButVulnerableResponse))
+    projects.value().head.ok shouldBe false
+    projects.value().head.high shouldBe 1
+    projects.value().head.medium shouldBe 0
+    projects.value().head.low shouldBe 0
+  }
+
+  "fail to find vulnerability list (nice)" in {
+    val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithMessage))
+    projects.isFailedAttempt() shouldBe true
+    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
+  }
+
+  "fail to find vulnerability list (not nice)" in {
+    val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithoutMessage))
+    projects.isFailedAttempt() shouldBe true
+    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
+  }
+
+  "label projects" in {
+    val results = SnykDisplay.labelProjects(SnykDisplayTest.goodProjects, SnykDisplayTest.goodVulnerabilities)
+    results.head.id shouldBe "id1"
+    results.head.name shouldBe "name1"
+    results.tail.head.id shouldBe "id2"
+    results.tail.head.name shouldBe "name2"
+  }
+
+}
+
+object SnykDisplayTest  {
+
+  private val mockBadResponseWithMessage =
+    s"""{"error": "some nice error"}"""
+
+  private val mockBadResponseWithoutMessage =
+    s"""{"toughluck": "no use"}"""
+
+  private val mockGoodOrganisationResponse =
+    s"""
+       |{"orgs":
+       |[
+       |  {"name": "guardian", "id": "1111111111" },
+       |  {"name": "nottheguardian", "id": "9999999999"}
+       |]
+       |}""".stripMargin
+
+  private val mockGoodProjectResponse =
+    s"""
+       |{
+       |  "org": {
+       |    "name": "guardian",
+       |    "id": "1111111111"
+       |  },
+       |  "projects": [
+       |    {
+       |      "name": "project1",
+       |      "id": "2222222222"
+       |    },
+       |    {
+       |      "name": "project2",
+       |      "id": "3333333333"
+       |    }
+       |  ]
+       |}
+     """.stripMargin
+
+  private val mockGoodAndNotVulnerableResponse =
+    s"""
+       |{
+       |  "ok": true,
+       |  "issues": {
+       |    "vulnerabilities": [],
+       |    "licenses": []
+       |  },
+       |  "dependencyCount": 0,
+       |  "packageManager": "sbt"
+       |}
+     """.stripMargin
+
+  private val mockGoodButVulnerableResponse =
+    s"""
+       |{
+       |  "ok": false,
+       |  "issues": {
+       |    "vulnerabilities": [
+       |      {
+       |        "id": "4444444444",
+       |        "url": "https://snyk.io/vuln/4444444444",
+       |        "title": "The Title",
+       |        "type": "vuln",
+       |        "description": "The description",
+       |        "from": [
+       |          "from1",
+       |          "from2",
+       |          "from3"
+       |        ],
+       |        "package": "The package",
+       |        "version": "The version",
+       |        "severity": "high",
+       |        "language": "The language",
+       |        "packageManager": "the package manager",
+       |        "semver": {
+       |          "unaffected": ">=the version",
+       |          "vulnerable": "<the version"
+       |        },
+       |        "publicationTime": "2015-11-06T02:09:36.182Z",
+       |        "disclosureTime": "2015-11-03T07:15:12.900Z",
+       |        "isUpgradable": true,
+       |        "isPatchable": true,
+       |        "identifiers": {
+       |          "CVE": [],
+       |          "CWE": [],
+       |          "NSP": 57,
+       |          "ALTERNATIVE": [
+       |            "5555555555"
+       |          ]
+       |        },
+       |        "credit": [
+       |          "Mickey Mouse"
+       |        ],
+       |        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+       |        "cvssScore": 7.5,
+       |        "patches": [
+       |          {
+       |            "id": "6666666666",
+       |            "urls": [
+       |              "https://example.com/6666666666.patch"
+       |            ],
+       |            "version": "<the version >=minversion",
+       |            "comments": [
+       |              "https://example.com/7777777777.patch"
+       |            ],
+       |            "modificationTime": "2015-11-17T09:29:10.000Z"
+       |          }
+       |        ],
+       |        "upgradePath": [
+       |          true,
+       |          "the first upgrade",
+       |          "the second upgrade"
+       |        ]
+       |      }
+       |    ],
+       |    "licenses": []
+       |  },
+       |  "dependencyCount": 0,
+       |  "packageManager": "the package manager"
+       |}
+     """.stripMargin
+
+  val goodProjects = List(
+    SnykProject("name1", "id1"),
+    SnykProject("name2", "id2")
+  )
+  val goodVulnerabilities = List(
+    SnykProjectIssues("fake name1", "fake id1", ok = false, List[SnykIssue]()),
+    SnykProjectIssues("fake name2", "fake id2", ok = false, List[SnykIssue]())
+  )
+
+
+}
+

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -2,7 +2,7 @@ package logic
 
 import model._
 import org.scalatest.{FreeSpec, Matchers}
-import utils.attempt.{AttemptValues}
+import utils.attempt.AttemptValues
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -12,34 +12,51 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
     organisation.value shouldBe SnykOrganisation("guardian", "1111111111")
   }
 
-  "fail to find organisationId (nice)" in {
+  "fail to find organisation (nice)" in {
     val organisationId = SnykDisplay.getOrganisation(SnykDisplayTest.mockBadResponseWithMessage, SnykOrganisationName("guardian"))
     organisationId.isFailedAttempt shouldBe true
     organisationId.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
   }
 
-  "fail to find organisationId (not nice)" in {
+  "fail to find organisation (not nice)" in {
     val organisationId = SnykDisplay.getOrganisation(SnykDisplayTest.mockBadResponseWithoutMessage, SnykOrganisationName("guardian"))
     organisationId.isFailedAttempt shouldBe true
     organisationId.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
   }
 
-  "find project id list" in {
-    val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockGoodProjectResponse)
-    !projects.value().exists(p => p.name == "project1") shouldBe false
-    !projects.value().exists(p => p.name == "project2") shouldBe false
+  "find projects" - {
+
+    "find project 1 in project list" in {
+      val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockGoodProjectResponse)
+      projects.value().exists(p => p.name == "project1") shouldBe true
+    }
+
+    "find project 2 in project list" in {
+      val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockGoodProjectResponse)
+      projects.value().exists(p => p.name == "project2") shouldBe true
+    }
+
   }
 
-  "fail to find project id list (nice)" in {
-    val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithMessage)
-    projects.isFailedAttempt shouldBe true
-    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
-  }
+  "fail to find project list" - {
+    "fail to find project id list (nice) - fails" in {
+      val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithMessage)
+      projects.isFailedAttempt shouldBe true
+    }
 
-  "fail to find project id list (not nice)" in {
-    val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithoutMessage)
-    projects.isFailedAttempt shouldBe true
-    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
+    "fail to find project id list (nice) - has message" in {
+      val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithMessage)
+      projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
+    }
+
+    "fail to find project id list (not nice) - fails" in {
+      val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithoutMessage)
+      projects.isFailedAttempt shouldBe true
+    }
+    "fail to find project id list (not nice) - has message" in {
+      val projects = SnykDisplay.getProjectIdList(SnykDisplayTest.mockBadResponseWithoutMessage)
+      projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
+    }
   }
 
   "find empty vulnerability list" in {
@@ -47,40 +64,92 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
     projects.value().head.ok shouldBe true
   }
 
-  "find non-empty vulnerability list" in {
-    val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockGoodButVulnerableResponse))
-    projects.value().head.ok shouldBe false
-    projects.value().head.high shouldBe 1
-    projects.value().head.medium shouldBe 0
-    projects.value().head.low shouldBe 0
+  "find non-empty vulnerability list" - {
+    "find ok" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockGoodButVulnerableResponse))
+      projects.value().head.ok shouldBe false
+    }
+
+    "find high count" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockGoodButVulnerableResponse))
+      projects.value().head.high shouldBe 1
+    }
+
+    "find medium count" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockGoodButVulnerableResponse))
+      projects.value().head.medium shouldBe 0
+    }
+
+    "find low count" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockGoodButVulnerableResponse))
+      projects.value().head.low shouldBe 0
+    }
   }
 
-  "fail to find vulnerability list (nice)" in {
-    val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithMessage))
-    projects.isFailedAttempt() shouldBe true
-    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
+  "fail to find vulnerability list (nice)" - {
+    "fail to find vulnerability list (nice) - fails" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithMessage))
+      projects.isFailedAttempt() shouldBe true
+    }
+    "fail to find vulnerability list (nice) - has message" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithMessage))
+      projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
+    }
   }
 
-  "fail to find vulnerability list (not nice)" in {
-    val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithoutMessage))
-    projects.isFailedAttempt() shouldBe true
-    projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
+  "fail to find vulnerability list (not nice)" - {
+    "fail to find vulnerability list (not nice) - fails" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithoutMessage))
+      projects.isFailedAttempt() shouldBe true
+    }
+    "fail to find vulnerability list (not nice) - has message" in {
+      val projects = SnykDisplay.parseProjectVulnerabilities(List(SnykDisplayTest.mockBadResponseWithoutMessage))
+      projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
+    }
   }
 
-  "label organisation" in {
-    val results = SnykDisplay.labelOrganisations(SnykDisplayTest.goodProjects, SnykDisplayTest.goodOrganisation)
-    results.head.organisation.get.id shouldBe "id0"
-    results.head.organisation.get.name shouldBe "name0"
-    results.tail.head.organisation.get.id shouldBe "id0"
-    results.tail.head.organisation.get.name shouldBe "name0"
+  "label organisation" - {
+    "label organisation - first id" in {
+      val results = SnykDisplay.labelOrganisations(SnykDisplayTest.goodProjects, SnykDisplayTest.goodOrganisation)
+      results.head.organisation.get.id shouldBe "id0"
+    }
+
+    "label organisation - first name" in {
+      val results = SnykDisplay.labelOrganisations(SnykDisplayTest.goodProjects, SnykDisplayTest.goodOrganisation)
+      results.head.organisation.get.name shouldBe "name0"
+    }
+
+    "label organisation - second id" in {
+      val results = SnykDisplay.labelOrganisations(SnykDisplayTest.goodProjects, SnykDisplayTest.goodOrganisation)
+      results.tail.head.organisation.get.id shouldBe "id0"
+    }
+
+    "label organisation - second name" in {
+      val results = SnykDisplay.labelOrganisations(SnykDisplayTest.goodProjects, SnykDisplayTest.goodOrganisation)
+      results.tail.head.organisation.get.name shouldBe "name0"
+    }
   }
 
-  "label projects" in {
-    val results = SnykDisplay.labelProjects(SnykDisplayTest.goodProjects, SnykDisplayTest.goodVulnerabilities)
-    results.head.project.get.id shouldBe "id1"
-    results.head.project.get.name shouldBe "name1"
-    results.tail.head.project.get.id shouldBe "id2"
-    results.tail.head.project.get.name shouldBe "name2"
+  "label projects" - {
+    "label projects - first id" - {
+      val results = SnykDisplay.labelProjects(SnykDisplayTest.goodProjects, SnykDisplayTest.goodVulnerabilities)
+      results.head.project.get.id shouldBe "id1"
+    }
+
+    "label projects - first name" in {
+      val results = SnykDisplay.labelProjects(SnykDisplayTest.goodProjects, SnykDisplayTest.goodVulnerabilities)
+      results.head.project.get.name shouldBe "name1"
+    }
+
+    "label projects - second id" in {
+      val results = SnykDisplay.labelProjects(SnykDisplayTest.goodProjects, SnykDisplayTest.goodVulnerabilities)
+      results.tail.head.project.get.id shouldBe "id2"
+    }
+
+    "label projects - second name" in {
+      val results = SnykDisplay.labelProjects(SnykDisplayTest.goodProjects, SnykDisplayTest.goodVulnerabilities)
+      results.tail.head.project.get.name shouldBe "name2"
+    }
   }
 
 }

--- a/hq/test/utils/attempt/AttemptValues.scala
+++ b/hq/test/utils/attempt/AttemptValues.scala
@@ -42,5 +42,11 @@ trait AttemptValues extends Matchers {
         _ => false
       )
     }
+    def getFailedAttempt()(implicit ec: ExecutionContext): FailedAttempt = {
+      Await.result(attempt.asFuture, 5.seconds).fold (
+        fa => fa,
+        _ => throw new TestFailedException("Could not extract failed attempt from Attempt", 10)
+      )
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "eslint": "eslint --max-warnings 0 --format codeframe --ignore-pattern '**/*.min.js' hq/public/javascripts/",
     "linter-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "prettier -o --write './**/*.{js,css}'",
-    "sass-lint": "sass-lint -v -q hq/public/stylesheets/*.css"
+    "sass-lint": "sass-lint -v -q hq/public/stylesheets/*.css",
+    "snyk-test": "PATH=/path/to/sbt/executable/folder:$PATH snyk test --debug --org=guardian --json --file=build.sbt",
+    "snyk-monitor": "PATH=/path/to/sbt/executable/folder:$PATH snyk monitor --debug --org=guardian --file=build.sbt"
   }
 }


### PR DESCRIPTION
## What does this change?

Adds a Snyk Report page
Fetches some configuration via Configraun configuration engine

## What is the value of this?

Exposes the results of snyk testing for vulnerabilities, including vulnerabilities found after the 
initial test.

Configraun use removes a 'secret' from the configuration file and stores it in AWS Parameter Store.
We should be moving towards this approach generally.  This implementation provides a dogfood implementation for others to use.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes.
Template changes are included.

## Any additional notes?

No