### PR TITLE
Display more helpful warnings, and confirm when there are no open security groups

### DIFF
--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -4,12 +4,12 @@ import auth.SecurityHQAuthActions
 import aws.AWS
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
+import logic.ReportDisplay.{exposedKeysSummary, sortAccountsByReportSummary}
 import play.api._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.CacheService
 import utils.attempt.PlayIntegration.attempt
-import logic.ReportDisplay.sortAccountsByReportSummary
 
 import scala.concurrent.ExecutionContext
 
@@ -24,9 +24,11 @@ class HQController (val config: Configuration, cacheService: CacheService, val a
   }
 
   def iam = authAction {
+    val exposedKeys = cacheService.getAllExposedKeys()
+    val keysSummary = exposedKeysSummary(exposedKeys)
     val accountsAndReports = cacheService.getAllCredentials()
     val sortedAccountsAndReports = sortAccountsByReportSummary(accountsAndReports.toList)
-    Ok(views.html.iam.iam(sortedAccountsAndReports))
+    Ok(views.html.iam.iam(sortedAccountsAndReports, keysSummary))
   }
 
   def iamAccount(accountId: String) = authAction.async {

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -32,7 +32,7 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)
-        flaggedSgs <- Attempt.fromEither(cacheService.getSgsForAccount(account))
+        flaggedSgs = cacheService.getSgsForAccount(account)
       } yield Ok(views.html.sgs.sgsAccount(account, flaggedSgs))
     }
   }

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -9,7 +9,6 @@ import play.api._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import services.CacheService
-import utils.attempt.Attempt
 import utils.attempt.PlayIntegration.attempt
 
 import scala.concurrent.ExecutionContext
@@ -24,7 +23,6 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
   def securityGroups = authAction {
     val allFlaggedSgs = cacheService.getAllSgs()
     val sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs.toList)
