### PR TITLE
Add indication of related CloudFormation stack to IAM users

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val hq = (project in file("hq")).
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-support" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",

--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -40,6 +40,7 @@ Resources:
             # IAM credentials overview
             - iam:GenerateCredentialReport
             - iam:GetCredentialReport
+            - cloudformation:DescribeStacks
 
 Outputs:
   SecurityHQRole:

--- a/hq/app/aws/iam/CloudFormation.scala
+++ b/hq/app/aws/iam/CloudFormation.scala
@@ -1,0 +1,34 @@
+package aws.iam
+
+import aws.AWS
+import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClient}
+import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack}
+import model.AwsAccount
+import utils.attempt.Attempt
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+object CloudFormation {
+  private[iam] def client(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
+    val auth = AWS.credentialsProvider(account)
+    AmazonCloudFormationAsyncClient.asyncBuilder()
+      .withCredentials(auth)
+      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
+  }
+
+  private[iam] def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {
+    val request = new DescribeStacksRequest()
+    handleAWSErrs(awsToScala(client.describeStacksAsync)(request))
+  }
+
+  private[iam] def getUserStacks(stacks: DescribeStacksResult): List[Stack] = {
+    for {
+      stack <- stacks.getStacks.asScala.toList
+      output <- stack.getOutputs.asScala.toList
+      if output.getOutputValue.contains(":user")
+    } yield stack
+  }
+}

--- a/hq/app/aws/iam/CredentialsReport.scala
+++ b/hq/app/aws/iam/CredentialsReport.scala
@@ -67,6 +67,8 @@ object CredentialsReport {
           user = row.getOrElse("user", "no username available"),
           arn = row.getOrElse("arn", "no ARN available"),
           creationTime = row.get("user_creation_time").flatMap(parseDateTimeOpt).get,
+          stackId = None,
+          stackName = None,
           passwordEnabled = row.get("password_enabled").flatMap(parseBoolean),
           passwordLastUsed = row.get("password_last_used").flatMap(parseDateTimeOpt),
           passwordLastChanged = row.get("password_last_changed").flatMap(parseDateTimeOpt),

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -3,20 +3,29 @@ package aws.iam
 import aws.AWS
 import aws.AwsAsyncHandler._
 import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult}
