### PR TITLE
Support for filtering suppressed SGs, add filter options to views

### DIFF
--- a/hq/app/logic/SecurityGroupDisplay.scala
+++ b/hq/app/logic/SecurityGroupDisplay.scala
@@ -1,11 +1,16 @@
 package logic
 
-import model.{ELB, Ec2Instance, SGInUse}
+import model.{ELB, Ec2Instance, SGInUse, SGOpenPortsDetail}
 
 
 object SecurityGroupDisplay {
 
   case class ResourceIcons(instances: Int, elbs: Int, unknown: Int)
+
+  case class SGReportDisplay(
+    suppressed: List[(SGOpenPortsDetail, Set[SGInUse])],
+    flagged: List[(SGOpenPortsDetail, Set[SGInUse])]
+  )
 
   def resourceIcons(usages: List[SGInUse]): ResourceIcons = {
 
@@ -16,6 +21,16 @@ object SecurityGroupDisplay {
     }
 
     ResourceIcons(instances, elbs, unknown)
+  }
+
+  def hasSuppressedReports(sgs: List[(SGOpenPortsDetail, Set[SGInUse])]): Boolean = {
+    sgs.exists(sg => sg._1.isSuppressed)
+  }
+
+  def splitReportsBySuppressed(sgs: List[(SGOpenPortsDetail, Set[SGInUse])]): SGReportDisplay = {
+    val (suppressed, flagged) = sgs.partition( sg => sg._1.isSuppressed )
+
+    SGReportDisplay(suppressed, flagged)
   }
 
 }

--- a/hq/app/views/fragments/openSecurityGroups.scala.html
+++ b/hq/app/views/fragments/openSecurityGroups.scala.html
@@ -1,5 +1,5 @@
 @import model.{SGOpenPortsDetail, SGInUse, Ec2Instance, ELB, UnknownUsage}
-@import logic.SecurityGroupDisplay.resourceIcons
+@import logic.SecurityGroupDisplay._
 
 @(flaggedSgs: List[(SGOpenPortsDetail, Set[SGInUse])], shadow: Boolean)
 
