### PR TITLE
Fix NPE in code to parse EC2 network interfaces

### DIFF
--- a/hq/test/aws/ec2/EC2Test.scala
+++ b/hq/test/aws/ec2/EC2Test.scala
@@ -33,6 +33,14 @@ class EC2Test extends FreeSpec with Matchers with Checkers with PropertyChecks w
         .withAttachment(new NetworkInterfaceAttachment())
       EC2.parseNetworkInterface(ni) shouldEqual UnknownUsage("network-interface", "ni-123")
     }
+
+    "does not throw if network interface info is null" in {
+      val ni = new NetworkInterface()
+        .withDescription(null)
+        .withNetworkInterfaceId(null)
+        .withAttachment(null)
+      noException should be thrownBy EC2.parseNetworkInterface(ni)
+    }
   }
 
   "extractTagsForSecurityGroups" - {


### PR DESCRIPTION
cc @katebee I looked at the error messages now we have them. I guess they have unusual instances in their clusters.

## What does this change?

Fixes NPE in `EC2.parseNetworkInterface` when the Network Interface is missing.
<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Will allow Ophan team to look at their SGs again.
<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

No
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

None