### PR TITLE
Update the cloudformation template of watched-accounts with new permissions

### DIFF
--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -35,11 +35,13 @@ Resources:
             - trustedadvisor:Refresh*
             - support:*
             - ec2:DescribeNetworkInterfaces
+            - ec2:DescribeRegions
             - ec2:DescribeSecurityGroups
             - ec2:DescribeVpcs
             # IAM credentials overview
             - iam:GenerateCredentialReport
             - iam:GetCredentialReport
+            - cloudformation:DescribeStacks
 
 Outputs:
   SecurityHQRole:


### PR DESCRIPTION
## What does this change?

#### 👉 describeRegions

###### CLI example: `aws ec2 describe-regions --profile example --region eu-west-2`

Allows Security HQ to `describe-regions` that a watched account has available, which is useful if you need to iterate over regions at some point to discover what stacks are in each one **

** The enum of Regions available from the AWS SDK is not hugely helpful for this, since it contains ALL regions, including ones that an account may not be able to access. This is annoying if you are trying to `describe-stacks` without dealing with constant API errors 😣

#### 👉 describeStacks

###### CLI example: `aws cloudformation describe-stacks --profile example --region us-east-1`

Security HQ will be able to learn of all the stacks in a watched account, which is very useful if you want to cross-reference with IAM users to see which originate from CloudFormation

## Will this require CloudFormation and/or updates to the AWS StackSet?

Putting changes into VC before  CloudFormation and updates to the AWS StackSet 😉 

## Any additional notes?

#### TODO:
- [ ] CloudFormation of watched accounts complete


