### PR TITLE
Disable assembly plugin for Security HQ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,10 @@ resolvers += DefaultMavenRepository
 val awsSdkVersion = "1.11.258"
 val playVersion = "2.6.7"
 
-lazy val hq = (project in file("hq")).
-  enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin, SbtWeb).
-  settings(
+lazy val hq = (project in file("hq"))
+  .enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin, SbtWeb)
+  .disablePlugins(sbtassembly.AssemblyPlugin)
+  .settings(
     name := """security-hq""",
     playDefaultPort := 9090,
     libraryDependencies ++= Seq(


### PR DESCRIPTION
## What does this change?

Disables the sbt assembly plugin for the hq project.

## What is the value of this?

Stops people wasting time trying to use assembly to build a deployable when they should be using dist.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No