+import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClient}
 import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest}
 import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
 import logic.{ReportDisplay, Retry}
 import model.{AwsAccount, CredentialReportDisplay, IAMCredentialsReport}
 import utils.attempt.{Attempt, FailedAttempt}
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 
 object IAMClient {
   private def client(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonIdentityManagementAsync = {
     val auth = AWS.credentialsProvider(account)
     AmazonIdentityManagementAsyncClientBuilder.standard()
+      .withCredentials(auth)
+      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
+  }
+
+  private def cloudFormationClient(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
+    val auth = AWS.credentialsProvider(account)
+    AmazonCloudFormationAsyncClient.asyncBuilder()
       .withCredentials(auth)
       .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
   }
@@ -31,13 +40,20 @@ object IAMClient {
     handleAWSErrs(awsToScala(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
   }
 
+  private def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {
+    val request = new DescribeStacksRequest()
+    handleAWSErrs(awsToScala(client.describeStacksAsync)(request))
+  }
+
   def getCredentialsReport(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
     val delay = 3.seconds
     val client = IAMClient.client(account)
+    val cloudClient = IAMClient.cloudFormationClient(account)
     for {
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
-    } yield ReportDisplay.toCredentialReportDisplay(report)
+      stacks <- getStackDescriptions(cloudClient)
+    } yield ReportDisplay.toCredentialReportDisplay(report, stacks)
   }
 
   def getAllCredentialReports(accounts: Seq[AwsAccount])(implicit executionContext: ExecutionContext): Attempt[Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]] = {

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -50,6 +50,15 @@ object ReportDisplay {
     else Green
   }
 
+  def linkForAwsConsole(stackId: String): String = {
+    val regionOpt = stackId.stripPrefix("arn:aws:cloudformation:").split(":").headOption
+
+    regionOpt match {
+      case Some(region) => s"https://console.aws.amazon.com/cloudformation/home?$region#/stack/detail?"
+      case _ => ""
+    }
+  }
+
   def toCredentialReportDisplay(report: IAMCredentialsReport): CredentialReportDisplay = {
 
     report.entries.filterNot(_.rootUser).foldLeft(CredentialReportDisplay(report.generatedAt)) { (report, cred) =>

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -18,6 +18,8 @@ case class IAMCredential(
   user: String,
   arn: String,
   creationTime: DateTime,
+  stackId : Option[String] = None,
+  stackName : Option[String] = None,
   passwordEnabled: Option[Boolean],
   passwordLastUsed: Option[DateTime],
   passwordLastChanged: Option[DateTime],
@@ -104,7 +106,7 @@ case object DEV extends Stage
 case object PROD extends Stage
 
 case class CredentialReportDisplay(
-  reportDate : DateTime,
+  reportDate: DateTime,
   machineUsers: Seq[MachineUser] = Seq.empty,
   humanUsers: Seq[HumanUser] = Seq.empty
 )
@@ -127,14 +129,18 @@ case class HumanUser(
   key1Status: KeyStatus,
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
-  lastActivityDay : Option[Long]
+  lastActivityDay : Option[Long],
+  stackId : Option[String] = None,
+  stackName : Option[String] = None,
 )
 case class MachineUser(
   username: String,
   key1Status: KeyStatus,
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
-  lastActivityDay: Option[Long]
+  lastActivityDay: Option[Long],
+  stackId : Option[String] = None,
+  stackName : Option[String] = None,
 )
 
 case class SnykToken(value: String) extends AnyVal

--- a/hq/app/views/fragments/allKeyStatus.scala.html
+++ b/hq/app/views/fragments/allKeyStatus.scala.html
@@ -7,7 +7,7 @@
 
 @keyStatus(keyStatus: KeyStatus) = {
     @if(keyStatus == AccessKeyDisabled) {
-        <span><i class="material-icons left tooltipped iam-key--disabled"  data-position="bottom" data-delay="50" data-tooltip="Disabled Access Key">vpn_key</i></span>
+        <span><i class="material-icons left tooltipped iam-icon--disabled"  data-position="bottom" data-delay="50" data-tooltip="Disabled Access Key">vpn_key</i></span>
     }
     @if(keyStatus == AccessKeyEnabled) {
         <span><i class="material-icons left tooltipped" data-position="bottom" data-delay="50" data-tooltip="Has active Access Key">vpn_key</i></span>

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -25,7 +25,7 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
                         @if(cred.stackId && cred.stackName) {
-                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
                         } else {
                             <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }
@@ -61,9 +61,9 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
                         @if(cred.stackId && cred.stackName) {
-                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
                         } else {
-                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }
                     </td>
                     <td>

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -22,7 +22,14 @@
 
             @for(cred <- report.humanUsers) {
                 <tr>
-                    <td><i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i></td>
+                    <td>
+                        <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
+                        @if(cred.stackId && cred.stackName) {
+                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                        } else {
+                            <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        }
+                    </td>
                     <td>
                         <a target="_blank" rel="noopener noreferrer" href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">
                             @if(cred.username.length > 30) {
@@ -51,7 +58,14 @@
 
             @for(cred <- report.machineUsers) {
                 <tr>
-                    <td><i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i></td>
+                    <td>
+                        <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
+                        @if(cred.stackId && cred.stackName) {
+                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                        } else {
+                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        }
+                    </td>
                     <td>
                         <a target="_blank" rel="noopener noreferrer" href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">
                             @if(cred.username.length > 30) {

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -25,7 +25,9 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
                         @if(cred.stackId && cred.stackName) {
-                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            </a>
                         } else {
                             <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }
@@ -61,7 +63,9 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
                         @if(cred.stackId && cred.stackName) {
-                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            </a>
                         } else {
                         <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -25,11 +25,11 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
                         @if(cred.stackId && cred.stackName) {
-                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
-                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
-                            </a>
+                        <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                            <i class="material-icons left tooltipped" data-tooltip="@cred.stackName.get stack" data-position="bottom" data-delay="50">cloud_done</i>
+                        </a>
                         } else {
-                            <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
                         }
                     </td>
                     <td>
@@ -63,11 +63,11 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
                         @if(cred.stackId && cred.stackName) {
-                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
-                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
-                            </a>
+                        <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                            <i class="material-icons left tooltipped" data-tooltip="@cred.stackName.get stack" data-position="bottom" data-delay="50">cloud_done</i>
+                        </a>
                         } else {
-                        <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
                         }
                     </td>
                     <td>

--- a/hq/test/aws/iam/CredentialsReportTest.scala
+++ b/hq/test/aws/iam/CredentialsReportTest.scala
@@ -91,7 +91,6 @@ class CredentialsReportTest extends FreeSpec with Matchers with OptionValues wit
         )
       }
 
-
       "fails when parsing empty CSV" in {
         val testReport = ""
         CredentialsReport.tryParsingReport(testReport).isFailedAttempt() shouldBe true
@@ -108,9 +107,7 @@ class CredentialsReportTest extends FreeSpec with Matchers with OptionValues wit
         userWithCreds should have (
           'passwordLastUsed (None)
         )
-
       }
-
     }
   }
 }

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -16,6 +16,8 @@ class ReportDisplayTest extends FreeSpec with Matchers {
       "user-1",
       now,
       None,
+      None,
+      None,
       Some(now.minusDays(1)),
       Some(now.minusDays(2)),
       Some(now.minusDays(3)),

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -233,6 +233,13 @@ class ReportDisplayTest extends FreeSpec with Matchers {
     }
   }
 
+  "linkForAwsConsole" - {
+    "returns the correct string from a stackId" in {
+      val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
+      linkForAwsConsole(stackId) shouldEqual "https://console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?"
+    }
+  }
+
   "reportStatusSummary" - {
     val now = DateTime.now()
 


### PR DESCRIPTION
## What does this change?

Adds a cloud icon next to the user type to indicate if the user is associated with a CloudFormation stack. IAM user arns that do not match any stack output will have a cloud with a line through:

<img width="1160" alt="picture 216" src="https://user-images.githubusercontent.com/8607683/36166646-12b8c174-10eb-11e8-8cd3-e1fb01c2deb9.png">


For IAM users that do have an associated CloudFormation stack, the stack name will appear on hover (as a tooltip) and the icon will be a link to the stack in the AWS console:

<img width="1199" alt="picture 217" src="https://user-images.githubusercontent.com/8607683/36166748-668b7738-10eb-11e8-9d26-7f4956444e0a.png">


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Simple identification of IAM users that have custom permissions/have not been Cloudformed

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes - StackSet update TODO!

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

Currently, this is only checking in the default region for Stacks. The next step is to check across regions...
