### PR TITLE
Moving to AMIgo backed AMIs

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -233,18 +233,10 @@ Resources:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev
           locale-gen en_GB.UTF-8
-          add-apt-repository -y ppa:openjdk-r/ppa
           apt-get -y update
           apt-get -y upgrade
-          apt-get -y install openjdk-8-jre-headless ntp python-pip
-          pip install --upgrade pip
-          pip install awscli
-          wget https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/debian_amd64/amazon-ssm-agent.deb
-          mkdir /tmp/ssm
-          dpkg -i amazon-ssm-agent.deb
+          apt-get -y install ntp
           echo ${Stage} > /etc/stage
-          # fix java-8 certs
-          /var/lib/dpkg/info/ca-certificates-java.postinst configure
           # setup security-hq
           adduser --system --home /security-hq --disabled-password security-hq
           aws --region eu-west-1 s3 cp s3://${SecurityHQSourceBundleBucket}/security/${Stage}/security-hq/security-hq.conf /security-hq

--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -3,6 +3,7 @@ stacks:
 regions:
 - eu-west-1
 deployments:
+
   security-hq:
     type: autoscaling
     parameters:
@@ -16,3 +17,7 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: security-hq
       templatePath: cfn.yaml
+      amiTags:
+        Recipe: security-hq
+        BuiltBy: amigo
+        AmigoStage: PROD


### PR DESCRIPTION
## What does this change?

This change updates the `hq/conf/riff-raff.yaml` file to make it possible for Riff-Raff to use the latest available AMI of the `security-hq` AMIgo recipe.

This recipe puts `aws-tools`, `java8` and `ssm-agent` onto `ubuntu-trusty`.

Accordingly, `cloudformation/security-hq.template.yaml` has been updated  by removing the duplicate work. 

Note: Ideally we would not have `apt-get -y update` and `apt-get -y upgrade` running as part of the launch config, but this is not the concern of this PR. This problem, namely the fact that a backed AMI needs this, will be addressed separately. 

Note: Since the cloud formation file is picked up as part of the deployment, there is here no requirement to do it manually beforehand in AWS console. 