### PR TITLE
Various styling and template improvements, and optimise readability of docs pages

### DIFF
--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -61,6 +61,14 @@ object SnykDisplay {
     case _: JsonParseException => None
   }
 
+  def linkToSnykProject(snykProjectIssues: SnykProjectIssues, queryString: Option[String]): String = {
+    snykProjectIssues.project match {
+      case Some(project: SnykProject) if project.organisation.nonEmpty =>
+        s"https://snyk.io/org/${project.organisation.get.name}/project/${project.id}/${queryString.getOrElse("")}"
+      case _ => ""
+    }
+  }
+
   def labelOrganisations(projects: List[SnykProject], snykOrg: SnykOrganisation): List[SnykProject] = {
     projects.map(project => project.copy(organisation = Some(snykOrg)))
   }

--- a/hq/app/views/doc.scala.html
+++ b/hq/app/views/doc.scala.html
@@ -2,20 +2,23 @@
 
 @(file: String)(implicit assets: AssetsFinder)
 
-@main(Nil) { @* Header *@
+@main(List("Documentation")) { @* Header *@
   <div class="hq-sub-header">
       <div class="container hq-sub-header__row">
           <div class="hq-sub-header__name">
-              <h4 class="header light grey-text text-lighten-5">Documentation</h4>
+              <h4 class="header light grey-text text-lighten-5">
+                  Documentation
+              </h4>
           </div>
       </div>
   </div>
 
 } { @* Main content *@
-
     <div class="container">
         <div class="row">
-            @{DocumentUtil.convert(file) getOrElse views.html.documentation.unknown(file)}
+            <div class="doc-content col">
+                @{DocumentUtil.convert(file) getOrElse views.html.documentation.unknown(file)}
+            </div>
         </div>
     </div>
 

--- a/hq/app/views/doc.scala.html
+++ b/hq/app/views/doc.scala.html
@@ -16,7 +16,7 @@
 } { @* Main content *@
     <div class="container">
         <div class="row">
-            <div class="doc-content col">
+            <div class="doc-content col s12 flow-text">
                 @{DocumentUtil.convert(file) getOrElse views.html.documentation.unknown(file)}
             </div>
         </div>

--- a/hq/app/views/documentation/unknown.scala.html
+++ b/hq/app/views/documentation/unknown.scala.html
@@ -3,7 +3,7 @@
 <h2>Not found</h2>
 <p>No documentation found on "@file".</p>
 <p>Consider searching on
-    <a href="https://www.google.com/search?q=@file">Google</a>, or
-    <a href="https://stackoverflow.com/search?q=@file">Stack Overflow</a>, ?
+    <a href="https://www.google.com/search?q=@file">Google</a> or
+    <a href="https://stackoverflow.com/search?q=@file">Stack Overflow</a>.
 </p>
 

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -31,14 +31,14 @@
                             @defining(reportStatusSummary(re)) { statusCounts =>
                                 @if(statusCounts.errors > 0) {
                                     <span class="icon-count">@statusCounts.errors</span>
-                                    <i class="material-icons red-text" data-delay="50">error</i>
+                                    <i class="material-icons red-text">error</i>
                                 }
                                 @if(statusCounts.warnings > 0) {
                                     <span class="icon-count">@statusCounts.warnings</span>
-                                    <i class="material-icons amber-text" data-delay="50">warning</i>
+                                    <i class="material-icons amber-text">warning</i>
                                 }
                                 @if(statusCounts.errors == 0 && statusCounts.warnings == 0) {
-                                    <i class="material-icons green-text" data-delay="50">check</i>
+                                    <i class="material-icons green-text">check</i>
                                 }
                             }
                         }

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -72,7 +72,7 @@
                                 <i class="material-icons">warning</i>
                             }
                             case Right(Nil) => {
-                                <i class="material-icons">done</i>
+                                <i class="material-icons green-text">check</i>
                             }
                             case Right(flaggedSgs) => {
                                 @defining(splitReportsBySuppressed(flaggedSgs)) { sgReports =>

--- a/hq/app/views/snyk/snyk.scala.html
+++ b/hq/app/views/snyk/snyk.scala.html
@@ -1,15 +1,13 @@
-@import logic.SnykDisplay
-@import logic._
+@import logic.SnykDisplay._
 @import model._
 
 @(results: List[SnykProjectIssues])(implicit assets: AssetsFinder)
 
 @main(List("Snyk")) { @* Header *@
-    <div class="container">
-        <div class="row">
-            <h1 class="header center-on-small-only grey-text text-lighten-5">Security HQ</h1>
-            <div class="col s12 m9">
-                <h4 class="grey-text text-darken-4 center-on-small-only">Snyk Results</h4>
+    <div class="hq-sub-header">
+        <div class="container hq-sub-header__row">
+            <div class="hq-sub-header__name">
+                <h4 class="header light grey-text text-lighten-5">Snyk Results</h4>
             </div>
         </div>
     </div>
@@ -30,20 +28,36 @@
 
             <tbody>
             @for(projectIssues <- results) {
-                <tr>
-                    <td>
-                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/">@projectIssues.project.get.name</a>
-                    </td>
-                    <td>
-                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/?disclosure=all&severity=high">@projectIssues.high</a>
-                    </td>
-                    <td>
-                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/?disclosure=all&severity=medium">@projectIssues.medium</a>
-                    </td>
-                    <td>
-                        <a class="black-text" href="https://snyk.io/org/@projectIssues.project.get.organisation.get.name/project/@projectIssues.project.get.id/?disclosure=all&severity=low">@projectIssues.low</a>
-                    </td>
-                </tr>
+                @projectIssues.project match {
+                    case Some(snykProject) => {
+                        <tr>
+                            <td>
+                                <a target="_blank" rel="noopener noreferrer" href="@linkToSnykProject(projectIssues, None)">
+                                    @snykProject.name
+                                    <i class="material-icons link_new_tab">open_in_new</i>
+                                </a>
+                            </td>
+                            <td>
+                                <a target="_blank" href="@{linkToSnykProject(projectIssues, Some("?disclosure=all&severity=high"))}">
+                                    @projectIssues.high
+                                </a>
+                            </td>
+                            <td>
+                                <a target="_blank" href="@{linkToSnykProject(projectIssues, Some("?disclosure=all&severity=medium"))}">
+                                    @projectIssues.medium
+                                </a>
+                            </td>
+                            <td>
+                                <a target="_blank" href="@{linkToSnykProject(projectIssues, Some("?disclosure=all&severity=low"))}">
+                                    @projectIssues.low
+                                </a>
+                            </td>
+                        </tr>
+                    }
+                    case None => { }
+                }
+
+
             }
 
         </table>

--- a/hq/markdown/index.md
+++ b/hq/markdown/index.md
@@ -1,5 +1,5 @@
 # List of help pages
 
    1. How to implement [Snyk](snyk) Vulnerability Analysis to check library dependencies.
-   1. How to implement [AWS run command (tutorial)](run-command) and remove the need for ssh/bastions.
-   1. How to use [Temporary SSH credentials](temporary-ssh).
+   2. How to implement [AWS run command (tutorial)](run-command) and remove the need for ssh/bastions.
+   3. How to use [Temporary SSH credentials](temporary-ssh).

--- a/hq/public/javascripts/jquery.filtertable.js
+++ b/hq/public/javascripts/jquery.filtertable.js
@@ -210,7 +210,7 @@
         containerClass: 'filter-table',
 
         // tag name of the container
-        containerTag: 'p',
+        containerTag: 'div',
 
         // jQuery expression method to use for filtering
         filterExpression: 'filterTableFind',
@@ -237,7 +237,7 @@
         inputType: 'search',
 
         // text to precede the filter input tag
-        label: 'Filter:',
+        label: '<i class="material-icons medium left">search</i>',
 
         // filter only when at least this number of characters are in the filter input field
         minChars: 1,
@@ -255,10 +255,11 @@
         quickList: [],
 
         // class of each quick list item
-        quickListClass: 'quick',
+        quickListClass: 'quick black-text',
 
         // quick list item label to clear the filter (e.g., '&times; Clear filter')
-        quickListClear: '',
+        quickListClear:
+          '<i class="material-icons filter-table__clear">close</i>',
 
         // tag surrounding quick list items (e.g., ul)
         quickListGroupTag: '',

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -322,6 +322,30 @@ table.iam-report__table th {
   height: 24px;
 }
 
+/* Docs */
+
+.doc-content h1 {
+  font-size: 3.5rem;
+}
+
+.doc-content h2 {
+  font-size: 3rem;
+}
+
+.doc-content h3 {
+  font-size: 2.5rem;
+}
+
+.doc-content h4 {
+  font-size: 2rem;
+}
+
+/* Snyk */
+
+.filter-table {
+  display: flex;
+}
+
 /* footer */
 
 .hq-footer__links {


### PR DESCRIPTION
## What does this change?

#### 👉 Documentation pages:

- Customise the heading font-sizes on the documentation pages, and use flow-text to auto-scale

<img width="1101" alt="picture 197" src="https://user-images.githubusercontent.com/8607683/35803039-4510ee30-0a6a-11e8-9674-75192449c27e.png">

#### 👉 Snyk report:

- Update the Snyk report page to use the current sub header design
- Style the Snyk report search form and add clear button for filter

<img width="1249" alt="picture 196" src="https://user-images.githubusercontent.com/8607683/35802644-c7d9156a-0a68-11e8-8c42-e9a0f5ae0935.png">

#### 👉 Other minor fixes and improvements:

- Move some logic out of the templates
- Delete unused data attributes
- Updates to styling, and usage of icons and hyperlinks

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

- Consistent design
- Optimising readability
- Code maintenance 

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope
