### PR TITLE
Removing unnecessary sbt pluging

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import com.gu.riffraff.artifact.RiffRaffArtifact
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
 import play.sbt.PlayImport.PlayKeys._
-import com.typesafe.sbt.packager.MappingsHelper._
 
 // common settings (apply to all projects)
 organization in ThisBuild := "com.gu"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
-
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.4")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")


### PR DESCRIPTION
## What does this change?

Removes the unnecessary import of sbt-native-packager version 1.3.2.
