### PR TITLE
Add AWS Inspector documentation

### DIFF
--- a/hq/markdown/aws-inspector.md
+++ b/hq/markdown/aws-inspector.md
@@ -1,0 +1,64 @@
+# AWS Inspector
+
+[AWS Inspector](https://aws.amazon.com/inspector/) is an automated scanning system to detect poor configuration, vulnerable OS modules and packages, and
+poor runtime behaviour.
+
+It is provided as standard to all AWS accounts.
+
+## Implementation
+
+An application has been created, which will:
+
+  * Create a lambda to
+    * Search for App, Stack and Stage tags on instances in the target account
+    * Create a resource group, assessment target, and assessment template for each combination, unless they already exist
+    * Limit the resource group to a maximum of five instances
+    * Start an Assessment run of one hour for each target
+  * Schedule the lambda for 3am on Mondays and Thursdays.
+
+### Repo
+
+See https://github.com/guardian/inspector-lambda
+
+### Artifact
+
+The artifact required by the lambda will be stored in a generic bucket owned by the `deployTools` account
+for the purpose of distributing code used by multiple guardian accounts:
+
+```
+s3://guardian-dist/guardian/PROD/inspectory-lambda.jar
+```
+
+New versions of this application are published by pushing to that location.
+
+### Stack Set
+
+This lambda will be deployed into each account using a stackset.  The cloudformation is in the inspector-lambda repo 
+under /cloudformation
+
+## Output
+
+An AWS Inspector run will be started for every combination of app, stack and stage present in the account, in the early
+hours of Mondays and Thursdays.
+
+These can be inspected and mitigated by the teams responsible.
+
+## Implementation Details
+
+### Agent
+
+In order to track instance behaviour, an agent must be installed on the target instances.  
+
+Amigo will do this for you with the `aws-inspector` role.
+Alternatively see [here](https://docs.aws.amazon.com/inspector/latest/userguide/inspector_installing-uninstalling-agents.html#install-linux).
+
+### Targeting
+
+Instances are targeted based on tags.
+
+Currently, AWS have implemented a 'match any' strategy on tag filters, which is of course, insane.  
+
+### Cost
+
+Currently, 30c per instance per scan.  This is relatively high, especially on highly scaled out services.
+

--- a/hq/markdown/aws-inspector.md
+++ b/hq/markdown/aws-inspector.md
@@ -1,7 +1,7 @@
 # AWS Inspector
 
-[AWS Inspector](https://aws.amazon.com/inspector/) is an automated scanning system to detect poor configuration, vulnerable OS modules and packages, and
-poor runtime behaviour.
+[AWS Inspector](https://aws.amazon.com/inspector/) is an automated scanning system to detect poor configuration, 
+vulnerable OS modules and packages, and poor runtime behaviour.
 
 It is provided as standard to all AWS accounts.
 
@@ -38,10 +38,10 @@ under /cloudformation
 
 ## Output
 
-An AWS Inspector run will be started for every combination of app, stack and stage present in the account, in the early
-hours of Mondays and Thursdays.
+An AWS Inspector run will be started for every combination of app, stack and stage present in the account, 
+including 'not present', in the early hours of Mondays and Thursdays.
 
-These can be inspected and mitigated by the teams responsible.
+The results can be inspected and mitigated by the teams responsible.
 
 ## Implementation Details
 
@@ -56,9 +56,13 @@ Alternatively see [here](https://docs.aws.amazon.com/inspector/latest/userguide/
 
 Instances are targeted based on tags.
 
-Currently, AWS have implemented a 'match any' strategy on tag filters, which is of course, insane.  
+Currently, AWS have implemented a 'match any' strategy on tag filters, which is of course, insane. As a result, including
+Stack=XXX, App=YYY, Stage==CODE will match all instances with Stage 'CODE' _even if they do not match the other tags_.
+
+As a result, the lambda will dynamically add another tag to each target instance with name `Inspection`, 
+and value 'AWSInspection-$stack-$app-$stage'. This is then used to target individual runs.
 
 ### Cost
 
-Currently, 30c per instance per scan.  This is relatively high, especially on highly scaled out services.
+Currently, 30c per instance per scan.  This is relatively high, especially on highly scaled out services.  For this reason, the lambda will choose up to five instances to scan.
 

--- a/hq/markdown/index.md
+++ b/hq/markdown/index.md
@@ -3,3 +3,5 @@
    1. How to implement [Snyk](snyk) Vulnerability Analysis to check library dependencies.
    2. How to implement [AWS run command (tutorial)](run-command) and remove the need for ssh/bastions.
    3. How to use [Temporary SSH credentials](temporary-ssh).
+   4. Scanning for weaknesses with [AWS Inspector](aws-inspector)
+   5. Fetching 'secrets' on instances from [AWS Parameter Store](parameter-store)


### PR DESCRIPTION
## What does this change?

Adds documentation of the AWS Inspector lambda + results implementation we will be using.

## What is the value of this?

Explains what Inspector offers and how it will be used.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

## Any additional notes?

No.