### PR TITLE
Add indication of related CloudFormation stack to IAM users

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val hq = (project in file("hq")).
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-support" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",

--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -42,6 +42,7 @@ Resources:
             - iam:GenerateCredentialReport
             - iam:GetCredentialReport
             - cloudformation:DescribeStacks
+            - cloudformation:DescribeStackResources
 
 Outputs:
   SecurityHQRole:

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -28,9 +28,16 @@ object EC2 {
       .build()
   }
 
-  def client(awsAccount: AwsAccount, region: Regions): AmazonEC2Async = {
+  def client(awsAccount: AwsAccount, region: Regions = Regions.EU_WEST_1): AmazonEC2Async = {
     val auth = AWS.credentialsProvider(awsAccount)
     client(auth, region)
+  }
+
+  def getAvailableRegions(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Region]] = {
+    val request = new DescribeRegionsRequest()
+    handleAWSErrs(awsToScala(client.describeRegionsAsync)(request)).map { result =>
+      result.getRegions.asScala.toList
+    }
   }
 
   /**

--- a/hq/app/aws/iam/CloudFormation.scala
+++ b/hq/app/aws/iam/CloudFormation.scala
@@ -14,15 +14,15 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 object CloudFormation {
-  private def cloudClient(auth: AWSCredentialsProviderChain, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
+  private def client(auth: AWSCredentialsProviderChain, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
     AmazonCloudFormationAsyncClientBuilder.standard()
       .withCredentials(auth)
       .withRegion(region.getName)
       .build()
   }
-  private[iam] def client(awsAccount: AwsAccount, region: Region): AmazonCloudFormationAsync = {
+  private def client(awsAccount: AwsAccount, region: Region): AmazonCloudFormationAsync = {
     val auth = AWS.credentialsProvider(awsAccount)
-    cloudClient(auth, region)
+    client(auth, region)
   }
 
   private[iam] def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {

--- a/hq/app/aws/iam/CloudFormation.scala
+++ b/hq/app/aws/iam/CloudFormation.scala
@@ -2,13 +2,12 @@ package aws.iam
 
 import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import aws.ec2.EC2
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult}
 import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder}
-import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack}
-import com.amazonaws.services.ec2.model.{DescribeRegionsRequest, DescribeRegionsResult}
-import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
-import model.AwsAccount
+import model.{AwsAccount, Stack}
 import utils.attempt.Attempt
 
 import scala.collection.JavaConverters._
@@ -26,40 +25,26 @@ object CloudFormation {
     cloudClient(auth, region)
   }
 
-  def describeRegionsClient(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonEC2Async = {
-    val auth = AWS.credentialsProvider(account)
-    AmazonEC2AsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName)
-      .build()
-  }
-
-  def describeRegions(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[DescribeRegionsResult] = {
-    val request = new DescribeRegionsRequest()
-    handleAWSErrs(awsToScala(client.describeRegionsAsync)(request))
-  }
-
   private[iam] def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {
     val request = new DescribeStacksRequest()
     handleAWSErrs(awsToScala(client.describeStacksAsync)(request))
   }
 
   private[iam] def getStacksFromAllRegions(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[DescribeStacksResult]] = {
-    val regionClient = describeRegionsClient(account)
+    val regionClient = EC2.client(account)
     for {
-      describeRegionsResult <- describeRegions(regionClient)
-      regions = describeRegionsResult.getRegions.asScala.toList
+      regions <- EC2.getAvailableRegions(regionClient)
       clients = regions.map(region => CloudFormation.client(account, Region.getRegion(Regions.fromName(region.getRegionName))))
       describeStacksResult <- Attempt.traverse(clients)(getStackDescriptions)
     } yield describeStacksResult
   }
 
-  private[iam] def getUserStacks(stacksResults: List[DescribeStacksResult]): List[Stack] = {
+  private[iam] def extractUserStacks(stacksResults: List[DescribeStacksResult]): List[Stack] = {
     for {
       result <- stacksResults
       stack <- result.getStacks.asScala.toList
       output <- stack.getOutputs.asScala.toList
       if output.getOutputValue.contains(":user")
-    } yield stack
+    } yield Stack(stack.getStackId, stack.getStackName, output.getOutputValue)
   }
 }

--- a/hq/app/aws/iam/CloudFormation.scala
+++ b/hq/app/aws/iam/CloudFormation.scala
@@ -5,9 +5,9 @@ import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import aws.ec2.EC2
 import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult}
+import com.amazonaws.services.cloudformation.model.{DescribeStackResourcesRequest, DescribeStackResourcesResult, DescribeStacksRequest, DescribeStacksResult}
 import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder}
-import model.{AwsAccount, Stack}
+import model.{AwsAccount, Stack, StackResource}
 import utils.attempt.Attempt
 
 import scala.collection.JavaConverters._
@@ -25,26 +25,48 @@ object CloudFormation {
     client(auth, region)
   }
 
-  private[iam] def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {
+  private def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
     val request = new DescribeStacksRequest()
-    handleAWSErrs(awsToScala(client.describeStacksAsync)(request))
+    handleAWSErrs(awsToScala(client.describeStacksAsync)(request)).map(parseStacksResult)
   }
 
-  private[iam] def getStacksFromAllRegions(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[DescribeStacksResult]] = {
+  private def getStackResources(stackName: String)(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[List[StackResource]] = {
+    val request = new DescribeStackResourcesRequest().withStackName(stackName)
+    handleAWSErrs(awsToScala(client.describeStackResourcesAsync)(request)).map(parseResourcesResult)
+  }
+
+  private[iam] def getStacksFromAllRegions(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
     val regionClient = EC2.client(account)
     for {
-      regions <- EC2.getAvailableRegions(regionClient)
-      clients = regions.map(region => CloudFormation.client(account, Region.getRegion(Regions.fromName(region.getRegionName))))
-      describeStacksResult <- Attempt.traverse(clients)(getStackDescriptions)
-    } yield describeStacksResult
+      availableRegions <- EC2.getAvailableRegions(regionClient)
+      regions = availableRegions.map(region => Region.getRegion(Regions.fromName(region.getRegionName)))
+      clients = regions.map(region => CloudFormation.client(account, region))
+      results <- Attempt.flatTraverse(clients)(getStackDescriptions)
+    } yield results
   }
 
-  private[iam] def extractUserStacks(stacksResults: List[DescribeStacksResult]): List[Stack] = {
+  private def parseResourcesResult(result: DescribeStackResourcesResult): List[StackResource] = {
     for {
-      result <- stacksResults
+      resource <- result.getStackResources.asScala.toList
+    } yield StackResource(
+      resource.getStackId,
+      resource.getStackName,
+      resource.getPhysicalResourceId,
+      resource.getLogicalResourceId,
+      resource.getResourceStatus,
+      resource.getResourceType
+    )
+  }
+
+  private[iam] def parseStacksResult(result: DescribeStacksResult): List[Stack] = {
+    for {
       stack <- result.getStacks.asScala.toList
       output <- stack.getOutputs.asScala.toList
-      if output.getOutputValue.contains(":user")
-    } yield Stack(stack.getStackId, stack.getStackName, output.getOutputValue)
+    } yield Stack(
+      stack.getStackId,
+      stack.getStackName,
+      output.getOutputValue,
+      None
+    )
   }
 }

--- a/hq/app/aws/iam/CloudFormation.scala
+++ b/hq/app/aws/iam/CloudFormation.scala
@@ -1,0 +1,34 @@
+package aws.iam
+
+import aws.AWS
+import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClient}
+import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack}
+import model.AwsAccount
+import utils.attempt.Attempt
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+object CloudFormation {
+  private[iam] def client(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
+    val auth = AWS.credentialsProvider(account)
+    AmazonCloudFormationAsyncClient.asyncBuilder()
+      .withCredentials(auth)
+      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
+  }
+
+  private[iam] def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {
+    val request = new DescribeStacksRequest()
+    handleAWSErrs(awsToScala(client.describeStacksAsync)(request))
+  }
+
+  private[iam] def getUserStacks(stacks: DescribeStacksResult): List[Stack] = {
+    for {
+      stack <- stacks.getStacks.asScala.toList
+      output <- stack.getOutputs.asScala.toList
+      if output.getOutputValue.contains(":user")
+    } yield stack
+  }
+}

--- a/hq/app/aws/iam/CloudFormation.scala
+++ b/hq/app/aws/iam/CloudFormation.scala
@@ -2,9 +2,12 @@ package aws.iam
 
 import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClient}
+import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder}
 import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult, Stack}
+import com.amazonaws.services.ec2.model.{DescribeRegionsRequest, DescribeRegionsResult}
+import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
 import model.AwsAccount
 import utils.attempt.Attempt
 
@@ -12,11 +15,28 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 object CloudFormation {
-  private[iam] def client(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
-    val auth = AWS.credentialsProvider(account)
-    AmazonCloudFormationAsyncClient.asyncBuilder()
+  private def cloudClient(auth: AWSCredentialsProviderChain, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
+    AmazonCloudFormationAsyncClientBuilder.standard()
       .withCredentials(auth)
-      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
+      .withRegion(region.getName)
+      .build()
+  }
+  private[iam] def client(awsAccount: AwsAccount, region: Region): AmazonCloudFormationAsync = {
+    val auth = AWS.credentialsProvider(awsAccount)
+    cloudClient(auth, region)
+  }
+
+  def describeRegionsClient(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonEC2Async = {
+    val auth = AWS.credentialsProvider(account)
+    AmazonEC2AsyncClientBuilder.standard()
+      .withCredentials(auth)
+      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName)
+      .build()
+  }
+
+  def describeRegions(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[DescribeRegionsResult] = {
+    val request = new DescribeRegionsRequest()
+    handleAWSErrs(awsToScala(client.describeRegionsAsync)(request))
   }
 
   private[iam] def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {
@@ -24,9 +44,20 @@ object CloudFormation {
     handleAWSErrs(awsToScala(client.describeStacksAsync)(request))
   }
 
-  private[iam] def getUserStacks(stacks: DescribeStacksResult): List[Stack] = {
+  private[iam] def getStacksFromAllRegions(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[DescribeStacksResult]] = {
+    val regionClient = describeRegionsClient(account)
     for {
-      stack <- stacks.getStacks.asScala.toList
+      describeRegionsResult <- describeRegions(regionClient)
+      regions = describeRegionsResult.getRegions.asScala.toList
+      clients = regions.map(region => CloudFormation.client(account, Region.getRegion(Regions.fromName(region.getRegionName))))
+      describeStacksResult <- Attempt.traverse(clients)(getStackDescriptions)
+    } yield describeStacksResult
+  }
+
+  private[iam] def getUserStacks(stacksResults: List[DescribeStacksResult]): List[Stack] = {
+    for {
+      result <- stacksResults
+      stack <- result.getStacks.asScala.toList
       output <- stack.getOutputs.asScala.toList
       if output.getOutputValue.contains(":user")
     } yield stack

--- a/hq/app/aws/iam/CredentialsReport.scala
+++ b/hq/app/aws/iam/CredentialsReport.scala
@@ -67,6 +67,8 @@ object CredentialsReport {
           user = row.getOrElse("user", "no username available"),
           arn = row.getOrElse("arn", "no ARN available"),
           creationTime = row.get("user_creation_time").flatMap(parseDateTimeOpt).get,
+          stackId = None,
+          stackName = None,
           passwordEnabled = row.get("password_enabled").flatMap(parseBoolean),
           passwordLastUsed = row.get("password_last_used").flatMap(parseDateTimeOpt),
           passwordLastChanged = row.get("password_last_changed").flatMap(parseDateTimeOpt),

--- a/hq/app/aws/iam/CredentialsReport.scala
+++ b/hq/app/aws/iam/CredentialsReport.scala
@@ -19,12 +19,13 @@ object CredentialsReport {
   def isComplete(report: GenerateCredentialReportResult): Boolean = report.getState == "COMPLETE"
 
   private[iam] def enrichReportWithStackDetails(report: IAMCredentialsReport, stacks: List[Stack]): IAMCredentialsReport = {
-    report.copy(entries = report.entries.map { cred =>
+    val updatedEntries = report.entries.map { cred =>
       val enrichedCred = for {
         sourceStack <- stacks.find(_.output.contains(cred.arn))
       } yield cred.copy(stackId = Some(sourceStack.id), stackName = Some(sourceStack.name))
       enrichedCred.getOrElse(cred)
-    })
+    }
+    report.copy(entries = updatedEntries)
   }
 
   private[iam] def tryParsingReport(content: String) = {

--- a/hq/app/aws/iam/CredentialsReport.scala
+++ b/hq/app/aws/iam/CredentialsReport.scala
@@ -21,8 +21,8 @@ object CredentialsReport {
   private[iam] def enrichReportWithStackDetails(report: IAMCredentialsReport, stacks: List[Stack]): IAMCredentialsReport = {
     val updatedEntries = report.entries.map { cred =>
       val enrichedCred = for {
-        sourceStack <- stacks.find(_.output.contains(cred.arn))
-      } yield cred.copy(stackId = Some(sourceStack.id), stackName = Some(sourceStack.name))
+        stack <- stacks.find(stack => stack.resources.exists(_.PhysicalResourceId.contains(cred.user)))
+      } yield cred.copy(stack = Some(stack))
       enrichedCred.getOrElse(cred)
     }
     report.copy(entries = updatedEntries)
@@ -77,8 +77,7 @@ object CredentialsReport {
           user = row.getOrElse("user", "no username available"),
           arn = row.getOrElse("arn", "no ARN available"),
           creationTime = row.get("user_creation_time").flatMap(parseDateTimeOpt).get,
-          stackId = None,
-          stackName = None,
+          stack = None,
           passwordEnabled = row.get("password_enabled").flatMap(parseBoolean),
           passwordLastUsed = row.get("password_last_used").flatMap(parseDateTimeOpt),
           passwordLastChanged = row.get("password_last_changed").flatMap(parseDateTimeOpt),

--- a/hq/app/aws/iam/CredentialsReport.scala
+++ b/hq/app/aws/iam/CredentialsReport.scala
@@ -2,29 +2,27 @@ package aws.iam
 
 import java.io.StringReader
 
-import model.{IAMCredential, IAMCredentialsReport}
+import model.{IAMCredential, IAMCredentialsReport, Stack}
 import com.github.tototoshi.csv._
 import org.joda.time.DateTime
 import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.cloudformation.model.Stack
 import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportResult, GetCredentialReportResult}
 import logic.DateUtils
 import utils.attempt.Attempt
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
-import scala.collection.JavaConverters._
 
 
 object CredentialsReport {
 
   def isComplete(report: GenerateCredentialReportResult): Boolean = report.getState == "COMPLETE"
 
-  private[iam] def enrichReportDetails(report: IAMCredentialsReport, stacks: List[Stack]): IAMCredentialsReport = {
+  private[iam] def enrichReportWithStackDetails(report: IAMCredentialsReport, stacks: List[Stack]): IAMCredentialsReport = {
     report.copy(entries = report.entries.map { cred =>
       val enrichedCred = for {
-        output <- stacks.find(_.getOutputs.asScala.toList.exists(_.getOutputValue.contains(cred.arn)))
-      } yield cred.copy(stackId = Some(output.getStackId), stackName = Some(output.getStackName))
+        sourceStack <- stacks.find(_.output.contains(cred.arn))
+      } yield cred.copy(stackId = Some(sourceStack.id), stackName = Some(sourceStack.name))
       enrichedCred.getOrElse(cred)
     })
   }

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -3,20 +3,29 @@ package aws.iam
 import aws.AWS
 import aws.AwsAsyncHandler._
 import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.cloudformation.model.{DescribeStacksRequest, DescribeStacksResult}
+import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClient}
 import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest}
 import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
 import logic.{ReportDisplay, Retry}
 import model.{AwsAccount, CredentialReportDisplay, IAMCredentialsReport}
 import utils.attempt.{Attempt, FailedAttempt}
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
 
 
 object IAMClient {
   private def client(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonIdentityManagementAsync = {
     val auth = AWS.credentialsProvider(account)
     AmazonIdentityManagementAsyncClientBuilder.standard()
+      .withCredentials(auth)
+      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
+  }
+
+  private def cloudFormationClient(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonCloudFormationAsync = {
+    val auth = AWS.credentialsProvider(account)
+    AmazonCloudFormationAsyncClient.asyncBuilder()
       .withCredentials(auth)
       .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
   }
@@ -31,13 +40,20 @@ object IAMClient {
     handleAWSErrs(awsToScala(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
   }
 
+  private def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[DescribeStacksResult] = {
+    val request = new DescribeStacksRequest()
+    handleAWSErrs(awsToScala(client.describeStacksAsync)(request))
+  }
+
   def getCredentialsReport(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
     val delay = 3.seconds
     val client = IAMClient.client(account)
+    val cloudClient = IAMClient.cloudFormationClient(account)
     for {
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
-    } yield ReportDisplay.toCredentialReportDisplay(report)
+      stacks <- getStackDescriptions(cloudClient)
+    } yield ReportDisplay.toCredentialReportDisplay(report, stacks)
   }
 
   def getAllCredentialReports(accounts: Seq[AwsAccount])(implicit executionContext: ExecutionContext): Attempt[Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]] = {

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -34,11 +34,10 @@ object IAMClient {
   def getCredentialsReport(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
     val delay = 3.seconds
     val client = IAMClient.client(account)
-    val cloudClient = CloudFormation.client(account)
     for {
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
-      stacks <- CloudFormation.getStackDescriptions(cloudClient)
+      stacks <- CloudFormation.getStacksFromAllRegions(account)
       userStacks = CloudFormation.getUserStacks(stacks)
       enrichedReport = CredentialsReport.enrichReportDetails(report, userStacks)
     } yield ReportDisplay.toCredentialReportDisplay(enrichedReport)
@@ -51,6 +50,4 @@ object IAMClient {
       }
     }
   }
-
-
 }

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -18,7 +18,8 @@ object IAMClient {
     val auth = AWS.credentialsProvider(account)
     AmazonIdentityManagementAsyncClientBuilder.standard()
       .withCredentials(auth)
-      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName).build()
+      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName)
+      .build()
   }
 
   private def generateCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[GenerateCredentialReportResult] = {
@@ -38,8 +39,8 @@ object IAMClient {
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
       stacks <- CloudFormation.getStacksFromAllRegions(account)
-      userStacks = CloudFormation.getUserStacks(stacks)
-      enrichedReport = CredentialsReport.enrichReportDetails(report, userStacks)
+      userStacks = CloudFormation.extractUserStacks(stacks)
+      enrichedReport = CredentialsReport.enrichReportWithStackDetails(report, userStacks)
     } yield ReportDisplay.toCredentialReportDisplay(enrichedReport)
   }
 

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -39,8 +39,7 @@ object IAMClient {
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
       stacks <- CloudFormation.getStacksFromAllRegions(account)
-      userStacks = CloudFormation.extractUserStacks(stacks)
-      enrichedReport = CredentialsReport.enrichReportWithStackDetails(report, userStacks)
+      enrichedReport = CredentialsReport.enrichReportWithStackDetails(report, stacks)
     } yield ReportDisplay.toCredentialReportDisplay(enrichedReport)
   }
 

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -50,6 +50,15 @@ object ReportDisplay {
     else Green
   }
 
+  def linkForAwsConsole(stackId: String): String = {
+    val regionOpt = stackId.stripPrefix("arn:aws:cloudformation:").split(":").headOption
+
+    regionOpt match {
+      case Some(region) => s"https://console.aws.amazon.com/cloudformation/home?$region#/stack/detail?"
+      case _ => ""
+    }
+  }
+
   def toCredentialReportDisplay(report: IAMCredentialsReport): CredentialReportDisplay = {
 
     report.entries.filterNot(_.rootUser).foldLeft(CredentialReportDisplay(report.generatedAt)) { (report, cred) =>

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -53,7 +53,7 @@ object ReportDisplay {
 
   def linkForAwsConsole(stack: Stack): Option[String] = {
     stack.region.map { region =>
-      s"https://console.aws.amazon.com/cloudformation/home?$region#/stack/detail?stackId=${URLEncoder.encode(stack.id, "utf-8")}"
+      s"https://$region.console.aws.amazon.com/cloudformation/home?$region#/stack/detail?stackId=${URLEncoder.encode(stack.id, "utf-8")}"
     }
   }
 

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -4,7 +4,11 @@ import logic.DateUtils.dayDiff
 import model._
 import org.joda.time.{DateTime, DateTimeZone, Days}
 import utils.attempt.FailedAttempt
+import java.net.URLEncoder
 
+import com.amazonaws.regions.Regions
+
+import scala.util.{Failure, Success, Try}
 
 object ReportDisplay {
 
@@ -50,12 +54,14 @@ object ReportDisplay {
     else Green
   }
 
-  def linkForAwsConsole(stackId: String): String = {
+  def linkForAwsConsole(stackId: String): Option[String] = {
     val regionOpt = stackId.stripPrefix("arn:aws:cloudformation:").split(":").headOption
 
-    regionOpt match {
-      case Some(region) => s"https://console.aws.amazon.com/cloudformation/home?$region#/stack/detail?"
-      case _ => ""
+    Try {
+      Regions.fromName(regionOpt.getOrElse("")).getName
+    } match {
+      case Success(region) => Some(s"https://console.aws.amazon.com/cloudformation/home?$region#/stack/detail?stackId=${URLEncoder.encode(stackId, "utf-8")}")
+      case Failure(_) => None
     }
   }
 

--- a/hq/app/logic/ReportDisplay.scala
+++ b/hq/app/logic/ReportDisplay.scala
@@ -6,9 +6,6 @@ import org.joda.time.{DateTime, DateTimeZone, Days}
 import utils.attempt.FailedAttempt
 import java.net.URLEncoder
 
-import com.amazonaws.regions.Regions
-
-import scala.util.{Failure, Success, Try}
 
 object ReportDisplay {
 
@@ -54,14 +51,9 @@ object ReportDisplay {
     else Green
   }
 
-  def linkForAwsConsole(stackId: String): Option[String] = {
-    val regionOpt = stackId.stripPrefix("arn:aws:cloudformation:").split(":").headOption
-
-    Try {
-      Regions.fromName(regionOpt.getOrElse("")).getName
-    } match {
-      case Success(region) => Some(s"https://console.aws.amazon.com/cloudformation/home?$region#/stack/detail?stackId=${URLEncoder.encode(stackId, "utf-8")}")
-      case Failure(_) => None
+  def linkForAwsConsole(stack: Stack): Option[String] = {
+    stack.region.map { region =>
+      s"https://console.aws.amazon.com/cloudformation/home?$region#/stack/detail?stackId=${URLEncoder.encode(stack.id, "utf-8")}"
     }
   }
 
@@ -76,8 +68,7 @@ object ReportDisplay {
             key2Status(cred),
             machineReportStatus(cred),
             dayDiff(lastActivityDate(cred)),
-            stackId = cred.stackId,
-            stackName = cred.stackName
+            stack = cred.stack
           ))
         } else None
 
@@ -90,8 +81,7 @@ object ReportDisplay {
             key2Status(cred),
             humanReportStatus(cred),
             dayDiff(lastActivityDate(cred)),
-            stackId = cred.stackId,
-            stackName = cred.stackName
+            stack = cred.stack
           ))
         } else None
 

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -12,8 +12,8 @@ case class AwsAccount(
 case class Stack(
   id: String,
   name: String,
-  output: String,
-  resources: Option[List[StackResource]]
+  resources: List[StackResource],
+  region: Option[String]
 )
 
 case class StackResource(
@@ -34,8 +34,7 @@ case class IAMCredential(
   user: String,
   arn: String,
   creationTime: DateTime,
-  stackId: Option[String] = None,
-  stackName: Option[String] = None,
+  stack: Option[Stack] = None,
   passwordEnabled: Option[Boolean],
   passwordLastUsed: Option[DateTime],
   passwordLastChanged: Option[DateTime],
@@ -146,8 +145,7 @@ case class HumanUser(
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
   lastActivityDay : Option[Long],
-  stackId: Option[String] = None,
-  stackName: Option[String] = None,
+  stack: Option[Stack] = None
 )
 case class MachineUser(
   username: String,
@@ -155,8 +153,7 @@ case class MachineUser(
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
   lastActivityDay: Option[Long],
-  stackId: Option[String] = None,
-  stackName: Option[String] = None,
+  stack: Option[Stack] = None
 )
 
 case class SnykToken(value: String) extends AnyVal

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -9,6 +9,12 @@ case class AwsAccount(
   roleArn: String
 )
 
+case class Stack(
+  id: String,
+  name: String,
+  output: String
+)
+
 case class IAMCredentialsReport(
   generatedAt: DateTime,
   entries: List[IAMCredential]
@@ -18,8 +24,8 @@ case class IAMCredential(
   user: String,
   arn: String,
   creationTime: DateTime,
-  stackId : Option[String] = None,
-  stackName : Option[String] = None,
+  stackId: Option[String] = None,
+  stackName: Option[String] = None,
   passwordEnabled: Option[Boolean],
   passwordLastUsed: Option[DateTime],
   passwordLastChanged: Option[DateTime],
@@ -130,8 +136,8 @@ case class HumanUser(
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
   lastActivityDay : Option[Long],
-  stackId : Option[String] = None,
-  stackName : Option[String] = None,
+  stackId: Option[String] = None,
+  stackName: Option[String] = None,
 )
 case class MachineUser(
   username: String,
@@ -139,8 +145,8 @@ case class MachineUser(
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
   lastActivityDay: Option[Long],
-  stackId : Option[String] = None,
-  stackName : Option[String] = None,
+  stackId: Option[String] = None,
+  stackName: Option[String] = None,
 )
 
 case class SnykToken(value: String) extends AnyVal

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -12,7 +12,17 @@ case class AwsAccount(
 case class Stack(
   id: String,
   name: String,
-  output: String
+  output: String,
+  resources: Option[List[StackResource]]
+)
+
+case class StackResource(
+  StackId: String,
+  StackName: String,
+  PhysicalResourceId: String,
+  LogicalResourceId: String,
+  ResourceStatus: String,
+  ResourceType: String
 )
 
 case class IAMCredentialsReport(

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -18,6 +18,8 @@ case class IAMCredential(
   user: String,
   arn: String,
   creationTime: DateTime,
+  stackId : Option[String] = None,
+  stackName : Option[String] = None,
   passwordEnabled: Option[Boolean],
   passwordLastUsed: Option[DateTime],
   passwordLastChanged: Option[DateTime],
@@ -104,7 +106,7 @@ case object DEV extends Stage
 case object PROD extends Stage
 
 case class CredentialReportDisplay(
-  reportDate : DateTime,
+  reportDate: DateTime,
   machineUsers: Seq[MachineUser] = Seq.empty,
   humanUsers: Seq[HumanUser] = Seq.empty
 )
@@ -127,14 +129,18 @@ case class HumanUser(
   key1Status: KeyStatus,
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
-  lastActivityDay : Option[Long]
+  lastActivityDay : Option[Long],
+  stackId : Option[String] = None,
+  stackName : Option[String] = None,
 )
 case class MachineUser(
   username: String,
   key1Status: KeyStatus,
   key2Status: KeyStatus,
   reportStatus: ReportStatus,
-  lastActivityDay: Option[Long]
+  lastActivityDay: Option[Long],
+  stackId : Option[String] = None,
+  stackName : Option[String] = None,
 )
 
 case class SnykToken(value: String) extends AnyVal

--- a/hq/app/views/fragments/allKeyStatus.scala.html
+++ b/hq/app/views/fragments/allKeyStatus.scala.html
@@ -7,7 +7,7 @@
 
 @keyStatus(keyStatus: KeyStatus) = {
     @if(keyStatus == AccessKeyDisabled) {
-        <span><i class="material-icons left tooltipped iam-key--disabled"  data-position="bottom" data-delay="50" data-tooltip="Disabled Access Key">vpn_key</i></span>
+        <span><i class="material-icons left tooltipped iam-icon--disabled"  data-position="bottom" data-delay="50" data-tooltip="Disabled Access Key">vpn_key</i></span>
     }
     @if(keyStatus == AccessKeyEnabled) {
         <span><i class="material-icons left tooltipped" data-position="bottom" data-delay="50" data-tooltip="Has active Access Key">vpn_key</i></span>

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -25,7 +25,7 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
                         @if(cred.stackId && cred.stackName) {
-                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
                         } else {
                             <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }
@@ -61,9 +61,9 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
                         @if(cred.stackId && cred.stackName) {
-                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
                         } else {
-                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }
                     </td>
                     <td>

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -22,7 +22,14 @@
 
             @for(cred <- report.humanUsers) {
                 <tr>
-                    <td><i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i></td>
+                    <td>
+                        <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
+                        @if(cred.stackId && cred.stackName) {
+                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                        } else {
+                            <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        }
+                    </td>
                     <td>
                         <a target="_blank" rel="noopener noreferrer" href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">
                             @if(cred.username.length > 30) {
@@ -51,7 +58,14 @@
 
             @for(cred <- report.machineUsers) {
                 <tr>
-                    <td><i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i></td>
+                    <td>
+                        <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
+                        @if(cred.stackId && cred.stackName) {
+                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud</i>
+                        } else {
+                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        }
+                    </td>
                     <td>
                         <a target="_blank" rel="noopener noreferrer" href="https://console.aws.amazon.com/iam/home#/users/@{cred.username}">
                             @if(cred.username.length > 30) {

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -10,7 +10,7 @@
 </div>
 <div class="row">
     <div class="col s12">
-        <table class="striped responsive-table iam-report__table" >
+        <table class="striped responsive-table iam-report__table">
             <tr>
                 <th>Type</th>
                 <th>User name</th>
@@ -24,12 +24,15 @@
                 <tr>
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
-                        @if(cred.stackId && cred.stackName) {
-                        <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
-                            <i class="material-icons left tooltipped" data-tooltip="@cred.stackName.get stack" data-position="bottom" data-delay="50">cloud_done</i>
-                        </a>
-                        } else {
-                        <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
+                        @(cred.stackId, cred.stackName) match {
+                            case (Some(stackId), Some(stackName)) => {
+                                <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stackId)">
+                                    <i class="material-icons left tooltipped" data-tooltip="@stackName stack" data-position="bottom" data-delay="50">cloud_done</i>
+                                </a>
+                            }
+                            case _ => {
+                                <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
+                            }
                         }
                     </td>
                     <td>
@@ -62,12 +65,15 @@
                 <tr>
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
-                        @if(cred.stackId && cred.stackName) {
-                        <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
-                            <i class="material-icons left tooltipped" data-tooltip="@cred.stackName.get stack" data-position="bottom" data-delay="50">cloud_done</i>
-                        </a>
-                        } else {
-                        <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
+                        @(cred.stackId, cred.stackName) match {
+                            case (Some(stackId), Some(stackName)) => {
+                                <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stackId)">
+                                    <i class="material-icons left tooltipped" data-tooltip="@stackName stack" data-position="bottom" data-delay="50">cloud_done</i>
+                                </a>
+                            }
+                            case _ => {
+                                <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
+                            }
                         }
                     </td>
                     <td>

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -24,11 +24,11 @@
                 <tr>
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
-                        @(cred.stackId, cred.stackName) match {
-                            case (Some(stackId), Some(stackName)) => {
-                                <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stackId)">
-                                    <i class="material-icons left tooltipped" data-tooltip="@stackName stack" data-position="bottom" data-delay="50">cloud_done</i>
-                                </a>
+                        @cred.stack match {
+                            case Some(stack) => {
+                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stack)">
+                                <i class="material-icons left tooltipped" data-tooltip="@stack.name stack" data-position="bottom" data-delay="50">cloud_done</i>
+                            </a>
                             }
                             case _ => {
                                 <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
@@ -65,10 +65,10 @@
                 <tr>
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
-                        @(cred.stackId, cred.stackName) match {
-                            case (Some(stackId), Some(stackName)) => {
-                                <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stackId)">
-                                    <i class="material-icons left tooltipped" data-tooltip="@stackName stack" data-position="bottom" data-delay="50">cloud_done</i>
+                        @cred.stack match {
+                            case Some(stack) => {
+                                <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stack)">
+                                    <i class="material-icons left tooltipped" data-tooltip="@stack.name stack" data-position="bottom" data-delay="50">cloud_done</i>
                                 </a>
                             }
                             case _ => {

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -25,7 +25,9 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
                         @if(cred.stackId && cred.stackName) {
-                            <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            </a>
                         } else {
                             <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }
@@ -61,7 +63,9 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
                         @if(cred.stackId && cred.stackName) {
-                        <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
+                            </a>
                         } else {
                         <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
                         }

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -25,11 +25,11 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
                         @if(cred.stackId && cred.stackName) {
-                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
-                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
-                            </a>
+                        <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                            <i class="material-icons left tooltipped" data-tooltip="@cred.stackName.get stack" data-position="bottom" data-delay="50">cloud_done</i>
+                        </a>
                         } else {
-                            <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
                         }
                     </td>
                     <td>
@@ -63,11 +63,11 @@
                     <td>
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
                         @if(cred.stackId && cred.stackName) {
-                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
-                                <i class="material-icons left tooltipped" data-tooltip="cloudformed" data-position="bottom" data-delay="50">cloud_done</i>
-                            </a>
+                        <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(cred.stackId.get)stackId=@helper.urlEncode(cred.stackId.get)">
+                            <i class="material-icons left tooltipped" data-tooltip="@cred.stackName.get stack" data-position="bottom" data-delay="50">cloud_done</i>
+                        </a>
                         } else {
-                        <i class="material-icons left tooltipped" data-tooltip="not cloudformed" data-position="bottom" data-delay="50">cloud_off</i>
+                        <i class="material-icons left tooltipped" data-tooltip="no CloudFormation stack" data-position="bottom" data-delay="50">cloud_off</i>
                         }
                     </td>
                     <td>

--- a/hq/test/aws/iam/CredentialsReportTest.scala
+++ b/hq/test/aws/iam/CredentialsReportTest.scala
@@ -91,7 +91,6 @@ class CredentialsReportTest extends FreeSpec with Matchers with OptionValues wit
         )
       }
 
-
       "fails when parsing empty CSV" in {
         val testReport = ""
         CredentialsReport.tryParsingReport(testReport).isFailedAttempt() shouldBe true
@@ -108,9 +107,7 @@ class CredentialsReportTest extends FreeSpec with Matchers with OptionValues wit
         userWithCreds should have (
           'passwordLastUsed (None)
         )
-
       }
-
     }
   }
 }

--- a/hq/test/aws/iam/CredentialsReportTest.scala
+++ b/hq/test/aws/iam/CredentialsReportTest.scala
@@ -1,6 +1,7 @@
 package aws.iam
 
 import com.amazonaws.regions.{Region, Regions}
+import model.{IAMCredential, IAMCredentialsReport, Stack, StackResource}
 import org.joda.time.{DateTime, DateTimeZone}
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
 import utils.attempt.AttemptValues
@@ -108,6 +109,53 @@ class CredentialsReportTest extends FreeSpec with Matchers with OptionValues wit
           'passwordLastUsed (None)
         )
       }
+    }
+  }
+
+  "enrichReportWithStackDetails" - {
+    val now = DateTime.now()
+    val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
+    val stackResourceA = StackResource(stackId, "example-key", "example-key-1ABC2D345EFG", "example", "CREATE_COMPLETE", "AWS::IAM::AccessKey")
+    val stackResourceB = StackResource(stackId, "example-user", "example-user-1ABC2D345EFG", "example", "CREATE_COMPLETE", "AWS::IAM::User")
+    val stackA = Stack(stackId, "stack-A", List(stackResourceA), Some("eu-west-1"))
+    val stackB = Stack(stackId, "stack-B", List(stackResourceB), Some("eu-west-1"))
+    val stackC = Stack(stackId, "stack-C", Nil, Some("eu-west-1"))
+    val cred = IAMCredential(
+      "example-user-1ABC2D345EFG",
+      "arn:xyz",
+      now,
+      None,
+      None,
+      Some(now.minusDays(1)),
+      Some(now.minusDays(2)),
+      Some(now.minusDays(3)),
+      mfaActive = true,
+      accessKey1Active = true,
+      Some(now.minusDays(4)),
+      Some(now.minusDays(5)),
+      None,
+      None,
+      accessKey2Active = true,
+      Some(now.minusDays(6)),
+      Some(now.minusDays(7)),
+      None,
+      None,
+      cert1Active = true,
+      Some(now.minusDays(8)),
+      cert2Active = true,
+      Some(now.minusDays(9))
+    )
+
+    "will discover the stack associated with the credential, and update the report" in {
+      val report = IAMCredentialsReport(now, List(cred.copy(user = "example-user-1ABC2D345EFG")))
+      val result = CredentialsReport.enrichReportWithStackDetails(report, List(stackA, stackB, stackC)).entries
+      result shouldEqual List(cred.copy(user = "example-user-1ABC2D345EFG", stack = Some(stackB)))
+    }
+
+    "will return the report unchanged if no associated stacks are found" in {
+      val report = IAMCredentialsReport(now, List(cred.copy(user = "custom-user")))
+      val result = CredentialsReport.enrichReportWithStackDetails(report, List(stackA, stackB, stackC)).entries
+      result shouldEqual List(cred.copy(user = "custom-user"))
     }
   }
 }

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -234,9 +234,16 @@ class ReportDisplayTest extends FreeSpec with Matchers {
   }
 
   "linkForAwsConsole" - {
-    "returns the correct string from a stackId" in {
+    "will return a valid URL from a valid stackId" in {
       val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
-      linkForAwsConsole(stackId) shouldEqual "https://console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?"
+      linkForAwsConsole(stackId) shouldEqual Some("https://console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?stackId=arn%3Aaws%3Acloudformation%3Aeu-west-1%3A123456789123%3Astack%2Fstack-name%2F8a123bc0-222d-33e4-5fg6-77aa88b12345")
+    }
+
+    "returns None if it cannot extract a valid region from the stackId" in {
+      val entirelyWrong = "something terrible has gone wrong, why is this string here?"
+      val withFakeRegion = "arn:aws:cloudformation:am-hubwards-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
+      linkForAwsConsole(entirelyWrong) shouldEqual None
+      linkForAwsConsole(withFakeRegion) shouldEqual None
     }
   }
 

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -16,6 +16,8 @@ class ReportDisplayTest extends FreeSpec with Matchers {
       "user-1",
       now,
       None,
+      None,
+      None,
       Some(now.minusDays(1)),
       Some(now.minusDays(2)),
       Some(now.minusDays(3)),

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -241,7 +241,7 @@ class ReportDisplayTest extends FreeSpec with Matchers {
         region = Some("eu-west-1")
       )
 
-      linkForAwsConsole(stack) shouldEqual Some("https://console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?stackId=arn%3Aaws%3Acloudformation%3Aeu-west-1%3A123456789123%3Astack%2Fstack-name%2F8a123bc0-222d-33e4-5fg6-77aa88b12345")
+      linkForAwsConsole(stack) shouldEqual Some("https://eu-west-1.console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?stackId=arn%3Aaws%3Acloudformation%3Aeu-west-1%3A123456789123%3Astack%2Fstack-name%2F8a123bc0-222d-33e4-5fg6-77aa88b12345")
     }
 
     "returns None if the region is missing from the stack" in {

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -233,6 +233,13 @@ class ReportDisplayTest extends FreeSpec with Matchers {
     }
   }
 
+  "linkForAwsConsole" - {
+    "returns the correct string from a stackId" in {
+      val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
+      linkForAwsConsole(stackId) shouldEqual "https://console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?"
+    }
+  }
+
   "reportStatusSummary" - {
     val now = DateTime.now()
 

--- a/hq/test/logic/ReportDisplayTest.scala
+++ b/hq/test/logic/ReportDisplayTest.scala
@@ -17,7 +17,6 @@ class ReportDisplayTest extends FreeSpec with Matchers {
       now,
       None,
       None,
-      None,
       Some(now.minusDays(1)),
       Some(now.minusDays(2)),
       Some(now.minusDays(3)),
@@ -234,16 +233,26 @@ class ReportDisplayTest extends FreeSpec with Matchers {
   }
 
   "linkForAwsConsole" - {
-    "will return a valid URL from a valid stackId" in {
-      val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
-      linkForAwsConsole(stackId) shouldEqual Some("https://console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?stackId=arn%3Aaws%3Acloudformation%3Aeu-west-1%3A123456789123%3Astack%2Fstack-name%2F8a123bc0-222d-33e4-5fg6-77aa88b12345")
+    "will return a valid URL from a valid Stack" in {
+      val stack = Stack(
+        id = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345",
+        name = "stack-name",
+        resources = Nil,
+        region = Some("eu-west-1")
+      )
+
+      linkForAwsConsole(stack) shouldEqual Some("https://console.aws.amazon.com/cloudformation/home?eu-west-1#/stack/detail?stackId=arn%3Aaws%3Acloudformation%3Aeu-west-1%3A123456789123%3Astack%2Fstack-name%2F8a123bc0-222d-33e4-5fg6-77aa88b12345")
     }
 
-    "returns None if it cannot extract a valid region from the stackId" in {
-      val entirelyWrong = "something terrible has gone wrong, why is this string here?"
-      val withFakeRegion = "arn:aws:cloudformation:am-hubwards-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
-      linkForAwsConsole(entirelyWrong) shouldEqual None
-      linkForAwsConsole(withFakeRegion) shouldEqual None
+    "returns None if the region is missing from the stack" in {
+      val stack = Stack(
+        id = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345",
+        name = "stack-name",
+        resources = Nil,
+        region = None
+      )
+
+      linkForAwsConsole(stack) shouldEqual None
     }
   }
 


### PR DESCRIPTION
## What does this change?

Adds a cloud icon next to the user type to indicate if the user is associated with a CloudFormation stack. IAM user arns that do not match any stack output will have a cloud with a line through:

<img width="1160" alt="picture 216" src="https://user-images.githubusercontent.com/8607683/36166646-12b8c174-10eb-11e8-8cd3-e1fb01c2deb9.png">


For IAM users that do have an associated CloudFormation stack, the stack name will appear on hover (as a tooltip) and the icon will be a link to the stack in the AWS console:

<img width="1199" alt="picture 217" src="https://user-images.githubusercontent.com/8607683/36166748-668b7738-10eb-11e8-9d26-7f4956444e0a.png">


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Simple identification of IAM users that have custom permissions/have not been Cloudformed

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

🔴 Yes! StackSet update TODO! 🔴 

This functionality requires 3 requests for each account:

```
SHQ ------- describeRegions ---------------> AWS

SHQ ------- describeStacks ----------------> AWS

SHQ ------- describeStackResources --------> AWS
```

The watched accounts still need `describeStackResources` to be added to the template

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

This should check across regions...