### PR TITLE
Correct path to sbt on team city

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val hq = (project in file("hq")).
       "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test
@@ -81,7 +82,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
       "ch.qos.logback" %  "logback-classic" % "1.2.3",
       "com.amazonaws" % "aws-java-sdk-config" % "1.11.246",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.10"
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -91,3 +91,5 @@ lazy val root = (project in file(".")).
   settings(
     name := """security-hq"""
   )
+
+addCommandAlias("dependency-tree", "dependencyTree")

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "linter-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "prettier -o --write './**/*.{js,css}'",
     "sass-lint": "sass-lint -v -q hq/public/stylesheets/*.css",
-    "snyk-test": "PATH=/path/to/sbt/executable/folder:$PATH snyk test --debug --org=guardian --json --file=build.sbt",
-    "snyk-monitor": "PATH=/path/to/sbt/executable/folder:$PATH snyk monitor --debug --org=guardian --file=build.sbt"
+    "snyk-test": "PATH=.:$PATH snyk test --debug --org=guardian --json --file=build.sbt",
+    "snyk-monitor": "PATH=.:$PATH snyk monitor --debug --org=guardian --file=build.sbt"
   }
 }

--- a/sbt
+++ b/sbt
@@ -26,7 +26,11 @@ do
 done
 
 java $DEBUG_PARAMS \
-    -Xms1024M -Xmx2048M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1024M \
+    -Xms1024M -Xmx2048M \
+    -Xss1M \
+    -XX:+CMSClassUnloadingEnabled \
+    -XX:MaxPermSize=1024M \
     $CONF_PARAMS \
     $TC_PARAMS \
+    -Dsbt.log.noformat=true \
     -jar bin/sbt-launch.jar "$@"

--- a/sbt
+++ b/sbt
@@ -3,6 +3,7 @@
 # Debug option
 DEBUG_PARAMS=""
 TC_PARAMS=""
+COLOUR_PARAMS=""
 
 CONF_PARAMS="-Dconfig.file=$HOME/.gu/security-hq.local.conf"
 for arg in "$@"
@@ -18,19 +19,27 @@ do
       shift
     fi
     if [ "$arg" == "--team-city" ]; then
-      f=$(grep '^teamcity.configuration.properties.file' "$TEAMCITY_BUILD_PROPERTIES_FILE" | cut -d'=' -f 2)
-      TC_PARAMS="-Dteamcity.configuration.properties.file=$f"
-      echo "Adding team city property: $TC_PARAMS"
+      echo "Ignoring '--team-city' in favour of checking for TEAMCITY_BUILD_PROPERTIES_FILE env var; please remove this switch"
       shift
     fi
 done
+
+if [ $TEAMCITY_BUILD_PROPERTIES_FILE ]; then
+  if [ -f $TEAMCITY_BUILD_PROPERTIES_FILE ]; then
+    f=$(grep '^teamcity.configuration.properties.file' "$TEAMCITY_BUILD_PROPERTIES_FILE" | cut -d'=' -f 2)
+    TC_PARAMS="-Dteamcity.configuration.properties.file=$f"
+    echo "Adding team city property: $TC_PARAMS"
+  else
+    echo "Unable to locate Team City build properties file $TEAMCITY_BUILD_PROPERTIES_FILE"
+  fi
+  COLOUR_PARAMS="-Dsbt.log.noformat=true"
+fi
 
 java $DEBUG_PARAMS \
     -Xms1024M -Xmx2048M \
     -Xss1M \
     -XX:+CMSClassUnloadingEnabled \
-    -XX:MaxPermSize=1024M \
     $CONF_PARAMS \
     $TC_PARAMS \
-    -Dsbt.log.noformat=true \
+    $COLOUR_PARAMS \
     -jar bin/sbt-launch.jar "$@"


### PR DESCRIPTION
## What does this change?

Correct path for sbt executable (local wrapper script for Security HQ)
Adds command alias required by Snyk for sbt 1.0+
Turns off colour on sbt.
Upversions vulnerable library.

## What is the value of this?

As is, Snyk fails to (1) find sbt; (2) invoke dependencyTree, (3) parse coloured output: this change corrects each of those so that Snyk tests can run.  

SHQ then did not pass the test; the upversioned library corrects this.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No