### PR TITLE
Expand all for IAM page MVP help modal for Security Groups pages, more scores 

### DIFF
--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -85,7 +85,8 @@ object ReportDisplay {
     val (warnings, errors, other) = reportStatusSummary.foldLeft(0,0,0) {
       case ( (war, err, oth), Amber ) => (war+1, err, oth)
       case ( (war, err, oth), Red ) => (war, err+1, oth)
-      case ( (war, err, oth), _ ) => (war, err, oth+1)
+      case ( (war, err, oth), Blue ) => (war, err, oth+1)
+      case ( (war, err, oth), _ ) => (war, err, oth)
     }
     ReportSummary(warnings, errors, other)
   }

--- a/hq/app/logic/SecurityGroupDisplay.scala
+++ b/hq/app/logic/SecurityGroupDisplay.scala
@@ -6,6 +6,7 @@ import model.{ELB, Ec2Instance, SGInUse, SGOpenPortsDetail}
 object SecurityGroupDisplay {
 
   case class ResourceIcons(instances: Int, elbs: Int, unknown: Int)
+  case class SGReportSummary(total: Int, suppressed: Int, flagged: Int, active: Int)
 
   case class SGReportDisplay(
     suppressed: List[(SGOpenPortsDetail, Set[SGInUse])],
@@ -19,8 +20,14 @@ object SecurityGroupDisplay {
       case ( (ins, elb, unk), ELB(_) ) => (ins, elb+1, unk)
       case ( (ins, elb, unk), _ ) => (ins, elb, unk+1)
     }
-
     ResourceIcons(instances, elbs, unknown)
+  }
+
+  def reportSummary(sgs: List[(SGOpenPortsDetail, Set[SGInUse])]): SGReportSummary = {
+    val (active, _) = sgs.partition( sg => sg._2.nonEmpty )
+    val (suppressed, flagged) = sgs.partition( sg => sg._1.isSuppressed )
+
+    SGReportSummary(sgs.length, suppressed.length, flagged.length, active.length)
   }
 
   def hasSuppressedReports(sgs: List[(SGOpenPortsDetail, Set[SGInUse])]): Boolean = {

--- a/hq/app/views/fragments/openSecurityGroups.scala.html
+++ b/hq/app/views/fragments/openSecurityGroups.scala.html
@@ -49,7 +49,10 @@
                     <tbody>
                         <tr>
                             <th>Port</th>
-                            <td>@flaggedSg.port</td>
+                            <td>
+                                @flaggedSg.port
+                                <a class="modal-trigger iam-modal__trigger right" href="#sg-help"><i class="material-icons black-text">help_outline</i></a>
+                            </td>
                         </tr>
                         <tr>
                             <th>Protocol</th>

--- a/hq/app/views/fragments/securityGroupHelp.scala.html
+++ b/hq/app/views/fragments/securityGroupHelp.scala.html
@@ -1,12 +1,14 @@
 <div id="sg-help" class="modal bottom-sheet sg-modal">
     <div class="modal-content">
         <h4><i class="material-icons large-icon left">vpn_lock</i>Security Groups Help</h4>
+        <p>A security group acts as a virtual stateful firewall that controls the traffic for one or more instances. Traffic can be restricted by protocol, by service port, source IP address or security group. The following issues may apply:</p>
         <ul class="collection">
             <li class="collection-item avatar">
                 <i class="material-icons circle large-icon white red-text">error</i>
-                <span class="title">Unrestricted Access</span>
-                <p>Restrict access to only those IP addresses that require it. Be sure to delete overly permissive rules after creating rules that are more restrictive.</p>
-                <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html" class="secondary-content">Read more in the AWS docs</a>
+                <span class="title">Unrestricted Access on Administrative Ports</span>
+                <p></p>
+                Limit access to common administrative ports to only a small subset of addresses.
+                <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html" class="secondary-content">Read more in the AWS docs</a>
             </li>
             <li class="collection-item avatar">
                 <i class="material-icons circle large-icon white amber-text">warning</i>

--- a/hq/app/views/fragments/securityGroupHelp.scala.html
+++ b/hq/app/views/fragments/securityGroupHelp.scala.html
@@ -4,18 +4,26 @@
         <p>A security group acts as a virtual stateful firewall that controls the traffic for one or more instances. Traffic can be restricted by protocol, by service port, source IP address or security group. The following issues may apply:</p>
         <ul class="collection">
             <li class="collection-item avatar">
-                <i class="material-icons circle large-icon white red-text">error</i>
+                <i class="material-icons circle large-icon red white-text">code</i>
                 <span class="title">Unrestricted Access on Administrative Ports</span>
                 <p></p>
                 Limit access to common administrative ports to only a small subset of addresses.
-                <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html" class="secondary-content">Read more in the AWS docs</a>
+                <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html#add-rule-authorize-access" class="secondary-content">authorising inbound traffic<i class="material-icons right">open_in_new</i></a>
             </li>
             <li class="collection-item avatar">
-                <i class="material-icons circle large-icon white amber-text">warning</i>
+                <i class="material-icons circle large-icon amber while-text">network_check</i>
                 <span class="title">Specific Ports Unrestricted</span>
                 <p>Restrict access to only those IP addresses that require it. Be sure to delete overly permissive rules after creating rules that are more restrictive.</p>
-                <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html" class="secondary-content">Read more in the AWS docs</a>
+                <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html#security-group-rules" class="secondary-content">using network security<i class="material-icons right">open_in_new</i></a>
             </li>
+            <li class="collection-item avatar">
+                <i class="material-icons circle large-icon purple white-text">control_point_duplicate</i>
+                <span class="title">Duplicate Security Group Rules</span>
+                <p>If there is more than one rule for a specific port, the most permissive rule will be applied.</p>
+                <a href="https://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html#SecurityGroupRules" class="secondary-content">security group rules<i class="material-icons right">open_in_new</i></a>
+            </li>
+
+
         </ul>
     </div>
 </div>

--- a/hq/app/views/fragments/securityGroupHelp.scala.html
+++ b/hq/app/views/fragments/securityGroupHelp.scala.html
@@ -1,0 +1,19 @@
+<div id="sg-help" class="modal bottom-sheet sg-modal">
+    <div class="modal-content">
+        <h4><i class="material-icons large-icon left">vpn_lock</i>Security Groups Help</h4>
+        <ul class="collection">
+            <li class="collection-item avatar">
+                <i class="material-icons circle large-icon white red-text">error</i>
+                <span class="title">Unrestricted Access</span>
+                <p>Restrict access to only those IP addresses that require it. Be sure to delete overly permissive rules after creating rules that are more restrictive.</p>
+                <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html" class="secondary-content">Read more in the AWS docs</a>
+            </li>
+            <li class="collection-item avatar">
+                <i class="material-icons circle large-icon white amber-text">warning</i>
+                <span class="title">Specific Ports Unrestricted</span>
+                <p>Restrict access to only those IP addresses that require it. Be sure to delete overly permissive rules after creating rules that are more restrictive.</p>
+                <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/authorizing-access-to-an-instance.html" class="secondary-content">Read more in the AWS docs</a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -2,6 +2,21 @@
 @import model._
 @(reports: List[(AwsAccount, Either[utils.attempt.FailedAttempt, CredentialReportDisplay])])(implicit assets: AssetsFinder)
 
+@floatingNav() = {
+<div class="fixed-action-btn js-floating-nav iam-floating-nav">
+    <a class="btn-floating btn-large">
+        <i class="large material-icons">menu</i>
+    </a>
+    <ul>
+        <li><a class="btn-floating red js-iam-collapse">
+            <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="collapse all">fullscreen_exit</i>
+        </a></li>
+        <li><a class="btn-floating yellow darken-1 js-iam-expand">
+            <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="expand all">fullscreen</i>
+        </a></li>
+    </ul>
+</div>
+}
 
 @main(List("IAM report")) { @* Header *@
     <div class="hq-sub-header">
@@ -20,50 +35,59 @@
 
 } { @* Main content *@
     <div class="container">
-        <ul class="collapsible" data-collapsible="accordion">
-        @for((account, report) <- reports) {
-            <li>
-                <div class="collapsible-header" tabindex="22">
-                    <i class="material-icons">keyboard_arrow_down</i>
-                    <span class="iam-header__name">@account.name</span>
-                    @report match {
-                        case Right(re) => {
-                            @defining(reportStatusSummary(re)) { statusCounts =>
-                                @if(statusCounts.errors > 0) {
-                                    <span class="icon-count">@statusCounts.errors</span>
-                                    <i class="material-icons red-text">error</i>
-                                }
-                                @if(statusCounts.warnings > 0) {
-                                    <span class="icon-count">@statusCounts.warnings</span>
-                                    <i class="material-icons amber-text">warning</i>
-                                }
-                                @if(statusCounts.errors == 0 && statusCounts.warnings == 0) {
-                                    <i class="material-icons green-text">check</i>
+        <div class="row">
+            <ul class="collapsible" data-collapsible="accordion">
+            @for((account, report) <- reports) {
+                <li>
+                    <div class="collapsible-header" tabindex="22">
+                        <i class="material-icons">keyboard_arrow_down</i>
+                        <span class="iam-header__name">@account.name</span>
+                        @report match {
+                            case Right(re) => {
+                                @defining(reportStatusSummary(re)) { statusCounts =>
+                                    @if(statusCounts.errors > 0) {
+                                        <span class="icon-count">@statusCounts.errors</span>
+                                        <i class="material-icons red-text">error</i>
+                                    }
+                                    @if(statusCounts.warnings > 0) {
+                                        <span class="icon-count">@statusCounts.warnings</span>
+                                        <i class="material-icons amber-text">warning</i>
+                                    }
+                                    @if(statusCounts.other > 0) {
+                                        <span class="icon-count">@statusCounts.other</span>
+                                        <i class="material-icons purple-text">watch_later</i>
+                                    }
+                                    @if(statusCounts.errors == 0 && statusCounts.warnings == 0) {
+                                        <i class="material-icons green-text">check</i>
+                                    }
                                 }
                             }
+                            case Left(_) => {
+                                <i class="material-icons">warning</i>
+                            }
                         }
-                        case Left(_) => {
-                            <i class="material-icons">warning</i>
+                    </div>
+                    <div class="collapsible-body">
+                    @report match {
+                        case Right(re) => {
+                            @views.html.iam.iamCredReportBody(sortUsersByReportSummary(re))
+                        }
+                        case Left(fa) => {
+                            <p class="p--warning">
+                            @for(err <- fa.failures) {
+                                @err.friendlyMessage
+                            }
+                            </p>
                         }
                     }
-                </div>
-                <div class="collapsible-body">
-                @report match {
-                    case Right(re) => {
-                        @views.html.iam.iamCredReportBody(sortUsersByReportSummary(re))
-                    }
-                    case Left(fa) => {
-                        <p class="p--warning">
-                        @for(err <- fa.failures) {
-                            @err.friendlyMessage
-                        }
-                        </p>
-                    }
-                }
-                </div>
-            </li>
-        }
-        </ul>
+                    </div>
+                </li>
+            }
+            </ul>
+        </div>
+
+        @floatingNav()
+
     </div>
 
     @views.html.fragments.credentialsHelp()

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -1,4 +1,4 @@
-@import logic.SecurityGroupDisplay.splitReportsBySuppressed
+@import logic.SecurityGroupDisplay.reportSummary
 
 @(flaggedSgsByAccount: List[(model.AwsAccount, Either[utils.attempt.FailedAttempt, List[(model.SGOpenPortsDetail, Set[model.SGInUse])]])])(implicit assets: AssetsFinder)
 
@@ -41,8 +41,8 @@
 
 } { @* Main content *@
     <div class="container">
-        <div class="row">
-            <h2>Open Security Groups</h2>
+        <div class="row flow-text">
+            <h3>Open Security Groups</h3>
             <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>
         </div>
 
@@ -51,7 +51,7 @@
                 <i class="material-icons left">visibility_off</i>
                 <span class="sg-header__name">Some Security Groups may be ignored due to settings in AWS Trusted Advisor</span>
 
-                <form action="#">
+                <form class="sg-filter" action="#">
                     <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
                     <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
                     <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />
@@ -59,6 +59,8 @@
                 </form>
             </div>
         </div>
+
+        @views.html.fragments.securityGroupHelp()
 
         <div class="row">
             <ul class="collapsible space-between js-sg-collapsible" data-collapsible="accordion">
@@ -75,11 +77,10 @@
                                 <i class="material-icons green-text">check</i>
                             }
                             case Right(flaggedSgs) => {
-                                @defining(splitReportsBySuppressed(flaggedSgs)) { sgReports =>
-                                    <span class="new badge" data-badge-caption="flagged resources">@sgReports.flagged.length</span>
-                                    @if(sgReports.suppressed.length > 0) {
-                                        <span class="new badge grey sg-header__badge" data-badge-caption="ignored">@sgReports.suppressed.length</span>
-                                    }
+                                @defining(reportSummary(flaggedSgs)) { summary =>
+                                    <span class="new badge red darken-3 sg-header__badge" data-badge-caption="in use">@summary.active</span>
+                                    <span class="new badge sg-header__badge" data-badge-caption="not in use">@{summary.flagged - summary.active}</span>
+                                    <span class="new badge grey sg-header__badge" data-badge-caption="ignored">@summary.suppressed</span>
                                 }
                             }
                         }

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -78,9 +78,15 @@
                             }
                             case Right(flaggedSgs) => {
                                 @defining(reportSummary(flaggedSgs)) { summary =>
-                                    <span class="new badge red darken-3 sg-header__badge" data-badge-caption="in use">@summary.active</span>
-                                    <span class="new badge sg-header__badge" data-badge-caption="not in use">@{summary.flagged - summary.active}</span>
-                                    <span class="new badge grey sg-header__badge" data-badge-caption="ignored">@summary.suppressed</span>
+                                    @if(summary.active > 0) {
+                                        <span class="new badge red darken-3 sg-header__badge" data-badge-caption="in use">@summary.active</span>
+                                    }
+                                    @if((summary.flagged - summary.active) > 0) {
+                                        <span class="new badge sg-header__badge" data-badge-caption="not in use">@{summary.flagged - summary.active}</span>
+                                    }
+                                    @if(summary.suppressed > 0) {
+                                        <span class="new badge grey sg-header__badge" data-badge-caption="ignored">@summary.suppressed</span>
+                                    }
                                 }
                             }
                         }

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -23,8 +23,9 @@
         <div class="row">
             <h2>Open Security Groups</h2>
             <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>
-            <a class="modal-trigger iam-modal__trigger right" href="#sg-help"><i class="material-icons black-text">help_outline</i></a>
         </div>
+
+        @views.html.fragments.securityGroupHelp()
 
         @if(hasSuppressedReports(flaggedSgs)) {
             <div class="row">
@@ -45,5 +46,6 @@
         <div class="row">
             @views.html.fragments.openSecurityGroups(flaggedSgs, shadow=true)
         </div>
+
     </div>
 }

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -23,6 +23,7 @@
         <div class="row">
             <h2>Open Security Groups</h2>
             <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>
+            <a class="modal-trigger iam-modal__trigger right" href="#sg-help"><i class="material-icons black-text">help_outline</i></a>
         </div>
 
         @if(hasSuppressedReports(flaggedSgs)) {
@@ -31,7 +32,7 @@
                     <i class="material-icons left">visibility_off</i>
                     <span class="sg-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
 
-                    <form action="#">
+                    <form class="sg-filter" action="#">
                         <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
                         <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
                         <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -14,6 +14,18 @@ $(document).ready(function() {
   // Make any tables with the filter class filterable
   $('.filterable-table').filterTable();
 
+  $('.js-iam-expand').click(function() {
+    $('.collapsible-header').addClass('active');
+    $('.collapsible-body').css('display', 'block');
+  });
+
+  $('.js-iam-collapse').click(function() {
+    $('.collapsible-header').removeClass(function() {
+      return 'active';
+    });
+    $('.collapsible-body').css('display', 'none');
+  });
+
   // Extra interactions for the dropdowns on the Security Groups page
   $('.js-sg-details').hover(
     function() {

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -201,6 +201,10 @@ nav {
 
 /* security group pages */
 
+.sg-filter {
+  min-width: 300px;
+}
+
 .sg-filter__label {
   margin-left: 20px;
 }
@@ -211,6 +215,7 @@ nav {
 
 .sg-header span.sg-header__badge {
   margin-left: 10px;
+  width: 80px;
 }
 
 .sg-container {

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -245,8 +245,11 @@ class ReportDisplayTest extends FreeSpec with Matchers {
       val humanRed = HumanUser("humanRed", hasMFA = false, AccessKeyEnabled, AccessKeyEnabled, Red, Some(1))
       val humanGreen = HumanUser("humanGreen", hasMFA = true, AccessKeyEnabled, AccessKeyEnabled, Green, Some(1))
       val machineAmber = MachineUser("machineAmber", AccessKeyEnabled, AccessKeyEnabled, Amber, Some(1))
+      val machineBlue = MachineUser("machineGreen", AccessKeyEnabled, AccessKeyEnabled, Blue, Some(1))
       val machineGreen = MachineUser("machineGreen", AccessKeyEnabled, AccessKeyEnabled, Green, Some(1))
-      val report = CredentialReportDisplay(now, humanUsers = Seq(humanRed, humanGreen), machineUsers = Seq(machineAmber, machineGreen, machineGreen, machineAmber))
+      val report = CredentialReportDisplay(
+        now, humanUsers = Seq(humanRed, humanGreen), machineUsers = Seq(machineAmber, machineBlue, machineGreen, machineAmber, machineBlue, machineBlue)
+      )
       reportStatusSummary(report).warnings shouldEqual 2
       reportStatusSummary(report).errors shouldEqual 1
       reportStatusSummary(report).other shouldEqual 3


### PR DESCRIPTION
## What does this change?

#### 👉 More numbers on the dashboard!

- Splitting flagged SGs into two subsets and giving separate counts for both

<img width="1260" alt="picture 200" src="https://user-images.githubusercontent.com/8607683/35873001-5f4c7dc2-0b60-11e8-9833-e9592785cfca.png">



#### 👉 SG helper modal and initial copy

- Start laying down the rules and recommendations for SG issues

<img width="1653" alt="picture 198" src="https://user-images.githubusercontent.com/8607683/35872787-b1557a48-0b5f-11e8-88d4-14eb1054d159.png">

#### 👉 IAM All Accounts page

- Helper menu with expand all, collapse all options
- Adding inactive user count and icon to the expandable headings

<img width="1432" alt="picture 199" src="https://user-images.githubusercontent.com/8607683/35872791-b697f60c-0b5f-11e8-9f8a-ca5ea64c054f.png">


#### 👉 Minor fixes

- Fix overflow issue on docs page by adding correct classes
- HTML structure consistency
- using helper classes to size text

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Supporting work for making SHQ more opinionated. 
Metrics are useful.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
