### PR TITLE
Scale out and debug memory usage

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -272,7 +272,7 @@ Resources:
         Ref: LaunchConfig
       MinSize: 2
       MaxSize: 4
-      DesiredCapacity: 1
+      DesiredCapacity: 2
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120
       LoadBalancerNames:

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -98,6 +98,11 @@ Resources:
             - s3:ListBucket
             - s3:GetObjectVersion
             - s3:GetObject
+          # Get parameters from SSM
+          - Effect: Allow
+            Resource: "*"
+            Action:
+            - ssm:GetParametersByPath
           # Describe instance tags, to find out its own stack, app, stage.
           - Effect: Allow
             Resource: "*"

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -265,8 +265,8 @@ Resources:
         Ref: Subnets
       LaunchConfigurationName:
         Ref: LaunchConfig
-      MinSize: 1
-      MaxSize: 2
+      MinSize: 2
+      MaxSize: 4
       DesiredCapacity: 1
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120

--- a/hq/upstart/security-hq.conf
+++ b/hq/upstart/security-hq.conf
@@ -25,7 +25,7 @@ script
   HEAP_SIZE_IN_MB=$(perl -e "print int($TOTAL_MEMORY * 0.75 / 1024)")
   HEAP_SIZE_CMD="-J-Xmx${HEAP_SIZE_IN_MB}m"
 
-  COMMAND="/security-hq/bin/security-hq $HEAP_SIZE_CMD $IF_64_BIT_OPTIONS $INCREMENTAL_MODE -J-XX:+PrintGCDetails -J-XX:+PrintGCDateStamps -J-Xloggc:gc.log -Dconfig.file=/security-hq/security-hq.conf"
+  COMMAND="/security-hq/bin/security-hq $HEAP_SIZE_CMD $IF_64_BIT_OPTIONS $INCREMENTAL_MODE -J-XX:NativeMemoryTracking=detail -J-XX:+PrintGCDetails -J-XX:+PrintGCDateStamps -J-Xloggc:gc.log -Dconfig.file=/security-hq/security-hq.conf"
 
   echo "$COMMAND" >/security-hq/cmd.txt
   $COMMAND >/security-hq/stdout.log 2>&1


### PR DESCRIPTION
## What does this change?

Allows for two instances (minimum) up to four during deployments.
Adds a flag to collate memory usage in the JRE

## What is the value of this?

To mitigate and investigate the instance failure due to memory exhaustion.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes

## Any additional notes?

These changes can be reverted once the memory issues are understood and resolved.