### PR TITLE
Deprecate Team City specific switch

### DIFF
--- a/sbt
+++ b/sbt
@@ -18,10 +18,6 @@ do
       CONF_PARAMS=""
       shift
     fi
-    if [ "$arg" == "--team-city" ]; then
-      echo "Ignoring '--team-city' in favour of checking for TEAMCITY_BUILD_PROPERTIES_FILE env var; please remove this switch"
-      shift
-    fi
 done
 
 if [ $TEAMCITY_BUILD_PROPERTIES_FILE ]; then


### PR DESCRIPTION
## What does this change?

Removes the TC switch now that builds succeed without it.

## What is the value of this?

Cleanliness.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No.