### PR TITLE
Make the accordions keyboard-navigable, add shortcut to account page

### DIFF
--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -23,7 +23,7 @@
         <ul class="collapsible" data-collapsible="accordion">
         @for((account, report) <- reports) {
             <li>
-                <div class="collapsible-header">
+                <div class="collapsible-header" tabindex="22">
                     <i class="material-icons">keyboard_arrow_down</i>
                     <span class="iam-header__name">@account.name</span>
                     @report match {

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -2,7 +2,7 @@
 
 @(flaggedSgsByAccount: List[(model.AwsAccount, Either[utils.attempt.FailedAttempt, List[(model.SGOpenPortsDetail, Set[model.SGInUse])]])])(implicit assets: AssetsFinder)
 
-@floatingNav = {
+@floatingNav(accountId: String) = {
   <div class="fixed-action-btn js-floating-nav sg-floating-nav">
       <a class="btn-floating btn-large">
         <i class="large material-icons">menu</i>
@@ -16,6 +16,9 @@
           </a></li>
           <li><a class="btn-floating blue js-sg-pin-end">
             <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="go to end">vertical_align_bottom</i>
+          </a></li>
+          <li><a href="/security-groups/@accountId" class="btn-floating purple js-sg-pin-acc">
+              <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="go to account page">pageview</i>
           </a></li>
       </ul>
   </div>
@@ -61,7 +64,7 @@
             <ul class="collapsible space-between js-sg-collapsible" data-collapsible="accordion">
             @for((account, flaggedSgsAttempt) <- flaggedSgsByAccount) {
                 <li class="js-sg-scroll">
-                    <div class="collapsible-header sg-header">
+                    <div class="collapsible-header sg-header" tabindex="22">
                         <i class="material-icons">keyboard_arrow_down</i>
                         <span class="sg-header__name">@account.name</span>
                         @flaggedSgsAttempt match {
@@ -97,7 +100,7 @@
                             @views.html.fragments.openSecurityGroups(flaggedSgs, shadow=false)
                         }
                     }
-                    @floatingNav
+                    @floatingNav(account.id)
                     </div>
                 </li>
 


### PR DESCRIPTION
## What does this change?

#### 👉 Adding tabindexes to the accordions
- Slightly improved accessibility since tab no longer ignores the accordions
- Users of [Vimium](https://vimium.github.io/) can enjoy greater keyboard control and navigation (Vimium is awesome - I recommend checking trying it out)

<img width="1249" alt="picture 194" src="https://user-images.githubusercontent.com/8607683/35629516-b903a580-0696-11e8-8772-8da09950cc7b.png">

#### 👉 Add link to account page into the floating nav
- Fewer clicks to navigate between all accounts and a specific individual account

<img width="1675" alt="picture 193" src="https://user-images.githubusercontent.com/8607683/35630319-06bb22a6-0699-11e8-8df8-74339819203d.png">


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Accessibility of JavaScript widgets ([MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets))

Improved developer experience 🎁 



<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

Nope
<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
