### PR TITLE
Use Set for Snyk issues

### DIFF
--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -24,7 +24,7 @@ object Serializers {
       and
       (JsPath \ "ok").read[Boolean]
       and
-      (JsPath \ "issues" \ "vulnerabilities").read[List[SnykIssue]]
+      (JsPath \ "issues" \ "vulnerabilities").read[Set[SnykIssue]]
     )(SnykProjectIssues.apply _)
 
 }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -147,7 +147,7 @@ case class SnykProject(name: String, id: String, organisation: Option[SnykOrgani
 
 case class SnykIssue(title: String, id: String, severity: String)
 
-case class SnykProjectIssues(project: Option[SnykProject], ok: Boolean, vulnerabilities: List[SnykIssue])  {
+case class SnykProjectIssues(project: Option[SnykProject], ok: Boolean, vulnerabilities: Set[SnykIssue])  {
   def high: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("high"))
   def medium: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("medium"))
   def low: Int = vulnerabilities.count(s => s.severity.equalsIgnoreCase("low"))

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -258,8 +258,8 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
     )
 
     val goodVulnerabilities = List(
-      SnykProjectIssues(None, ok = false, List[SnykIssue]()),
-      SnykProjectIssues(None, ok = false, List[SnykIssue]())
+      SnykProjectIssues(None, ok = false, Set[SnykIssue]()),
+      SnykProjectIssues(None, ok = false, Set[SnykIssue]())
     )
 
     "label projects - first id" - {
@@ -290,7 +290,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "medium"),
               SnykIssue("Issue2", "3", "low")
@@ -299,7 +299,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "high"),
               SnykIssue("Issue2", "3", "medium"),
@@ -315,7 +315,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "medium"),
               SnykIssue("Issue3", "3", "low")
@@ -324,7 +324,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "medium"),
               SnykIssue("Issue3", "3", "medium"),
@@ -340,7 +340,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "medium"),
               SnykIssue("Issue3", "3", "low")
@@ -349,7 +349,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "medium"),
               SnykIssue("Issue3", "3", "low"),
@@ -365,7 +365,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("Y", "b", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "medium"),
               SnykIssue("Issue3", "3", "low")
@@ -374,7 +374,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
           SnykProjectIssues(
             Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
             ok = true,
-            List(
+            Set(
               SnykIssue("Issue1", "1", "high"),
               SnykIssue("Issue2", "2", "medium"),
               SnykIssue("Issue3", "3", "low")


### PR DESCRIPTION
## What does this change?

Correct Snyk response information by deduplicating.

## What is the value of this?

Some Issues are found through multiple dependency routes.  They should still, ideally, be
only counted as one.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

## Any additional notes?

No.