-
     Ok(views.html.sgs.sgs(sortedFlaggedSgs))
   }
 

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -93,14 +93,12 @@ object ReportDisplay {
   }
 
   def exposedKeysSummary(allReports: Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]): Map[AwsAccount, Boolean] = {
-    def checkForExposedKeys(temp: Either[FailedAttempt, List[ExposedIAMKeyDetail]]): Boolean = temp match {
-      case Right(keys) if keys.nonEmpty => true
-      case _ => false
-    }
-
     for {
-      report <- allReports
-    } yield (report._1, checkForExposedKeys(report._2))
+      (account, report) <- allReports
+    } yield (account, report match {
+        case Right(keys) if keys.nonEmpty => true
+        case _ => false
+    })
   }
 
   def sortAccountsByReportSummary[L](reports: List[(AwsAccount, Either[L, CredentialReportDisplay])]): List[(AwsAccount, Either[L, CredentialReportDisplay])] = {

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -3,6 +3,7 @@ package logic
 import model._
 import DateUtils.dayDiff
 import org.joda.time.{DateTime, DateTimeZone, Days}
+import utils.attempt.FailedAttempt
 
 
 object ReportDisplay {
@@ -89,6 +90,17 @@ object ReportDisplay {
       case ( (war, err, oth), _ ) => (war, err, oth)
     }
     ReportSummary(warnings, errors, other)
+  }
+
+  def exposedKeysSummary(allReports: Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]): Map[AwsAccount, Boolean] = {
+    def checkForExposedKeys(temp: Either[FailedAttempt, List[ExposedIAMKeyDetail]]): Boolean = temp match {
+      case Right(keys) if keys.nonEmpty => true
+      case _ => false
+    }
+
+    for {
+      report <- allReports
+    } yield (report._1, checkForExposedKeys(report._2))
   }
 
   def sortAccountsByReportSummary[L](reports: List[(AwsAccount, Either[L, CredentialReportDisplay])]): List[(AwsAccount, Either[L, CredentialReportDisplay])] = {

--- a/hq/app/views/fragments/mfa.scala.html
+++ b/hq/app/views/fragments/mfa.scala.html
@@ -1,6 +1,0 @@
-@(hasMFA: Boolean)
-
-<i class="material-icons left tooltipped" data-tooltip="Password enabled">lock_outline</i>
-@if(hasMFA) {
-    <i class="material-icons left tooltipped" data-position="bottom" data-delay="50" data-tooltip="MFA enabled">important_devices</i>
-}

--- a/hq/app/views/fragments/warningMessage.scala.html
+++ b/hq/app/views/fragments/warningMessage.scala.html
@@ -1,0 +1,12 @@
+@import utils.attempt.FailedAttempt
+
+@(report: String, fa: FailedAttempt)
+
+<div class="row">
+    <div class="card-panel amber black-text">
+        @for(err <- fa.failures) {
+        <h5 class="uppercase">@report<i class="material-icons medium right">warning</i></h5>
+        <b>WARNING: </b>@err.friendlyMessage
+        }
+    </div>
+</div>

--- a/hq/app/views/iam/exposedKeys.scala.html
+++ b/hq/app/views/iam/exposedKeys.scala.html
@@ -4,7 +4,7 @@
 @if(exposedIamKeys.nonEmpty) {
     <div class="row">
         <h2>Exposed IAM Keys</h2>
-        <div class="card-panel red white-text">
+        <div class="card-panel red darken-1 white-text">
 
             <p class="warning">
                 <i class="material-icons right">warning</i>

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -1,6 +1,7 @@
 @import logic.ReportDisplay._
 @import model._
-@(reports: List[(AwsAccount, Either[utils.attempt.FailedAttempt, CredentialReportDisplay])])(implicit assets: AssetsFinder)
+@import utils.attempt.FailedAttempt
+@(reports: List[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])], exposedKeySummary: Map[AwsAccount, Boolean])(implicit assets: AssetsFinder)
 
 @floatingNav() = {
 <div class="fixed-action-btn js-floating-nav iam-floating-nav">
@@ -35,6 +36,28 @@
 
 } { @* Main content *@
     <div class="container">
+
+        <div class="row iam-key-alert__wrapper">
+            @for((account, hasExposedKeys) <- exposedKeySummary) {
+                @if(hasExposedKeys) {
+
+                    <div class="col s12 m6">
+                        <div class="card red darken-1 white-text">
+                            <div class="card-content white-text valign-wrapper">
+                                <i class="material-icons large-icon white-text left">warning</i>
+                                <p>@account.name has exposed keys!</p>
+                            </div>
+                            <div class="card-action">
+                                <a href="/iam/@account.id">@account.name credentials report
+                                    <i class="material-icons right">chevron_right</i>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                }
+            }
+        </div>
+
         <div class="row">
             <ul class="collapsible" data-collapsible="accordion">
             @for((account, report) <- reports) {

--- a/hq/app/views/iam/iamAccount.scala.html
+++ b/hq/app/views/iam/iamAccount.scala.html
@@ -3,20 +3,6 @@
 @(awsAccount: AwsAccount, exposedIamKeys: Either[FailedAttempt, List[ExposedIAMKeyDetail]], credentialsReport: Either[FailedAttempt, CredentialReportDisplay])(implicit assets: AssetsFinder)
 
 
-@errorMessage(fa: FailedAttempt) = {
-    <div class="row">
-        <div class="card-panel yellow black-text">
-            @for(err <- fa.failures) {
-            <p class="warning">
-                <i class="material-icons right">warning</i>
-                <b>WARNING:</b>
-                @err.friendlyMessage
-            </p>
-            }
-        </div>
-    </div>
-}
-
 @main(List(awsAccount.name, "IAM report")) { @* Header *@
 <div class="hq-sub-header">
     <div class="container hq-sub-header__row">
@@ -40,7 +26,7 @@
                 @views.html.iam.exposedKeys(exposedIamKeys)
             }
             case Left(fa) => {
-                @errorMessage(fa)
+                @views.html.fragments.warningMessage("exposed IAM keys", fa)
             }
         }
 
@@ -55,7 +41,7 @@
                 @views.html.fragments.credentialsHelp()
             }
             case Left(fa) => {
-                @errorMessage(fa)
+                @views.html.fragments.warningMessage("credential report", fa)
             }
         }
     </div>

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -33,8 +33,15 @@
                             <i class="material-icons link_new_tab">open_in_new</i>
                         </a>
                     </td>
-                    <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)</td>
-                    <td>@views.html.fragments.mfa(cred.hasMFA)</td>
+                    <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)
+
+                    </td>
+                    <td>
+                        <i class="material-icons left tooltipped" data-tooltip="Password enabled">lock_outline</i>
+                        @if(cred.hasMFA) {
+                        <i class="material-icons left tooltipped" data-position="bottom" data-delay="50" data-tooltip="MFA enabled">important_devices</i>
+                        }
+                    </td>
                     <td>
                         <span>@ReportDisplay.toDayString(cred.lastActivityDay)</span>
                     </td>

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -23,7 +23,6 @@
 } { @* Main content *@
     <div class="container">
 
-
         @flaggedSgsResult match {
             case Right(flaggedSgs) => {
                 <div class="row">

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -48,16 +48,22 @@
                     </div>
                 </div>
                 }
+
                 <div class="row">
-                    @views.html.fragments.openSecurityGroups(flaggedSgs, shadow=true)
+                    @if(flaggedSgs.nonEmpty) {
+                        @views.html.fragments.openSecurityGroups(flaggedSgs, shadow=true)
+                    } else {
+                    <div class="card-panel valign-wrapper">
+                        <i class="material-icons medium green-text left">verified_user</i>
+                        <h5>No open Security Groups found</h5>
+                    </div>
+                    }
                 </div>
             }
             case Left(fa) => {
                 @views.html.fragments.warningMessage("security groups", fa)
             }
         }
