### PR TITLE
Sorting for the credentials reports, and the account names

### DIFF
--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -103,7 +103,7 @@ object EC2 {
         (0, 1, 0, account.name)
       // finally, empty flagged results
       // sort internally by name of account
-      case (account, Right(flaggedSgs)) =>
+      case (account, Right(_)) =>
         (1, 0, 0, account.name)
     }
   }

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -8,7 +8,7 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.CacheService
 import utils.attempt.PlayIntegration.attempt
-import logic.ReportDisplay.sortByReportSummary
+import logic.ReportDisplay.sortAccountsByReportSummary
 
 
 import scala.concurrent.ExecutionContext
@@ -25,7 +25,7 @@ class HQController (val config: Configuration, cacheService: CacheService)
 
   def iam = authAction {
     val accountsAndReports = cacheService.getAllCredentials()
-    val sortedAccountsAndReports = sortByReportSummary(accountsAndReports.toList)
+    val sortedAccountsAndReports = sortAccountsByReportSummary(accountsAndReports.toList)
     Ok(views.html.iam.iam(sortedAccountsAndReports))
   }
 

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -8,6 +8,8 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.CacheService
 import utils.attempt.PlayIntegration.attempt
+import logic.ReportDisplay.sortByReportSummary
+
 
 import scala.concurrent.ExecutionContext
 
