### PR TITLE
Log unexpected errors

### DIFF
--- a/hq/app/utils/attempt/Attempt.scala
+++ b/hq/app/utils/attempt/Attempt.scala
@@ -2,6 +2,8 @@ package utils.attempt
 
 import java.util.{Timer, TimerTask}
 
+import play.api.Logger
+
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
@@ -46,6 +48,7 @@ case class Attempt[A] private (underlying: Future[Either[FailedAttempt, A]]) {
   def asFuture(implicit ec: ExecutionContext): Future[Either[FailedAttempt, A]] = {
     underlying recover { case err =>
       val apiErrors = FailedAttempt(Failure(err.getMessage, "Unexpected error", 500, throwable = Some(err)))
+      Logger.error(apiErrors.logMessage, apiErrors.firstException.orNull)
       scala.Left(apiErrors)
     }
   }

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -3,6 +3,16 @@ package utils.attempt
 
 case class FailedAttempt(failures: List[Failure]) {
   def statusCode: Int = failures.map(_.statusCode).max
+  def logMessage: String = failures.map { failure =>
+    val context = failure.context.fold("")(c => s" ($c)")
+    s"${failure.message}$context"
+  }.mkString(", ")
+  def firstException: Option[Throwable] = {
+    for {
+      exceptingFailure <- failures.find(_.throwable.isDefined)
+      throwable <- exceptingFailure.throwable
+    } yield throwable
+  }
 }
 object FailedAttempt {
   def apply(error: Failure): FailedAttempt = {

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -3,10 +3,12 @@ package utils.attempt
 
 case class FailedAttempt(failures: List[Failure]) {
   def statusCode: Int = failures.map(_.statusCode).max
+
   def logMessage: String = failures.map { failure =>
     val context = failure.context.fold("")(c => s" ($c)")
     s"${failure.message}$context"
   }.mkString(", ")
+
   def firstException: Option[Throwable] = {
     for {
       exceptingFailure <- failures.find(_.throwable.isDefined)

--- a/hq/app/utils/attempt/PlayIntegration.scala
+++ b/hq/app/utils/attempt/PlayIntegration.scala
@@ -9,14 +9,9 @@ import scala.concurrent.{ExecutionContext, Future}
 object PlayIntegration extends Results {
   def attempt[A](action: => Attempt[Result])(implicit ec: ExecutionContext, assetsFinder: AssetsFinder): Future[Result] = {
     action.fold(
-      { err =>
-        err.failures.foreach { failure =>
-          failure.throwable match {
-            case Some(th) => Logger.error(failure.message, th)
-            case _ => Logger.error(failure.message)
-          }
-        }
-        Status(err.statusCode)(views.html.error(err))
+      { failures =>
+        Logger.error(failures.logMessage, failures.firstException.orNull)
+        Status(failures.statusCode)(views.html.error(failures))
       },
       identity
     )


### PR DESCRIPTION
## What does this change?

Adds log line to unexpected errors.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

The application previously assumed that all logging would be done at the edge of the program (in PlayIntegration). This is no longer true because in several areas we have chosen to handle errors ourselves instead of using the automatic error handling provided by Attempt (e.g. in all the cached data). Our own error handling is ok, but does not deal well with unexpected errors so it is important that we log information at these points.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope.
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

It also simplifies an existing logging call along the same lines.

The change adds methods to FailedAttempt to make logging calls simpler. I advocate avoiding mixing data definitions with behaviour. The case where (in my head) it's ok to go against this rule is when the properties added to the data definition are entirely emergent (they take no arguments) because they are properties of the data definition, rather than other behaviour. This is the case here and in particular, this file is for the failure behaviour rather than pure model definitions. I'm convinceable if anyone feels strongly about these being somewhere else, but on balance here looked best to me.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
