### PR TITLE
Re-instate AWS Inspector in Launch Config

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -236,6 +236,9 @@ Resources:
           apt-get -y update
           apt-get -y upgrade
           apt-get -y install ntp
+          # setup Amazon Inspector
+          /usr/bin/wget https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install
+          /bin/bash install
           echo ${Stage} > /etc/stage
           # setup security-hq
           adduser --system --home /security-hq --disabled-password security-hq


### PR DESCRIPTION
## What does this change?

Reverts to installing AWS Inspector at launch instead of in the AMI.

## What is the value of this?

The AMI install failed because the kernel module present from the installer did not necessarily match the running kernel at launch.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes.

## Have you committed your changes to the CloudFormation templates? 

Yes

## Has the CloudFormation or StackSet update been completed?

No - it is automated by riffraff

## Any additional notes?

No