-
-
 
     </div>
 }

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -1,7 +1,9 @@
 @import model.{AwsAccount, SGInUse, SGOpenPortsDetail}
 @import logic.SecurityGroupDisplay.hasSuppressedReports
+@import utils.attempt.FailedAttempt
 
-@(awsAccount: AwsAccount, flaggedSgs: List[(SGOpenPortsDetail, Set[SGInUse])])(implicit assets: AssetsFinder)
+@(awsAccount: AwsAccount, flaggedSgsResult: Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]])(implicit assets: AssetsFinder)
+
 
 @main(List(awsAccount.name)) { @* Header *@
 <div class="hq-sub-header">
@@ -20,32 +22,42 @@
 
 } { @* Main content *@
     <div class="container">
-        <div class="row">
-            <h2>Open Security Groups</h2>
-            <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>
-        </div>
 
-        @views.html.fragments.securityGroupHelp()
 
-        @if(hasSuppressedReports(flaggedSgs)) {
-            <div class="row">
-                <div class="card-panel valign-wrapper">
-                    <i class="material-icons left">visibility_off</i>
-                    <span class="sg-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
-
-                    <form class="sg-filter" action="#">
-                        <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
-                        <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
-                        <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />
-                        <label class="black-text sg-filter__label" for="show-ignored-sgs">Show ignored</label>
-                    </form>
+        @flaggedSgsResult match {
+            case Right(flaggedSgs) => {
+                <div class="row">
+                    <h2>Open Security Groups</h2>
+                    <p>The following Security Groups have ports open to the world, i.e. a CIDR set to <code>0.0.0.0/0</code>.</p>
                 </div>
-            </div>
+
+                @views.html.fragments.securityGroupHelp()
+
+                @if(hasSuppressedReports(flaggedSgs)) {
+                <div class="row">
+                    <div class="card-panel valign-wrapper">
+                        <i class="material-icons left">visibility_off</i>
+                        <span class="sg-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
+
+                        <form class="sg-filter" action="#">
+                            <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
+                            <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
+                            <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />
+                            <label class="black-text sg-filter__label" for="show-ignored-sgs">Show ignored</label>
+                        </form>
+                    </div>
+                </div>
+                }
+                <div class="row">
+                    @views.html.fragments.openSecurityGroups(flaggedSgs, shadow=true)
+                </div>
+            }
+            case Left(fa) => {
+                @views.html.fragments.warningMessage("security groups", fa)
+            }
         }
 
-        <div class="row">
-            @views.html.fragments.openSecurityGroups(flaggedSgs, shadow=true)
-        </div>
+
 
     </div>
 }

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -38,6 +38,10 @@ nav {
   justify-content: space-between;
 }
 
+.uppercase {
+  text-transform: uppercase;
+}
+
 .icon-count {
   margin-right: 5px;
   text-align: end;


### PR DESCRIPTION
## What does this change?

#### 👉 Show confirmation card when there are no open security groups

This is nicer and more unambiguous than the previously empty container. Teams should be pleased with their big green check! 👍 👍 

<img width="400" alt="picture 212" src="https://user-images.githubusercontent.com/8607683/35992351-f38a139e-0d01-11e8-9437-08e9dd85f7b0.png">

#### 👉 More details on the warnings for account pages 

This significantly changes the page for an accounts security groups. Previously if the data was not available in the cache, the user would hit the standard error page. However, passing the error to the view allows some bonus styling, and keeps the user on their account hub, so they can still use the tabs on the sub nav.

<img width="1676" alt="picture 214" src="https://user-images.githubusercontent.com/8607683/35992543-6e5b2f18-0d02-11e8-924d-fed9cdcd7d5b.png">

#### 👉 Add warnings about exposed keys to the all accounts page

We currently only show exposed keys on the individual account pages, which makes the warnings less likely to be encountered if someone is using the all accounts page. This PR adds a check for any accounts with exposed keys, and will add a red alert to the top of the page for each account. The alert links to the IAM account page which will have the complete details on any and all exposed keys.

<img width="1237" alt="picture 208" src="https://user-images.githubusercontent.com/8607683/35992704-f5e3afb4-0d02-11e8-983f-1c71fb036159.png">


## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

For highlighting exposed keys on the all accounts page, arguably we should map an account to `true` if the exposedKeys cache data is missing. However, the basic alerting introduced is still better than no alerting; happy to iterate!

There are some bonus stylistic improvements and opinionated template restructuring.
