### PR TITLE
Fix colour of disabled icon

### DIFF
--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -317,7 +317,7 @@ nav {
   margin-right: auto;
 }
 
-.iam-key--disabled {
+.iam-icon--disabled {
   opacity: 0.3;
 }
 


### PR DESCRIPTION
## What does this change?

Makes disabled icons grey again

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

CSS fix

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