@@ -32,10 +32,14 @@
 
 <div class="sg-container">
 @for((flaggedSg, usages) <- flaggedSgs) {
-    <div class="sg-container__card">
+    <div class="sg-container__card sg-suppressed--@flaggedSg.isSuppressed">
         <div class="card @if(!shadow){z-depth-0}">
             <div class="card-content card-content--title">
-                <span class="card-title">@flaggedSg.name</span>
+                <span class="card-title">@flaggedSg.name
+                @if(flaggedSg.isSuppressed) {
+                    <i class="material-icons right tooltipped" data-position="top" data-tooltip="Suppressed alert">alarm_off</i>
+                }
+                </span>
             </div>
             <div class="card-content--border @{
                 flaggedSg.alertLevel.toLowerCase

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -1,3 +1,5 @@
+@import logic.SecurityGroupDisplay.splitReportsBySuppressed
+
 @(flaggedSgsByAccount: List[(model.AwsAccount, Either[utils.attempt.FailedAttempt, List[(model.SGOpenPortsDetail, Set[model.SGInUse])]])])(implicit assets: AssetsFinder)
 
 @floatingNav = {
@@ -39,11 +41,27 @@
         <div class="row">
             <h2>Open Security Groups</h2>
             <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>
+        </div>
 
+        <div class="row">
+            <div class="card-panel valign-wrapper">
+                <i class="material-icons left">visibility_off</i>
+                <span class="sg-header__name">Some Security Groups may be ignored due to settings in AWS Trusted Advisor</span>
+
+                <form action="#">
+                    <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
+                    <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
+                    <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />
+                    <label class="black-text sg-filter__label" for="show-ignored-sgs">Show ignored</label>
+                </form>
+            </div>
+        </div>
+
+        <div class="row">
             <ul class="collapsible space-between js-sg-collapsible" data-collapsible="accordion">
             @for((account, flaggedSgsAttempt) <- flaggedSgsByAccount) {
                 <li class="js-sg-scroll">
-                    <div class="collapsible-header">
+                    <div class="collapsible-header sg-header">
                         <i class="material-icons">keyboard_arrow_down</i>
                         <span class="sg-header__name">@account.name</span>
                         @flaggedSgsAttempt match {
@@ -54,7 +72,12 @@
                                 <i class="material-icons">done</i>
                             }
                             case Right(flaggedSgs) => {
-                                <span class="new badge" data-badge-caption="flagged resources">@flaggedSgs.length</span>
+                                @defining(splitReportsBySuppressed(flaggedSgs)) { sgReports =>
+                                    <span class="new badge" data-badge-caption="flagged resources">@sgReports.flagged.length</span>
+                                    @if(sgReports.suppressed.length > 0) {
+                                        <span class="new badge grey sg-header__badge" data-badge-caption="ignored">@sgReports.suppressed.length</span>
+                                    }
+                                }
                             }
                         }
                     </div>

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -1,4 +1,5 @@
 @import model.{AwsAccount, SGInUse, SGOpenPortsDetail}
+@import logic.SecurityGroupDisplay.hasSuppressedReports
 
 @(awsAccount: AwsAccount, flaggedSgs: List[(SGOpenPortsDetail, Set[SGInUse])])(implicit assets: AssetsFinder)
 
@@ -22,7 +23,25 @@
         <div class="row">
             <h2>Open Security Groups</h2>
             <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>
+        </div>
 
+        @if(hasSuppressedReports(flaggedSgs)) {
+            <div class="row">
+                <div class="card-panel valign-wrapper">
+                    <i class="material-icons left">visibility_off</i>
+                    <span class="sg-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
+
+                    <form action="#">
+                        <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
+                        <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
+                        <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />
+                        <label class="black-text sg-filter__label" for="show-ignored-sgs">Show ignored</label>
+                    </form>
+                </div>
+            </div>
+        }
+
+        <div class="row">
             @views.html.fragments.openSecurityGroups(flaggedSgs, shadow=true)
         </div>
     </div>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -22,6 +22,15 @@ $(document).ready(function() {
     }
   );
 
+  $('.js-sg-filter').change(function() {
+    $('#show-ignored-sgs')[0].checked
+      ? $('.sg-suppressed--true').show()
+      : $('.sg-suppressed--true').hide();
+    $('#show-flagged-sgs')[0].checked
+      ? $('.sg-suppressed--false').show()
+      : $('.sg-suppressed--false').hide();
+  });
+
   $('.js-sg-details').click(function() {
     $(this).collapsible('destroy');
 

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -1,6 +1,7 @@
 /* COLOUR SCHEME
 DARK GREY:  #212121
 TEAL:       #009688
+LIGHT GREY: #F5F5F5
 NOT-WHITE:  #F7F0F0
 HIGHLIGHT:  #8AF3FF
 
@@ -200,8 +201,16 @@ nav {
 
 /* security group pages */
 
+.sg-filter__label {
+  margin-left: 20px;
+}
+
 .sg-header__name {
-  margin-right: auto;
+  flex-grow: 2;
+}
+
+.sg-header span.sg-header__badge {
+  margin-left: 10px;
 }
 
 .sg-container {
@@ -222,6 +231,14 @@ nav {
   .sg-container {
     grid-template-columns: repeat(3, 1fr);
   }
+}
+
+.sg-suppressed--true {
+  display: none;
+}
+
+.sg-suppressed--true .card {
+  background-color: #f5f5f5;
 }
 
 .sg-container__card {

--- a/hq/test/logic/SecurityGroupDisplayTest.scala
+++ b/hq/test/logic/SecurityGroupDisplayTest.scala
@@ -1,6 +1,6 @@
 package logic
 
-import model.{ELB, Ec2Instance, SGInUse, UnknownUsage}
+import model._
 import org.scalatest.{FreeSpec, Matchers}
 import SecurityGroupDisplay._
 
@@ -19,6 +19,27 @@ class SecurityGroupDisplayTest extends FreeSpec with Matchers {
       resourceIcons(usages).instances shouldEqual 1
       resourceIcons(usages).elbs shouldEqual 2
       resourceIcons(usages).unknown shouldEqual 1
+    }
+  }
+
+  "splitReportsBySuppressed" - {
+    val flaggedA = SGOpenPortsDetail("Ok", "eu-west-1", "name-1", "sg-1", "vpc-1", "tcp", "1099", "Yellow", isSuppressed = false, None, None)
+    val flaggedB = SGOpenPortsDetail("Ok", "eu-west-1", "name-2", "sg-2", "vpc-2", "tcp", "1099", "Yellow", isSuppressed = false, None, None)
+    val suppressedA = SGOpenPortsDetail("Ok", "eu-west-1", "name-3", "sg-3", "vpc-3", "tcp", "1099", "Yellow", isSuppressed = true, None, None)
+    val suppressedB = SGOpenPortsDetail("Ok", "eu-west-1", "name-4", "sg-4", "vpc-4", "tcp", "1099", "Yellow", isSuppressed = true, None, None)
+
+    "returns two lists when there are flagged and suppressed" in {
+      val sgReport = List((flaggedA, Set[SGInUse]()), (suppressedA, Set[SGInUse]()), (flaggedB, Set[SGInUse]()), (flaggedA, Set[SGInUse]()))
+      splitReportsBySuppressed(sgReport).suppressed.length shouldEqual 1
+      splitReportsBySuppressed(sgReport).flagged.length shouldEqual 3
+    }
+
+    "will place SGs with suppressed reports into the suppressed list" in {
+      val sgReport = List((suppressedA, Set[SGInUse]()), (flaggedA, Set[SGInUse]()), (suppressedB, Set[SGInUse]()))
+      splitReportsBySuppressed(sgReport).suppressed shouldEqual List(
+        (suppressedA, Set[SGInUse]())
+        (suppressedB, Set[SGInUse]())
+      )
     }
   }
 }

--- a/hq/test/logic/SecurityGroupDisplayTest.scala
+++ b/hq/test/logic/SecurityGroupDisplayTest.scala
@@ -28,18 +28,22 @@ class SecurityGroupDisplayTest extends FreeSpec with Matchers {
     val suppressedA = SGOpenPortsDetail("Ok", "eu-west-1", "name-3", "sg-3", "vpc-3", "tcp", "1099", "Yellow", isSuppressed = true, None, None)
     val suppressedB = SGOpenPortsDetail("Ok", "eu-west-1", "name-4", "sg-4", "vpc-4", "tcp", "1099", "Yellow", isSuppressed = true, None, None)
 
-    "returns two lists when there are flagged and suppressed" in {
+    "returns two lists when there are only flagged Security Groups, and no suppressed" in {
+      val sgReport = List((flaggedA, Set[SGInUse]()), (flaggedB, Set[SGInUse]()))
+      splitReportsBySuppressed(sgReport).suppressed.length shouldEqual 0
+      splitReportsBySuppressed(sgReport).flagged.length shouldEqual 2
+    }
+
+    "returns two lists when there are both flagged and suppressed Security Groups" in {
       val sgReport = List((flaggedA, Set[SGInUse]()), (suppressedA, Set[SGInUse]()), (flaggedB, Set[SGInUse]()), (flaggedA, Set[SGInUse]()))
       splitReportsBySuppressed(sgReport).suppressed.length shouldEqual 1
       splitReportsBySuppressed(sgReport).flagged.length shouldEqual 3
     }
 
-    "will place SGs with suppressed reports into the suppressed list" in {
-      val sgReport = List((suppressedA, Set[SGInUse]()), (flaggedA, Set[SGInUse]()), (suppressedB, Set[SGInUse]()))
-      splitReportsBySuppressed(sgReport).suppressed shouldEqual List(
-        (suppressedA, Set[SGInUse]())
-        (suppressedB, Set[SGInUse]())
-      )
+    "will place each Security Group into the correct list" in {
+      val sgReport = List((suppressedA, Set[SGInUse]()), (flaggedA, Set[SGInUse]()), (flaggedB, Set[SGInUse]()), (suppressedB, Set[SGInUse]()))
+      splitReportsBySuppressed(sgReport).suppressed shouldEqual List((suppressedA, Set()), (suppressedB, Set()))
+      splitReportsBySuppressed(sgReport).flagged shouldEqual List((flaggedA, Set()), (flaggedB, Set()))
     }
   }
 }


### PR DESCRIPTION
## What does this change?

Currently SHQ is not using the `isSuppressed` value from the TrustedAdvisor (TA) result.  If a Security Group warning is excluded/suppressed via the TA console `isSuppressed` will be `true`

> isSuppressed specifies whether the AWS resource was ignored by Trusted Advisor because it was marked as suppressed by the user.

This is a MVP at adding some filtering and visual cues to accommodate `isSuppressed`

#### 👉 Visually distinguish Security Groups when they are suppressed

- Add icon and tooltip to the card title
- Make the card background grey

<img width="1248" alt="picture 190" src="https://user-images.githubusercontent.com/8607683/35624771-e228f0fa-0687-11e8-9d4c-8fdc45c72b35.png">


#### 👉 All accounts page

- Add optional badges to show the number of excluded/suppressed Security Groups (SGs)
- Adds **permanent** card panel, with explainer text and checkboxes to toggle which SGs to display
- Defaults to showing flagged SGs with the ignored SGs hidden

<img width="1214" alt="picture 191" src="https://user-images.githubusercontent.com/8607683/35624907-4ebcde98-0688-11e8-8e16-a196aaebca59.png">


#### 👉 Individual account pages

- Adds **conditional** card panel about ignored Security Groups (SGs) **if** there are ignored SGs
- Defaults to showing flagged SGs with the ignored SGs hidden

<img width="1239" alt="picture 189" src="https://user-images.githubusercontent.com/8607683/35624695-98a56760-0687-11e8-94d1-c6987ba7faf5.png">


## What is the value of this?

SHQ probably still wants oversight of suppressed reports, however, suppressed reports add noise to the SGs list and are probably not helpful to individual teams.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

## Any additional notes?

This PR is interested in splitting flaggedSgs into two subsets that I have called `suppressed` and `flagged`. Arguably flaggedSgs should then be called something else, or maybe these subsets should be `excluded` and `included`...Naming things is hard. ¯\\_(ツ)\_/¯

Accounts are still sorted according to the total number of SG reports (including suppressed). We may want to change this (target for future PR).

#### I can confirm that checkboxes are 100% more aesthetically pleasing than using toggles here

<img width="200" alt="picture 187" src="https://user-images.githubusercontent.com/8607683/35623537-d8d05fe2-0683-11e8-8c4f-410bb018c091.png">