@@ -23,7 +25,8 @@ class HQController (val config: Configuration, cacheService: CacheService)
 
   def iam = authAction {
     val accountsAndReports = cacheService.getAllCredentials()
-    Ok(views.html.iam.iam(accountsAndReports))
+    val sortedAccountsAndReports = sortByReportSummary(accountsAndReports.toList)
+    Ok(views.html.iam.iam(sortedAccountsAndReports))
   }
 
   def iamAccount(accountId: String) = authAction.async {

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -86,7 +86,7 @@ object ReportDisplay {
     ReportSummary(warnings, errors, other)
   }
 
-  def sortByReportSummary[L](reports: List[(AwsAccount, Either[L, CredentialReportDisplay])]): List[(AwsAccount, Either[L, CredentialReportDisplay])] = {
+  def sortAccountsByReportSummary[L](reports: List[(AwsAccount, Either[L, CredentialReportDisplay])]): List[(AwsAccount, Either[L, CredentialReportDisplay])] = {
     reports.sortBy {
       case (account, Right(report)) if reportStatusSummary(report).errors + reportStatusSummary(report).warnings != 0 =>
         (0, reportStatusSummary(report).errors * -1, reportStatusSummary(report).warnings * -1, account.name)

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -58,8 +58,8 @@ object ReportDisplay {
         } else None
 
       report.copy(
-        machineUsers = report.machineUsers.sortWith(sortByStatus) ++ machineUser,
-        humanUsers = report.humanUsers.sortWith(sortByStatus) ++ humanUser
+        machineUsers = report.machineUsers ++ machineUser,
+        humanUsers = report.humanUsers ++ humanUser
       )
     }
   }
@@ -97,12 +97,22 @@ object ReportDisplay {
     }
   }
 
-  private def sortByStatus(u1: AwsUser, u2: AwsUser) = {
-    def statusCode(status: ReportStatus): Int = status match {
-      case Red => 2
+  def sortUsersByReportSummary(report: CredentialReportDisplay): CredentialReportDisplay = {
+    report.copy(
+      machineUsers = report.machineUsers.sortBy(user => (user.reportStatus, user.username)),
+      humanUsers = report.humanUsers.sortBy(user => (user.reportStatus, user.username))
+    )
+  }
+
+  implicit val reportStatusOrdering: Ordering[ReportStatus] = new Ordering[ReportStatus] {
+    private def statusCode(status: ReportStatus): Int = status match {
+      case Red => 0
       case Amber => 1
-      case _ => 0
+      case Green => 99
     }
-    statusCode(u1.reportStatus) > statusCode(u2.reportStatus)
+
+    override def compare(x: ReportStatus, y: ReportStatus): Int = {
+      statusCode(x) - statusCode(y)
+    }
   }
 }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -120,6 +120,14 @@ object Red extends ReportStatus
 object Green extends ReportStatus
 object Amber extends ReportStatus
 
+sealed trait AwsUser {
+  def username: String
+  def key1Status: KeyStatus
+  def key2Status: KeyStatus
+  def reportStatus: ReportStatus
+  def lastActivityDay: Option[Long]
+}
+
 case class HumanUser(
   username: String,
   hasMFA : Boolean,
@@ -127,11 +135,12 @@ case class HumanUser(
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
   lastActivityDay : Option[Long]
-)
+) extends AwsUser
+
 case class MachineUser(
   username: String,
   key1Status: KeyStatus,
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
-  lastActivityDay : Option[Long]
-)
+  lastActivityDay: Option[Long]
+) extends AwsUser

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -120,14 +120,6 @@ object Red extends ReportStatus
 object Green extends ReportStatus
 object Amber extends ReportStatus
 
-sealed trait AwsUser {
-  def username: String
-  def key1Status: KeyStatus
-  def key2Status: KeyStatus
-  def reportStatus: ReportStatus
-  def lastActivityDay: Option[Long]
-}
-
 case class HumanUser(
   username: String,
   hasMFA : Boolean,
@@ -135,12 +127,11 @@ case class HumanUser(
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
   lastActivityDay : Option[Long]
-) extends AwsUser
-
+)
 case class MachineUser(
   username: String,
   key1Status: KeyStatus,
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
   lastActivityDay: Option[Long]
-) extends AwsUser
+)

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -50,7 +50,7 @@
                 <div class="collapsible-body">
                 @report match {
                     case Right(re) => {
-                        @views.html.iam.iamCredReportBody(re)
+                        @views.html.iam.iamCredReportBody(sortUsersByReportSummary(re))
                     }
                     case Left(fa) => {
                         <p class="p--warning">

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -1,6 +1,6 @@
-@import logic.ReportDisplay.reportStatusSummary
+@import logic.ReportDisplay._
 @import model._
-@(reports: Map[AwsAccount, Either[utils.attempt.FailedAttempt, CredentialReportDisplay]])(implicit assets: AssetsFinder)
+@(reports: List[(AwsAccount, Either[utils.attempt.FailedAttempt, CredentialReportDisplay])])(implicit assets: AssetsFinder)
 
 
 @main(List("IAM report")) { @* Header *@

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -1,5 +1,5 @@
 @import logic.DateUtils
-@import model.CredentialReportDisplay
+@import model._
 @import logic.ReportDisplay
 @(report: CredentialReportDisplay)
 
@@ -18,8 +18,8 @@
                 <th>Last Activity</th>
                 <th>Status</th>
             </tr>
-            @for(cred <- report.humanUsers) {
 
+            @for(cred <- report.humanUsers) {
                 <tr>
                     <td>
                         <a target="_blank" rel="noopener noreferrer"  href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">@views.html.fragments.username(cred.username)
@@ -29,13 +29,12 @@
                     <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)</td>
                     <td>@views.html.fragments.mfa(cred.hasMFA)</td>
                     <td>
-                        <span>
-                            @ReportDisplay.toDayString(cred.lastActivityDay)
-                        </span>
+                        <span>@ReportDisplay.toDayString(cred.lastActivityDay)</span>
                     </td>
                     <td>@views.html.fragments.humanReportStatus(cred.reportStatus)</td>
                 </tr>
             }
+
             @for(cred <- report.machineUsers) {
                 <tr>
                     <td>


### PR DESCRIPTION
## What does this change?

#### 👉 Sort IAM credentials reports by number of issues

The all accounts IAM credentials report is currently sorted according to the account name...

This PR will make SHQ order the the accounts by the severity and number of alerts:

```
# errors > # warnings > account name
```

<img width="1238" alt="picture 169" src="https://user-images.githubusercontent.com/8607683/35403458-abf34d08-01f7-11e8-83ad-2f3c4bfa4bb2.png">

#### 👉 Sorting accounts within accounts!

Users were once listed in alphabetical order, now the ones with severe alerts will appear at the top of their section! \* 

##### \* see additional notes

<img width="1240" alt="picture 175" src="https://user-images.githubusercontent.com/8607683/35453586-ae61a62c-02c2-11e8-8159-6423dd7ea195.png">




<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Metrics and motivation
 
<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

The IAM body template currently builds from two distinct lists (humanUsers and machineUsers). Some refactoring of how the users are stored and the table is generated will be required before they can be sorted _together_

These changes only apply to the All Accounts page, since this is a good place to get an overview of how things are doing; I have left the original sorting in place on the individual account pages.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
