### PR TITLE
Pre-create AWS clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ flycheck_*.el
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/dictionaries
+notes
 
 # Sensitive or high-churn files:
 .idea/**/dataSources/

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -46,6 +46,4 @@ object IAMClient {
       }
     }
   }
-
-
 }

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -24,12 +24,12 @@ class HQController (val config: Configuration, cacheService: CacheService)
   }
 
   def iam = authAction {
-    val accountsAndReports = cacheService.getAllCredentials
+    val accountsAndReports = cacheService.getAllCredentials()
     val sortedAccountsAndReports = sortAccountsByReportSummary(accountsAndReports.toList)
     Ok(views.html.iam.iam(sortedAccountsAndReports))
   }
 
-  def iamAccount(accountId: String) = authAction.async {
+  def iamAccount(accountId: String): Action[AnyContent] = authAction.async {
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -24,7 +24,7 @@ class HQController (val config: Configuration, cacheService: CacheService)
   }
 
   def iam = authAction {
-    val accountsAndReports = cacheService.getAllCredentials()
+    val accountsAndReports = cacheService.getAllCredentials
     val sortedAccountsAndReports = sortAccountsByReportSummary(accountsAndReports.toList)
     Ok(views.html.iam.iam(sortedAccountsAndReports))
   }

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -21,7 +21,7 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
   private val accounts = Config.getAwsAccounts(config)
 
   def securityGroups = authAction {
-    val allFlaggedSgs = cacheService.getAllSgs()
+    val allFlaggedSgs = cacheService.getAllSgs
     val sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs.toList)
 
     Ok(views.html.sgs.sgs(sortedFlaggedSgs))

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -21,7 +21,7 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
   private val accounts = Config.getAwsAccounts(config)
 
   def securityGroups = authAction {
-    val allFlaggedSgs = cacheService.getAllSgs
+    val allFlaggedSgs = cacheService.getAllSgs()
     val sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs.toList)
 
     Ok(views.html.sgs.sgs(sortedFlaggedSgs))

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -85,15 +85,15 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   }
 
   if (environment.mode != Mode.Test) {
-    val credentialsSubscription = Observable.interval(500.millis, 1.minutes).subscribe { _ =>
+    val credentialsSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
       refreshCredentialsBoxTa()
     }
 
-    val exposedKeysSubscription = Observable.interval(500.millis, 1.minutes).subscribe { _ =>
+    val exposedKeysSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
       refreshExposedKeysBoxTa()
     }
 
-    val sgSubscription = Observable.interval(500.millis, 1.minutes).subscribe { _ =>
+    val sgSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
       refreshSgsBoxTa()
     }
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -2,7 +2,7 @@ package services
 
 import aws.ec2.EC2
 import aws.iam.IAMClient
-import aws.support.TrustedAdvisorExposedIAMKeys
+import aws.support.{TrustedAdvisor, TrustedAdvisorExposedIAMKeys}
 import com.gu.Box
 import config.Config
 import model._
@@ -18,12 +18,15 @@ import scala.concurrent.duration._
 
 class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, environment: Environment)(implicit ec: ExecutionContext) {
   private val accounts = Config.getAwsAccounts(config)
+  private val taAccounts = Config.getAwsAccounts(config).map(account => TrustedAdvisor.client(account)).zip(accounts)
+  private val iamAccounts = Config.getAwsAccounts(config).map(account => IAMClient.client(account)).zip(accounts)
+
   private val startingCache = accounts.map(acc => (acc, Left(Failure.cacheServiceError(acc.id, "cache").attempt))).toMap
   private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(startingCache)
   private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(startingCache)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
 
-  def getAllCredentials(): Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = credentialsBox.get()
+  def getAllCredentials: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = credentialsBox.get()
 
   def getCredentialsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, CredentialReportDisplay] = {
     credentialsBox.get().getOrElse(
@@ -32,7 +35,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
     )
   }
 
-  def getAllExposedKeys(): Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]] = exposedKeysBox.get()
+  def getAllExposedKeys: Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]] = exposedKeysBox.get()
 
   def getExposedKeysForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[ExposedIAMKeyDetail]] = {
     exposedKeysBox.get().getOrElse(
@@ -41,7 +44,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
     )
   }
 
-  def getAllSgs(): Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]] = sgsBox.get()
+  def getAllSgs: Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]] = sgsBox.get()
 
   def getSgsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]] = {
     sgsBox.get().getOrElse(
@@ -50,31 +53,31 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
     )
   }
 
-  private def refreshCredentialsBox(): Unit = {
+  private def refreshCredentialsBoxTa(): Unit = {
     Logger.info("Started refresh of the Credentials data")
     for {
-      allCredentialReports <- IAMClient.getAllCredentialReports(accounts)
+      allCredentialReports <- IAMClient.getAllCredentialReportsTa(iamAccounts)
     } yield {
       Logger.info("Sending the refreshed data to the Credentials Box")
       credentialsBox.send(allCredentialReports.toMap)
     }
   }
 
-  private def refreshExposedKeysBox(): Unit = {
+  private def refreshExposedKeysBoxTa(): Unit = {
     Logger.info("Started refresh of the Exposed Keys data")
     for {
-      allExposedKeys <- TrustedAdvisorExposedIAMKeys.getAllExposedKeys(accounts)
+      allExposedKeys <- TrustedAdvisorExposedIAMKeys.getAllExposedKeysTa(taAccounts)
     } yield {
       Logger.info("Sending the refreshed data to the Exposed Keys Box")
       exposedKeysBox.send(allExposedKeys.toMap)
     }
   }
 
-  private def refreshSgsBox(): Unit = {
+  private def refreshSgsBoxTa(): Unit = {
     Logger.info("Started refresh of the Security Groups data")
     for {
-      _ <- EC2.refreshSGSReports(accounts)
-      allFlaggedSgs <- EC2.allFlaggedSgs(accounts)
+      _ <- EC2.refreshSGSReportsTa(taAccounts)
+      allFlaggedSgs <- EC2.allFlaggedSgsTa(taAccounts)
     } yield {
       Logger.info("Sending the refreshed data to the Security Groups Box")
       sgsBox.send(allFlaggedSgs.toMap)
@@ -82,16 +85,16 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   }
 
   if (environment.mode != Mode.Test) {
-    val credentialsSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
-      refreshCredentialsBox()
+    val credentialsSubscription = Observable.interval(500.millis, 1.minutes).subscribe { _ =>
+      refreshCredentialsBoxTa()
     }
 
-    val exposedKeysSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
-      refreshExposedKeysBox()
+    val exposedKeysSubscription = Observable.interval(500.millis, 1.minutes).subscribe { _ =>
+      refreshExposedKeysBoxTa()
     }
 
-    val sgSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
-      refreshSgsBox()
+    val sgSubscription = Observable.interval(500.millis, 1.minutes).subscribe { _ =>
+      refreshSgsBoxTa()
     }
 
     lifecycle.addStopHook { () =>


### PR DESCRIPTION
## What does this change?

Pre create all the AWS clients and hold on to them.

## What is the value of this?

This change will save set up time on each cache refresh.
The memory footprint will increase as a result.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

This is a test release and can be reverted immediately in the event of any failure.