### PR TITLE
Using ami-68630a11 (with java8, awscli tools and ssm-agent already installed)

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -64,6 +64,12 @@ Mappings:
       Value: security-hq
 
 Resources:
+
+  SecurityHQInstance:
+    Type: "AWS::EC2::Instance"
+    Properties:
+      ImageId: "ami-68630a11"
+
   SecurityHQInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
@@ -233,15 +239,9 @@ Resources:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev
           locale-gen en_GB.UTF-8
-          add-apt-repository -y ppa:openjdk-r/ppa
           apt-get -y update
           apt-get -y upgrade
-          apt-get -y install openjdk-8-jre-headless ntp python-pip
-          pip install --upgrade pip
-          pip install awscli
-          wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
-          mkdir /tmp/ssm
-          dpkg -i amazon-ssm-agent.deb
+          apt-get -y install ntp
           echo ${Stage} > /etc/stage
           # fix java-8 certs
           /var/lib/dpkg/info/ca-certificates-java.postinst configure


### PR DESCRIPTION
## What does this change?

Here we set security-hq to use AMI ami-68630a11 which was baked in AMIgo. This AMI comes with java8, awscli tools and the ssm-agent already installed. Accordingly the `UserData` section of the cloudformation has been updated. 