### PR TITLE
New snyk api

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -26,12 +26,6 @@ class AppComponents(context: Context)
   with AhcWSComponents with AssetsComponents {
 
   implicit val impWsClient: WSClient = wsClient
-//  val snykWsClient: WSClient = {
-//    val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(3))
-//    val asyncHttpClient = new AsyncHttpClientProvider(environment, configuration, applicationLifecycle)(ec).get
-//    new AhcWSClientProvider(asyncHttpClient).get
-//  }
-
   implicit val impPlayBodyParser: BodyParser[AnyContent] = playBodyParsers.default
   implicit val impControllerComponents: ControllerComponents = controllerComponents
   implicit val impAssetsFinder: AssetsFinder = assetsFinder
@@ -71,7 +65,6 @@ class AppComponents(context: Context)
     new HQController(configuration, cacheService, googleAuthConfig),
     new SecurityGroupsController(configuration, cacheService, googleAuthConfig),
     new SnykController(configuration, configraun, googleAuthConfig),
-//    new SnykController(configuration, configraun, googleAuthConfig, snykWsClient),
     new AuthController(environment, configuration, googleAuthConfig),
     new UtilityController(),
     assets

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -1,5 +1,3 @@
-import java.util.concurrent.Executors
-
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.gu.configraun.Configraun
 import com.gu.configraun.aws.AWSSimpleSystemsManagementFactory
@@ -10,15 +8,12 @@ import filters.HstsFilter
 import play.api.ApplicationLoader.Context
 import play.api.{BuiltInComponentsFromContext, Logger}
 import play.api.libs.ws.WSClient
-import play.api.libs.ws.ahc.{AhcWSClientProvider, AhcWSComponents, AsyncHttpClientProvider}
+import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.{AnyContent, BodyParser, ControllerComponents}
 import play.api.routing.Router
 import play.filters.csrf.CSRFComponents
 import router.Routes
 import services.CacheService
-
-import scala.concurrent.ExecutionContext
-
 
 class AppComponents(context: Context)
   extends BuiltInComponentsFromContext(context)

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -26,11 +26,11 @@ class AppComponents(context: Context)
   with AhcWSComponents with AssetsComponents {
 
   implicit val impWsClient: WSClient = wsClient
-  val snykWsClient: WSClient = {
-    val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(3))
-    val asyncHttpClient = new AsyncHttpClientProvider(environment, configuration, applicationLifecycle)(ec).get
-    new AhcWSClientProvider(asyncHttpClient).get
-  }
+//  val snykWsClient: WSClient = {
+//    val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(3))
+//    val asyncHttpClient = new AsyncHttpClientProvider(environment, configuration, applicationLifecycle)(ec).get
+//    new AhcWSClientProvider(asyncHttpClient).get
+//  }
 
   implicit val impPlayBodyParser: BodyParser[AnyContent] = playBodyParsers.default
   implicit val impControllerComponents: ControllerComponents = controllerComponents
@@ -70,7 +70,8 @@ class AppComponents(context: Context)
     httpErrorHandler,
     new HQController(configuration, cacheService, googleAuthConfig),
     new SecurityGroupsController(configuration, cacheService, googleAuthConfig),
-    new SnykController(configuration, configraun, googleAuthConfig, snykWsClient),
+    new SnykController(configuration, configraun, googleAuthConfig),
+//    new SnykController(configuration, configraun, googleAuthConfig, snykWsClient),
     new AuthController(environment, configuration, googleAuthConfig),
     new UtilityController(),
     assets

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -21,13 +21,13 @@ object Snyk {
     }
   }
 
-  def getProjects(token: SnykToken, organisations: List[SnykOrganisation], wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[(SnykOrganisation, WSResponse)]] = {
+  def getProjects(token: SnykToken, organisations: List[SnykOrganisation], wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[(SnykOrganisation, String)]] = {
     Attempt.traverse(organisations) { organisation =>
       val snykProjectsUrl = s"https://snyk.io/api/v1/org/${organisation.id}/projects"
       val futureResponse = wsClient.url(snykProjectsUrl)
         .addHttpHeaders("Authorization" -> s"token ${token.value}")
         .get()
-        .transform(response => (organisation, response), f => f )
+        .transform(response => (organisation, response.body), f => f )
       Attempt.fromFuture(futureResponse) {
         case NonFatal(e) =>
           val failure = Failure(e.getMessage, "Could not read projects from Snyk", 502, None, Some(e))

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -25,7 +25,6 @@ object Snyk {
 
   def getProjects(token: SnykToken, organisations: List[SnykOrganisation], wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[(SnykOrganisation, WSResponse)]] = {
     Attempt.traverse(organisations) { organisation =>
-      println(organisation)
       val snykProjectsUrl = s"https://snyk.io/api/v1/org/${organisation.id}/projects"
       val b = wsClient.url(snykProjectsUrl)
         .addHttpHeaders("Authorization" -> s"token ${token.value}")
@@ -44,7 +43,6 @@ object Snyk {
     val projectVulnerabilityResponses = projects
       .map(project => {
         val snykProjectUrl = s"https://snyk.io/api/v1/org/${project.organisation.get.id}/project/${project.id}/issues"
-        println(snykProjectUrl)
         val projectIssuesFilter = Json.obj(
           "filters" -> Json.obj(
             "severity" -> JsArray(List(

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -20,10 +20,10 @@ object Snyk {
   }
 
   def getProjects(token: SnykToken, organisations: List[SnykOrganisation], wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[(SnykOrganisation, String)]] = {
-    Attempt.traverse(organisations) { organisation =>
+    Attempt.labelledTraverse(organisations) { organisation =>
       val snykProjectsUrl = s"https://snyk.io/api/v1/org/${organisation.id}/projects"
       val futureResponse = snykRequest(token, snykProjectsUrl, wsClient).get
-        .transform(response => (organisation, response.body), f => f )
+        .map(response => response.body)
       handleFuture(futureResponse, "project")
     }
   }

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -10,7 +10,8 @@ import scala.util.control.NonFatal
 
 object Snyk {
 
-  def snykRequest(token:SnykToken, url:String, wsClient: WSClient) = wsClient.url(url).addHttpHeaders("Authorization" -> s"token ${token.value}")
+  def snykRequest(token:SnykToken, url:String, wsClient: WSClient) = 
+    wsClient.url(url).addHttpHeaders("Authorization" -> s"token ${token.value}")
 
   def getSnykOrganisations(token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[WSResponse] = {
     val snykOrgUrl = "https://snyk.io/api/v1/orgs"

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -5,7 +5,7 @@ import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
 object Snyk {
@@ -52,7 +52,7 @@ object Snyk {
     }
   }
 
-  def handleFuture[A](future: scala.concurrent.Future[A], label: String)(implicit ec: ExecutionContext) = Attempt.fromFuture(future) {
+  def handleFuture[A](future: Future[A], label: String)(implicit ec: ExecutionContext) = Attempt.fromFuture(future) {
     case NonFatal(e) =>
       val failure = Failure(e.getMessage, s"Could not read ${label} from Snyk", 502, None, Some(e))
       FailedAttempt(failure)

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -15,7 +15,6 @@ object Snyk {
     val snykOrgUrl = "https://snyk.io/api/v1/orgs"
     val futureResponse = wsClient.url(snykOrgUrl)
       .addHttpHeaders("Authorization" -> s"token ${token.value}")
-        .addQueryStringParameters(("apple", "orange"))
       .get
     Attempt.fromFuture(futureResponse) { case NonFatal(e) =>
       val failure = Failure(e.getMessage, "Could not read organisations from Snyk", 502, None, Some(e))

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -11,9 +11,11 @@ import scala.util.control.NonFatal
 object Snyk {
 
   def getSnykOrganisations(token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[WSResponse] = {
+    println(token)
     val snykOrgUrl = "https://snyk.io/api/v1/orgs"
     val futureResponse = wsClient.url(snykOrgUrl)
       .addHttpHeaders("Authorization" -> s"token ${token.value}")
+        .addQueryStringParameters(("apple", "orange"))
       .get
     Attempt.fromFuture(futureResponse) { case NonFatal(e) =>
       val failure = Failure(e.getMessage, "Could not read organisations from Snyk", 502, None, Some(e))
@@ -23,6 +25,7 @@ object Snyk {
 
   def getProjects(token: SnykToken, organisations: List[SnykOrganisation], wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[(SnykOrganisation, WSResponse)]] = {
     Attempt.traverse(organisations) { organisation =>
+      println(organisation)
       val snykProjectsUrl = s"https://snyk.io/api/v1/org/${organisation.id}/projects"
       val b = wsClient.url(snykProjectsUrl)
         .addHttpHeaders("Authorization" -> s"token ${token.value}")
@@ -41,6 +44,7 @@ object Snyk {
     val projectVulnerabilityResponses = projects
       .map(project => {
         val snykProjectUrl = s"https://snyk.io/api/v1/org/${project.organisation.get.id}/project/${project.id}/issues"
+        println(snykProjectUrl)
         val projectIssuesFilter = Json.obj(
           "filters" -> Json.obj(
             "severity" -> JsArray(List(

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -2,7 +2,7 @@ package api
 
 import model._
 import play.api.libs.json._
-import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
+import play.api.libs.ws.{WSClient, WSResponse}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -10,7 +10,7 @@ import scala.util.control.NonFatal
 
 object Snyk {
 
-  def snykRequest(token:SnykToken, url:String, wsClient: WSClient) = 
+  private def snykRequest(token:SnykToken, url:String, wsClient: WSClient) =
     wsClient.url(url).addHttpHeaders("Authorization" -> s"token ${token.value}")
 
   def getSnykOrganisations(token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[WSResponse] = {
@@ -52,9 +52,9 @@ object Snyk {
     }
   }
 
-  def handleFuture[A](future: Future[A], label: String)(implicit ec: ExecutionContext) = Attempt.fromFuture(future) {
+  def handleFuture[A](future: Future[A], label: String)(implicit ec: ExecutionContext): Attempt[A] = Attempt.fromFuture(future) {
     case NonFatal(e) =>
-      val failure = Failure(e.getMessage, s"Could not read ${label} from Snyk", 502, None, Some(e))
+      val failure = Failure(e.getMessage, s"Could not read $label from Snyk", 502, None, Some(e))
       FailedAttempt(failure)
   }
 }

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -11,7 +11,6 @@ import scala.util.control.NonFatal
 object Snyk {
 
   def getSnykOrganisations(token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[WSResponse] = {
-    println(token)
     val snykOrgUrl = "https://snyk.io/api/v1/orgs"
     val futureResponse = wsClient.url(snykOrgUrl)
       .addHttpHeaders("Authorization" -> s"token ${token.value}")
@@ -25,11 +24,11 @@ object Snyk {
   def getProjects(token: SnykToken, organisations: List[SnykOrganisation], wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[(SnykOrganisation, WSResponse)]] = {
     Attempt.traverse(organisations) { organisation =>
       val snykProjectsUrl = s"https://snyk.io/api/v1/org/${organisation.id}/projects"
-      val b = wsClient.url(snykProjectsUrl)
+      val futureResponse = wsClient.url(snykProjectsUrl)
         .addHttpHeaders("Authorization" -> s"token ${token.value}")
         .get()
         .transform(response => (organisation, response), f => f )
-      Attempt.fromFuture(b) {
+      Attempt.fromFuture(futureResponse) {
         case NonFatal(e) =>
           val failure = Failure(e.getMessage, "Could not read projects from Snyk", 502, None, Some(e))
           FailedAttempt(failure)

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -93,7 +93,7 @@ object EC2 {
   private [ec2] def sortSecurityGroupsByInUse(sgsPortFlags : List[SGOpenPortsDetail], sgUsage: Map[String, Set[SGInUse]]) = {
     sgsPortFlags
       .map(sgOpenPortsDetail => sgOpenPortsDetail -> sgUsage.getOrElse(sgOpenPortsDetail.id, Set.empty))
-      .sortWith{ case  ((_, s1), (_, s2)) => s1.size > s2.size }
+      .sortWith { case  ((_, s1), (_, s2)) => s1.size > s2.size }
   }
 
   def sortAccountByFlaggedSgs[L, R](accountsWithFlaggedSgs: List[(AwsAccount, Either[L, List[R]])]): List[(AwsAccount, Either[L, List[R]])] = {

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -26,7 +26,7 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
     Ok(views.html.sgs.sgs(sortedFlaggedSgs))
   }
 
-  def securityGroupsAccount(accountId: String) = authAction.async {
+  def securityGroupsAccount(accountId: String): Action[AnyContent] = authAction.async {
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -32,7 +32,6 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
     Action.async {
       attempt {
         for {
-
           token <- getSnykToken
           requiredOrganisation <- getSnykOrganisation
 
@@ -59,17 +58,17 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
   }
 
   def getSnykToken: Attempt[SnykToken] = configraun.getAsString("/snyk/token") match {
-    case Left(a:ConfigraunError) =>
-      val failure = Failure(a.message, "Could not read Snyk token from aws parameter store", 500, None, Some(a.e))
+    case Left(error) =>
+      val failure = Failure(error.message, "Could not read Snyk token from aws parameter store", 500, None, Some(error.e))
       Attempt.Left(failure)
-    case Right(a:String) => Attempt.Right(SnykToken(a))
+    case Right(token) => Attempt.Right(SnykToken(token))
   }
 
   def getSnykOrganisation: Attempt[SnykGroupId] = configraun.getAsString("/snyk/organisation") match {
-    case Left(a:ConfigraunError) =>
-      val failure = Failure(a.message, "Could not read Snyk organisation from aws parameter store", 500, None, Some(a.e))
+    case Left(error) =>
+      val failure = Failure(error.message, "Could not read Snyk organisation from aws parameter store", 500, None, Some(error.e))
       Attempt.Left(failure)
-    case Right(a:String) => Attempt.Right(SnykGroupId(a))
+    case Right(groupId) => Attempt.Right(SnykGroupId(groupId))
   }
 
 }

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -39,7 +39,7 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
           organisations <- SnykDisplay.parseOrganisations(organisationResponse.body, requiredOrganisation)
 
           projectResponses <- Snyk.getProjects(token, organisations, wsClient)
-          projectResponseBodies = projectResponses.map{ case (organisation,response) => (organisation, response.body)}
+          projectResponseBodies = projectResponses.map{ case (organisation,response) => (organisation, response)}
 
           organisationAndProjects <- SnykDisplay.getProjectIdList(projectResponseBodies)
           labelledProjects = SnykDisplay.labelOrganisations(organisationAndProjects)

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -39,7 +39,7 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
           organisations <- SnykDisplay.parseOrganisations(organisationResponse.body, requiredOrganisation)
 
           projectResponses <- Snyk.getProjects(token, organisations, wsClient)
-          organisationAndProjects <- SnykDisplay.getProjectIdList(projectResponses)
+          organisationAndProjects <- SnykDisplay.parseProjectResponses(projectResponses)
           labelledProjects = SnykDisplay.labelOrganisations(organisationAndProjects)
 
           vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, wsClient)

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -39,9 +39,7 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
           organisations <- SnykDisplay.parseOrganisations(organisationResponse.body, requiredOrganisation)
 
           projectResponses <- Snyk.getProjects(token, organisations, wsClient)
-          projectResponseBodies = projectResponses.map{ case (organisation,response) => (organisation, response)}
-
-          organisationAndProjects <- SnykDisplay.getProjectIdList(projectResponseBodies)
+          organisationAndProjects <- SnykDisplay.getProjectIdList(projectResponses)
           labelledProjects = SnykDisplay.labelOrganisations(organisationAndProjects)
 
           vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, wsClient)

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -16,8 +16,10 @@ import utils.attempt.PlayIntegration.attempt
 import model._
 
 class SnykController(val config: Configuration, val configraun: com.gu.configraun.models.Configuration,
-                     val authConfig: GoogleAuthConfig,
-                     val snykWsClient: WSClient)
+                     val authConfig: GoogleAuthConfig
+//                     ,
+//                     val snykWsClient: WSClient
+                     )
                     (implicit
                      val ec: ExecutionContext,
                      val wsClient: WSClient,
@@ -37,16 +39,19 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
 
           requiredOrganisation <- getSnykOrganisation
 
-          organisationResponse <- Snyk.getSnykOrganisations(token, snykWsClient)
+          organisationResponse <- Snyk.getSnykOrganisations(token, wsClient)
+//          organisationResponse <- Snyk.getSnykOrganisations(token, snykWsClient)
           organisations <- SnykDisplay.parseOrganisations(organisationResponse.body, requiredOrganisation)
 
-          projectResponses <- Snyk.getProjects(token, organisations, snykWsClient)
+          projectResponses <- Snyk.getProjects(token, organisations, wsClient)
+//          projectResponses <- Snyk.getProjects(token, organisations, snykWsClient)
           projectResponseBodies = projectResponses.map{ case (organisation,response) => (organisation, response.body)}
 
           organisationAndProjects <- SnykDisplay.getProjectIdList(projectResponseBodies)
           labelledProjects = SnykDisplay.labelOrganisations(organisationAndProjects)
 
-          vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, snykWsClient)
+          vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, wsClient)
+//          vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, snykWsClient)
           vulnerabilitiesResponseBodies = vulnerabilitiesResponse.map(a => a.body)
 
           parsedVulnerabilitiesResponse <- SnykDisplay.parseProjectVulnerabilities(vulnerabilitiesResponseBodies)

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -16,7 +16,8 @@ import utils.attempt.PlayIntegration.attempt
 import model._
 
 class SnykController(val config: Configuration, val configraun: com.gu.configraun.models.Configuration,
-                     val authConfig: GoogleAuthConfig)
+                     val authConfig: GoogleAuthConfig,
+                     val snykWsClient: WSClient)
                     (implicit
                      val ec: ExecutionContext,
                      val wsClient: WSClient,
@@ -31,18 +32,23 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
     Action.async {
       attempt {
         for {
+
           token <- getSnykToken
+
           requiredOrganisation <- getSnykOrganisation
 
-          organisationResponse <- Snyk.getSnykOrganisations(token, wsClient)
-          organisation <- SnykDisplay.getOrganisation(organisationResponse.body, requiredOrganisation)
+          organisationResponse <- Snyk.getSnykOrganisations(token, snykWsClient)
+          organisations <- SnykDisplay.parseOrganisations(organisationResponse.body, requiredOrganisation)
 
-          projectResponse <- Snyk.getProjects(token, organisation.id, wsClient)
-          projects <- SnykDisplay.getProjectIdList(projectResponse.body)
-          labelledProjects = SnykDisplay.labelOrganisations(projects, organisation)
+          projectResponses <- Snyk.getProjects(token, organisations, snykWsClient)
+          projectResponseBodies = projectResponses.map{ case (organisation,response) => (organisation, response.body)}
 
-          vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(organisation.id, projects, token, wsClient)
+          organisationAndProjects <- SnykDisplay.getProjectIdList(projectResponseBodies)
+          labelledProjects = SnykDisplay.labelOrganisations(organisationAndProjects)
+
+          vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, snykWsClient)
           vulnerabilitiesResponseBodies = vulnerabilitiesResponse.map(a => a.body)
+
           parsedVulnerabilitiesResponse <- SnykDisplay.parseProjectVulnerabilities(vulnerabilitiesResponseBodies)
 
           results = SnykDisplay.labelProjects(labelledProjects, parsedVulnerabilitiesResponse)
@@ -60,14 +66,11 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
     case Right(a:String) => Attempt.Right(SnykToken(a))
   }
 
-  def getSnykOrganisation: Attempt[SnykOrganisationName] = configraun.getAsString("/snyk/organisation") match {
+  def getSnykOrganisation: Attempt[SnykGroupId] = configraun.getAsString("/snyk/organisation") match {
     case Left(a:ConfigraunError) =>
       val failure = Failure(a.message, "Could not read Snyk organisation from aws parameter store", 500, None, Some(a.e))
       Attempt.Left(failure)
-    case Right(a:String) => Attempt.Right(SnykOrganisationName(a))
+    case Right(a:String) => Attempt.Right(SnykGroupId(a))
   }
 
 }
-
-
-

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -9,7 +9,6 @@ import play.api.mvc._
 import scala.concurrent.ExecutionContext
 import logic.SnykDisplay
 import api.Snyk
-import com.gu.configraun.Errors.ConfigraunError
 import com.gu.googleauth.GoogleAuthConfig
 import utils.attempt.{Attempt, Failure}
 import utils.attempt.PlayIntegration.attempt

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -17,8 +17,6 @@ import model._
 
 class SnykController(val config: Configuration, val configraun: com.gu.configraun.models.Configuration,
                      val authConfig: GoogleAuthConfig
-//                     ,
-//                     val snykWsClient: WSClient
                      )
                     (implicit
                      val ec: ExecutionContext,
@@ -36,22 +34,18 @@ class SnykController(val config: Configuration, val configraun: com.gu.configrau
         for {
 
           token <- getSnykToken
-
           requiredOrganisation <- getSnykOrganisation
 
           organisationResponse <- Snyk.getSnykOrganisations(token, wsClient)
-//          organisationResponse <- Snyk.getSnykOrganisations(token, snykWsClient)
           organisations <- SnykDisplay.parseOrganisations(organisationResponse.body, requiredOrganisation)
 
           projectResponses <- Snyk.getProjects(token, organisations, wsClient)
-//          projectResponses <- Snyk.getProjects(token, organisations, snykWsClient)
           projectResponseBodies = projectResponses.map{ case (organisation,response) => (organisation, response.body)}
 
           organisationAndProjects <- SnykDisplay.getProjectIdList(projectResponseBodies)
           labelledProjects = SnykDisplay.labelOrganisations(organisationAndProjects)
 
           vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, wsClient)
-//          vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, token, snykWsClient)
           vulnerabilitiesResponseBodies = vulnerabilitiesResponse.map(a => a.body)
 
           parsedVulnerabilitiesResponse <- SnykDisplay.parseProjectVulnerabilities(vulnerabilitiesResponseBodies)

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -40,12 +40,9 @@ object SnykDisplay {
   def parseJsonToOrganisationList(s: String): Attempt[List[SnykOrganisation]] =
     parseJsonToObject[List[SnykOrganisation]]("organisations", s, body => {(Json.parse(body) \ "orgs").validate[List[SnykOrganisation]]} )
 
-  def getProjectIdList(organisationAndRequestList: List[(SnykOrganisation, String)])(implicit ec: ExecutionContext): Attempt[List[((SnykOrganisation, String), List[SnykProject])]] = {
-    Attempt.labelledTraverse(organisationAndRequestList) { s =>
-      parseJsonToProjectIdList(s._2)
-    }
-  }
-
+  def getProjectIdList(organisationAndRequestList: List[(SnykOrganisation, String)])(implicit ec: ExecutionContext): Attempt[List[((SnykOrganisation, String), List[SnykProject])]] =
+    Attempt.labelledTraverse(organisationAndRequestList) { s => parseJsonToProjectIdList(s._2) }
+  
   def parseJsonToProjectIdList(s: String): Attempt[List[SnykProject]] =
     parseJsonToObject("project ids", s, body => (Json.parse(body) \ "projects").validate[List[SnykProject]] )
 

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -1,6 +1,5 @@
 package logic
 
-import com.fasterxml.jackson.core.JsonParseException
 import play.api.libs.json._
 import utils.attempt.{Attempt, Failure}
 
@@ -9,7 +8,6 @@ import model._
 import model.Serializers._
 
 import scala.util.{Success, Try}
-import scala.util.control.NonFatal
 
 object SnykDisplay {
 

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -57,7 +57,10 @@ object SnykDisplay {
   def labelOrganisations(orgAndProjects: List[((SnykOrganisation, String), List[SnykProject])]): List[SnykProject] =
     orgAndProjects.flatMap{ case ((organisation, _), projects) => projects.map(project => project.copy(organisation = Some(organisation)))}
 
-  def labelProjects(projects: List[SnykProject], responses: List[SnykProjectIssues]): List[SnykProjectIssues] = projects.zip(responses).map(a => a._2.copy(project = Some(a._1)))
+  def labelProjects(projects: List[SnykProject], responses: List[SnykProjectIssues]): List[SnykProjectIssues] =
+    projects.zip(responses).map { case (project, issues) =>
+      issues.copy(project = Some(project))
+    }
 
   def sortProjects(projects: List[SnykProjectIssues]): List[SnykProjectIssues] =
     projects.sortBy(spi => (-spi.high, -spi.medium, -spi.low, spi.project.get.name))

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -47,7 +47,7 @@ object SnykDisplay {
     parseJsonToObject("project ids", s, body => (Json.parse(body) \ "projects").validate[List[SnykProject]] )
 
   def parseProjectVulnerabilitiesBody(s: String): Attempt[SnykProjectIssues] =
-  parseJsonToObject("project vulnerabilities", s, body => Json.parse(body).validate[SnykProjectIssues])
+    parseJsonToObject("project vulnerabilities", s, body => Json.parse(body).validate[SnykProjectIssues])
 
   def parseProjectVulnerabilities(bodies: List[String])(implicit ec: ExecutionContext): Attempt[List[SnykProjectIssues]] = Attempt.traverse(bodies)(parseProjectVulnerabilitiesBody)
 
@@ -60,9 +60,7 @@ object SnykDisplay {
   def labelOrganisations(orgAndProjects: List[((SnykOrganisation, String), List[SnykProject])]): List[SnykProject] =
     orgAndProjects.flatMap{ case ((organisation, _), projects) => projects.map(project => project.copy(organisation = Some(organisation)))}
 
-  def labelProjects(projects: List[SnykProject], responses: List[SnykProjectIssues]): List[SnykProjectIssues] = {
-    projects.zip(responses).map(a => a._2.copy(project = Some(a._1)))
-  }
+  def labelProjects(projects: List[SnykProject], responses: List[SnykProjectIssues]): List[SnykProjectIssues] = projects.zip(responses).map(a => a._2.copy(project = Some(a._1)))
 
   def sortProjects(projects: List[SnykProjectIssues]): List[SnykProjectIssues] =
     projects.sortBy(spi => (-spi.high, -spi.medium, -spi.low, spi.project.get.name))

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -37,7 +37,7 @@ object SnykDisplay {
       Attempt.Left(failure)
   }
 
-  def getProjectIdList(organisationAndRequestList: List[(SnykOrganisation, String)])(implicit ec: ExecutionContext): Attempt[List[((SnykOrganisation, String), List[SnykProject])]] =
+  def parseProjectResponses(organisationAndRequestList: List[(SnykOrganisation, String)])(implicit ec: ExecutionContext): Attempt[List[((SnykOrganisation, String), List[SnykProject])]] =
     Attempt.labelledTraverse(organisationAndRequestList) { case (_, body) =>
       parseJsonToProjectIdList(body)
     }

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -37,17 +37,14 @@ object SnykDisplay {
       Attempt.Left(failure)
   }
 
-  def parseJsonToOrganisationList(s: String): Attempt[List[SnykOrganisation]] =
-    parseJsonToObject[List[SnykOrganisation]]("organisations", s, body => {(Json.parse(body) \ "orgs").validate[List[SnykOrganisation]]} )
-
   def getProjectIdList(organisationAndRequestList: List[(SnykOrganisation, String)])(implicit ec: ExecutionContext): Attempt[List[((SnykOrganisation, String), List[SnykProject])]] =
     Attempt.labelledTraverse(organisationAndRequestList) { s => parseJsonToProjectIdList(s._2) }
 
-  def parseJsonToProjectIdList(s: String): Attempt[List[SnykProject]] =
-    parseJsonToObject("project ids", s, body => (Json.parse(body) \ "projects").validate[List[SnykProject]] )
+  def parseJsonToOrganisationList(s: String): Attempt[List[SnykOrganisation]] = parseJsonToObject("organisations", s, body => {(Json.parse(body) \ "orgs").validate[List[SnykOrganisation]]} )
 
-  def parseProjectVulnerabilitiesBody(s: String): Attempt[SnykProjectIssues] =
-    parseJsonToObject("project vulnerabilities", s, body => Json.parse(body).validate[SnykProjectIssues])
+  def parseJsonToProjectIdList(s: String): Attempt[List[SnykProject]]         = parseJsonToObject("project ids", s, body => (Json.parse(body) \ "projects").validate[List[SnykProject]] )
+
+  def parseProjectVulnerabilitiesBody(s: String): Attempt[SnykProjectIssues]  = parseJsonToObject("project vulnerabilities", s, body => Json.parse(body).validate[SnykProjectIssues])
 
   def parseProjectVulnerabilities(bodies: List[String])(implicit ec: ExecutionContext): Attempt[List[SnykProjectIssues]] = Attempt.traverse(bodies)(parseProjectVulnerabilitiesBody)
 

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -14,7 +14,7 @@ object SnykDisplay {
     for {
       organisationList <- parseJsonToOrganisationList(s)
       guardianOrganisationList = organisationList filter {
-        case SnykOrganisation(_, id, Some(group)) => group.id==snykGroupId.value // && !id.equals("89877232-f84c-43af-9436-e9e0a61f640d")
+        case SnykOrganisation(_, id, Some(group)) => group.id==snykGroupId.value
         case _ => false
       }
     } yield guardianOrganisationList

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -11,7 +11,6 @@ import model.Serializers._
 object SnykDisplay {
 
   def parseOrganisations(s: String, snykGroupId: SnykGroupId)(implicit ec: ExecutionContext): Attempt[List[SnykOrganisation]] = {
-    println(snykGroupId)
     for {
       organisationList <- parseJsonToOrganisationList(s)
       guardianOrganisationList = organisationList filter {

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -14,7 +14,7 @@ object SnykDisplay {
     for {
       organisationList <- parseJsonToOrganisationList(s)
       guardianOrganisationList = organisationList filter {
-        case SnykOrganisation(_, id, Some(group)) => group.id==snykGroupId.value && !id.equals("89877232-f84c-43af-9436-e9e0a61f640d")
+        case SnykOrganisation(_, id, Some(group)) => group.id==snykGroupId.value // && !id.equals("89877232-f84c-43af-9436-e9e0a61f640d")
         case _ => false
       }
     } yield guardianOrganisationList

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -38,13 +38,18 @@ object SnykDisplay {
   }
 
   def getProjectIdList(organisationAndRequestList: List[(SnykOrganisation, String)])(implicit ec: ExecutionContext): Attempt[List[((SnykOrganisation, String), List[SnykProject])]] =
-    Attempt.labelledTraverse(organisationAndRequestList) { s => parseJsonToProjectIdList(s._2) }
+    Attempt.labelledTraverse(organisationAndRequestList) { case (_, body) =>
+      parseJsonToProjectIdList(body)
+    }
 
-  def parseJsonToOrganisationList(s: String): Attempt[List[SnykOrganisation]] = parseJsonToObject("organisations", s, body => {(Json.parse(body) \ "orgs").validate[List[SnykOrganisation]]} )
+  def parseJsonToOrganisationList(s: String): Attempt[List[SnykOrganisation]] =
+    parseJsonToObject("organisations", s, body => (Json.parse(body) \ "orgs").validate[List[SnykOrganisation]])
 
-  def parseJsonToProjectIdList(s: String): Attempt[List[SnykProject]]         = parseJsonToObject("project ids", s, body => (Json.parse(body) \ "projects").validate[List[SnykProject]] )
+  def parseJsonToProjectIdList(s: String): Attempt[List[SnykProject]] =
+    parseJsonToObject("project ids", s, body => (Json.parse(body) \ "projects").validate[List[SnykProject]])
 
-  def parseProjectVulnerabilitiesBody(s: String): Attempt[SnykProjectIssues]  = parseJsonToObject("project vulnerabilities", s, body => Json.parse(body).validate[SnykProjectIssues])
+  def parseProjectVulnerabilitiesBody(s: String): Attempt[SnykProjectIssues] =
+    parseJsonToObject("project vulnerabilities", s, body => Json.parse(body).validate[SnykProjectIssues])
 
   def parseProjectVulnerabilities(bodies: List[String])(implicit ec: ExecutionContext): Attempt[List[SnykProjectIssues]] = Attempt.traverse(bodies)(parseProjectVulnerabilitiesBody)
 

--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -7,7 +7,19 @@ object Serializers {
 
   implicit val snykErrorFormat: Reads[SnykError] = Json.reads[SnykError]
 
-  implicit val snykOrgFormat: Reads[SnykOrganisation] = Json.reads[SnykOrganisation]
+  implicit val snykGroupFormat: Reads[SnykGroup] = (
+    (JsPath \ "name").read[String]
+      and
+      (JsPath \ "id").read[String]
+    )(SnykGroup.apply _)
+
+  implicit val snykOrgFormat: Reads[SnykOrganisation] = (
+    (JsPath \ "name").read[String]
+      and
+      (JsPath \ "id").read[String]
+      and
+      (JsPath \ "group").readNullable[SnykGroup]
+    )(SnykOrganisation.apply _)
 
   implicit val snykProjectFormat: Reads[SnykProject] = (
     (JsPath \ "name").read[String]

--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -7,11 +7,7 @@ object Serializers {
 
   implicit val snykErrorFormat: Reads[SnykError] = Json.reads[SnykError]
 
-  implicit val snykGroupFormat: Reads[SnykGroup] = (
-    (JsPath \ "name").read[String]
-      and
-      (JsPath \ "id").read[String]
-    )(SnykGroup.apply _)
+  implicit val snykGroupFormat: Reads[SnykGroup] = Json.reads[SnykGroup]
 
   implicit val snykOrgFormat: Reads[SnykOrganisation] = (
     (JsPath \ "name").read[String]

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -159,7 +159,11 @@ case class SnykToken(value: String) extends AnyVal
 
 case class SnykOrganisationName(value: String) extends AnyVal
 
-case class SnykOrganisation(name: String, id: String)
+case class SnykGroupId(value: String) extends AnyVal
+
+case class SnykGroup(name: String, id: String)
+
+case class SnykOrganisation(name: String, id: String, groupOpt: Option[SnykGroup])
 
 case class SnykProject(name: String, id: String, organisation: Option[SnykOrganisation])
 

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -58,7 +58,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
 
   "find projects" - {
     val mockGoodProjectResponse = readFile("goodProjectResponse")
-    val projects = SnykDisplay.getProjectIdList(
+    val projects = SnykDisplay.parseProjectResponses(
       List(
         (
           SnykOrganisation("1111111111", "1111111111", None),
@@ -76,24 +76,24 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
 
   "fail to find project list" - {
     "bad response" in {
-      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), s"""response is not json!""")))
+      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), s"""response is not json!""")))
       projects.isFailedAttempt shouldBe true
       projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (response is not json!)"
     }
     "fail to find project id list (nice) - fails" in {
-      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
       projects.isFailedAttempt shouldBe true
     }
     "fail to find project id list (nice) - has message" in {
-      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
       projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
     }
     "fail to find project id list (not nice) - fails" in {
-      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
       projects.isFailedAttempt shouldBe true
     }
     "fail to find project id list (not nice) - has message" in {
-      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
       projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
     }
   }

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -1,6 +1,6 @@
 package logic
 
-import model.{SnykIssue, _}
+import model.{SnykIssue, SnykOrganisation, _}
 import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.AttemptValues
 
@@ -13,31 +13,122 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
   private val mockBadResponseWithoutMessage =
     s"""{"toughluck": "no use"}"""
 
-  "find organisation" in {
+
+  "parse single organisation" - {
+    "null group" in {
+      val mockGoodOrganisationResponse =
+        s"""
+           |{
+           |  "orgs": [
+           |    {
+           |      "name": "guardian-org-1",
+           |      "id": "id1",
+           |      "group": null
+           |    }
+           |  ]
+           |}
+           |""".stripMargin
+
+      val organisationAttempt = SnykDisplay.parseJsonToOrganisationList(mockGoodOrganisationResponse)
+      organisationAttempt.value() shouldBe List(SnykOrganisation("guardian-org-1", "id1", None))
+
+    }
+
+    "no group" in {
+      val mockGoodOrganisationResponse =
+        s"""
+           |{
+           |  "orgs": [
+           |    {
+           |      "name": "guardian-org-1",
+           |      "id": "id1"
+           |    }
+           |  ]
+           |}
+           |""".stripMargin
+
+      val organisationAttempt = SnykDisplay.parseJsonToOrganisationList(mockGoodOrganisationResponse)
+      organisationAttempt.value shouldBe List(SnykOrganisation("guardian-org-1", "id1", None))
+    }
+
+    "real group" in {
+      val mockGoodOrganisationResponse =
+        s"""
+           |{
+           |  "orgs": [
+           |    {
+           |      "name": "guardian-org-1",
+           |      "id": "id1",
+           |      "group": {
+           |        "name": "guardian-org-2",
+           |        "id": "id2"
+           |      }
+           |    }
+           |  ]
+           |}
+           |""".stripMargin
+
+      val organisationAttempt = SnykDisplay.parseJsonToOrganisationList(mockGoodOrganisationResponse)
+      organisationAttempt.value shouldBe List(SnykOrganisation("guardian-org-1", "id1", Some(SnykGroup("guardian-org-2", "id2"))))
+    }
+  }
+
+  "find organisations" in {
     val mockGoodOrganisationResponse = s"""
-      |{"orgs":
-      |[
-      |  {"name": "guardian", "id": "1111111111" },
-      |  {"name": "nottheguardian", "id": "9999999999"}
-      |]
-      |}""".stripMargin
-    val organisation = SnykDisplay.getOrganisation(mockGoodOrganisationResponse, SnykOrganisationName("guardian"))
-    organisation.value shouldBe SnykOrganisation("guardian", "1111111111")
+      |{
+      |  "orgs": [
+      |    {
+      |      "name": "guardian-org-1",
+      |      "id": "id1",
+      |      "group": {
+      |        "name": "guardian",
+      |        "id": "id0"
+      |      }
+      |    },
+      |    {
+      |      "name": "guardian-org-2",
+      |      "id": "id2",
+      |      "group": {
+      |        "name": "guardian",
+      |        "id": "id0"
+      |      }
+      |    },
+      |    {
+      |      "name": "not-guardian-org-3",
+      |      "id": "id3",
+      |      "group": null
+      |    },
+      |    {
+      |      "name": "not-guardian-org-4",
+      |      "id": "id2",
+      |      "group": {
+      |        "name": "Someone Else",
+      |        "id": "id4"
+      |      }
+      |    }
+      |  ]
+      |}
+""".stripMargin
+    val organisation = SnykDisplay.parseOrganisations(mockGoodOrganisationResponse, SnykGroupId("id0"))
+    organisation.value shouldBe List(
+      SnykOrganisation("guardian-org-1", "id1", Some(SnykGroup("guardian", "id0"))),
+      SnykOrganisation("guardian-org-2", "id2", Some(SnykGroup("guardian", "id0")))
+    )
   }
 
   "fail to find organisation" - {
     "bad response" in {
-      val organisationId = SnykDisplay.getOrganisation(s"""response is not json!""", SnykOrganisationName("guardian"))
+      val organisationId = SnykDisplay.parseOrganisations(s"""response is not json!""", SnykGroupId("guardian"))
       organisationId.isFailedAttempt shouldBe true
       organisationId.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (response is not json!)"
     }
     "message received in response" in {
-      val organisationId = SnykDisplay.getOrganisation(mockBadResponseWithMessage, SnykOrganisationName("guardian"))
+      val organisationId = SnykDisplay.parseOrganisations(mockBadResponseWithMessage, SnykGroupId("guardian"))
       organisationId.isFailedAttempt shouldBe true
       organisationId.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
     }
     "message not received in response" in {
-      val organisationId = SnykDisplay.getOrganisation(mockBadResponseWithoutMessage, SnykOrganisationName("guardian"))
+      val organisationId = SnykDisplay.parseOrganisations(mockBadResponseWithoutMessage, SnykGroupId("guardian"))
       organisationId.isFailedAttempt shouldBe true
       organisationId.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
     }
@@ -63,124 +154,135 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
          |  ]
          |}
      """.stripMargin
+    val projects = SnykDisplay.getProjectIdList(
+      List(
+        (
+          SnykOrganisation("1111111111", "1111111111", None),
+          mockGoodProjectResponse
+        )
+      )
+    )
     "find project 1 in project list" in {
-      val projects = SnykDisplay.getProjectIdList(mockGoodProjectResponse)
-      projects.value().exists(p => p.name == "project1") shouldBe true
+      projects.value.head._2.exists(p => p.name == "project1") shouldBe true
     }
     "find project 2 in project list" in {
-      val projects = SnykDisplay.getProjectIdList(mockGoodProjectResponse)
-      projects.value().exists(p => p.name == "project2") shouldBe true
+      projects.value.head._2.exists(p => p.name == "project2") shouldBe true
     }
   }
 
   "fail to find project list" - {
     "bad response" in {
-      val projects = SnykDisplay.getProjectIdList(s"""response is not json!""")
+      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), s"""response is not json!""")))
       projects.isFailedAttempt shouldBe true
       projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (response is not json!)"
     }
     "fail to find project id list (nice) - fails" in {
-      val projects = SnykDisplay.getProjectIdList(mockBadResponseWithMessage)
+      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
       projects.isFailedAttempt shouldBe true
     }
     "fail to find project id list (nice) - has message" in {
-      val projects = SnykDisplay.getProjectIdList(mockBadResponseWithMessage)
+      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
       projects.getFailedAttempt.failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
     }
     "fail to find project id list (not nice) - fails" in {
-      val projects = SnykDisplay.getProjectIdList(mockBadResponseWithoutMessage)
+      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
       projects.isFailedAttempt shouldBe true
     }
     "fail to find project id list (not nice) - has message" in {
-      val projects = SnykDisplay.getProjectIdList(mockBadResponseWithoutMessage)
+      val projects = SnykDisplay.getProjectIdList(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
       projects.getFailedAttempt.failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
     }
   }
 
   "find vulnerability list" - {
     "find ok for empty list" in {
-      val mockGoodAndNotVulnerableResponse = s"""
-         |{
-         |  "ok": true,
-         |  "issues": {
-         |    "vulnerabilities": [],
-         |    "licenses": []
-         |  },
-         |  "dependencyCount": 0,
-         |  "packageManager": "sbt"
-         |}
+      val mockGoodAndNotVulnerableResponse =
+        s"""
+           |{
+           |  "ok": true,
+           |  "issues": {
+           |    "vulnerabilities": [],
+           |    "licenses": []
+           |  },
+           |  "dependencyCount": 0,
+           |  "packageManager": "sbt"
+           |}
      """.stripMargin
       val projects = SnykDisplay.parseProjectVulnerabilities(List(mockGoodAndNotVulnerableResponse))
       projects.value().head.ok shouldBe true
     }
+  }
 
-    val mockGoodButVulnerableResponse = s"""
-       |{
-       |  "ok": false,
-       |  "issues": {
-       |    "vulnerabilities": [
-       |      {
-       |        "id": "4444444444",
-       |        "url": "https://snyk.io/vuln/4444444444",
-       |        "title": "The Title",
-       |        "type": "vuln",
-       |        "description": "The description",
-       |        "from": [
-       |          "from1",
-       |          "from2",
-       |          "from3"
-       |        ],
-       |        "package": "The package",
-       |        "version": "The version",
-       |        "severity": "high",
-       |        "language": "The language",
-       |        "packageManager": "the package manager",
-       |        "semver": {
-       |          "unaffected": ">=the version",
-       |          "vulnerable": "<the version"
-       |        },
-       |        "publicationTime": "2015-11-06T02:09:36.182Z",
-       |        "disclosureTime": "2015-11-03T07:15:12.900Z",
-       |        "isUpgradable": true,
-       |        "isPatchable": true,
-       |        "identifiers": {
-       |          "CVE": [],
-       |          "CWE": [],
-       |          "NSP": 57,
-       |          "ALTERNATIVE": [
-       |            "5555555555"
-       |          ]
-       |        },
-       |        "credit": [
-       |          "Mickey Mouse"
-       |        ],
-       |        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-       |        "cvssScore": 7.5,
-       |        "patches": [
-       |          {
-       |            "id": "6666666666",
-       |            "urls": [
-       |              "https://example.com/6666666666.patch"
-       |            ],
-       |            "version": "<the version >=minversion",
-       |            "comments": [
-       |              "https://example.com/7777777777.patch"
-       |            ],
-       |            "modificationTime": "2015-11-17T09:29:10.000Z"
-       |          }
-       |        ],
-       |        "upgradePath": [
-       |          true,
-       |          "the first upgrade",
-       |          "the second upgrade"
-       |        ]
-       |      }
-       |    ],
-       |    "licenses": []
-       |  },
-       |  "dependencyCount": 0,
-       |  "packageManager": "the package manager"
-       |}
+  "find results from good vulnerability response" - {
+
+    val mockGoodButVulnerableResponse =
+      s"""
+         |{
+         |  "ok": false,
+         |  "issues": {
+         |    "vulnerabilities": [
+         |      {
+         |        "id": "4444444444",
+         |        "url": "https://snyk.io/vuln/4444444444",
+         |        "title": "The Title",
+         |        "type": "vuln",
+         |        "description": "The description",
+         |        "from": [
+         |          "from1",
+         |          "from2",
+         |          "from3"
+         |        ],
+         |        "package": "The package",
+         |        "version": "The version",
+         |        "severity": "high",
+         |        "language": "The language",
+         |        "packageManager": "the package manager",
+         |        "semver": {
+         |          "unaffected": ">=the version",
+         |          "vulnerable": "<the version"
+         |        },
+         |        "publicationTime": "2015-11-06T02:09:36.182Z",
+         |        "disclosureTime": "2015-11-03T07:15:12.900Z",
+         |        "isUpgradable": true,
+         |        "isPatchable": true,
+         |        "identifiers": {
+         |          "CVE": [],
+         |          "CWE": [],
+         |          "NSP": 57,
+         |          "ALTERNATIVE": [
+         |            "5555555555"
+         |          ]
+         |        },
+         |        "credit": [
+         |          "Mickey Mouse"
+         |        ],
+         |        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+         |        "cvssScore": 7.5,
+         |        "patches": [
+         |          {
+         |            "id": "6666666666",
+         |            "urls": [
+         |              "https://example.com/6666666666.patch"
+         |            ],
+         |            "version": "<the version >=minversion",
+         |            "comments": [
+         |              "https://example.com/7777777777.patch"
+         |            ],
+         |            "modificationTime": "2015-11-17T09:29:10.000Z"
+         |          }
+         |        ],
+         |        "upgradePath": [
+         |          true,
+         |          "the first upgrade",
+         |          "the second upgrade"
+         |        ]
+         |      }
+         |    ],
+         |    "licenses": []
+         |  },
+         |  "dependencyCount": 0,
+         |  "packageManager": "the package manager"
+         |}
      """.stripMargin
 
 
@@ -227,26 +329,30 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
   }
 
   "label organisation" - {
-    val goodOrganisation = SnykOrganisation("name0", "id0")
+    val goodOrganisation = SnykOrganisation("name0", "id0", None)
     val goodProjects = List(
-      SnykProject("name1", "id1", None),
-      SnykProject("name2", "id2", None)
+      (goodOrganisation,
+        List(
+          SnykProject("name1", "id1", None),
+          SnykProject("name2", "id2", None)
+        )
+      )
     )
 
     "label organisation - first id" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects, goodOrganisation)
+      val results = SnykDisplay.labelOrganisations(goodProjects)
       results.head.organisation.get.id shouldBe "id0"
     }
     "label organisation - first name" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects, goodOrganisation)
+      val results = SnykDisplay.labelOrganisations(goodProjects)
       results.head.organisation.get.name shouldBe "name0"
     }
     "label organisation - second id" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects, goodOrganisation)
+      val results = SnykDisplay.labelOrganisations(goodProjects)
       results.tail.head.organisation.get.id shouldBe "id0"
     }
     "label organisation - second name" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects, goodOrganisation)
+      val results = SnykDisplay.labelOrganisations(goodProjects)
       results.tail.head.organisation.get.name shouldBe "name0"
     }
   }
@@ -285,10 +391,10 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
 
   "sort projects" - {
     "All equal except number of high risk issues" in {
-      val sortedProjects = SnykDisplay.sortProjects(
+      SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),
@@ -297,7 +403,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),
@@ -310,10 +416,10 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
       ).map(spi => spi.project.get.id) shouldBe List[String]("a", "b")
     }
     "All equal except number of medium risk issues" in {
-      val sortedProjects = SnykDisplay.sortProjects(
+      SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),
@@ -322,7 +428,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),
@@ -335,10 +441,10 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
       ).map(spi => spi.project.get.id) shouldBe List[String]("a", "b")
     }
     "All equal except number of low risk issues" in {
-      val sortedProjects = SnykDisplay.sortProjects(
+      SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),
@@ -347,7 +453,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),
@@ -360,10 +466,10 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
       ).map(spi => spi.project.get.id) shouldBe List[String]("a", "b")
     }
     "All equal except name" in {
-      val sortedProjects = SnykDisplay.sortProjects(
+      SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("Y", "b", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("Y", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),
@@ -372,7 +478,7 @@ class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian")))),
+            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
             ok = true,
             Set(
               SnykIssue("Issue1", "1", "high"),

--- a/hq/test/resources/logic/SnykDisplayTest/badResponseWithMessage.json
+++ b/hq/test/resources/logic/SnykDisplayTest/badResponseWithMessage.json
@@ -1,0 +1,1 @@
+{"error": "some nice error"}

--- a/hq/test/resources/logic/SnykDisplayTest/badResponseWithoutMessage.json
+++ b/hq/test/resources/logic/SnykDisplayTest/badResponseWithoutMessage.json
@@ -1,0 +1,1 @@
+{"toughluck": "no use"}

--- a/hq/test/resources/logic/SnykDisplayTest/goodAndNotVulnerableResponse.json
+++ b/hq/test/resources/logic/SnykDisplayTest/goodAndNotVulnerableResponse.json
@@ -1,0 +1,9 @@
+{
+  "ok": true,
+  "issues": {
+    "vulnerabilities": [],
+    "licenses": []
+  },
+  "dependencyCount": 0,
+  "packageManager": "sbt"
+}

--- a/hq/test/resources/logic/SnykDisplayTest/goodButVulnerableResponse.json
+++ b/hq/test/resources/logic/SnykDisplayTest/goodButVulnerableResponse.json
@@ -1,0 +1,66 @@
+{
+  "ok": false,
+  "issues": {
+    "vulnerabilities": [
+      {
+        "id": "4444444444",
+        "url": "https://snyk.io/vuln/4444444444",
+        "title": "The Title",
+        "type": "vuln",
+        "description": "The description",
+        "from": [
+          "from1",
+          "from2",
+          "from3"
+        ],
+        "package": "The package",
+        "version": "The version",
+        "severity": "high",
+        "language": "The language",
+        "packageManager": "the package manager",
+        "semver": {
+          "unaffected": ">=the version",
+          "vulnerable": "<the version"
+        },
+        "publicationTime": "2015-11-06T02:09:36.182Z",
+        "disclosureTime": "2015-11-03T07:15:12.900Z",
+        "isUpgradable": true,
+        "isPatchable": true,
+        "identifiers": {
+          "CVE": [],
+          "CWE": [],
+          "NSP": 57,
+          "ALTERNATIVE": [
+            "5555555555"
+          ]
+        },
+        "credit": [
+          "Mickey Mouse"
+        ],
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "cvssScore": 7.5,
+        "patches": [
+          {
+            "id": "6666666666",
+            "urls": [
+              "https://example.com/6666666666.patch"
+            ],
+            "version": "<the version >=minversion",
+            "comments": [
+              "https://example.com/7777777777.patch"
+            ],
+            "modificationTime": "2015-11-17T09:29:10.000Z"
+          }
+        ],
+        "upgradePath": [
+          true,
+          "the first upgrade",
+          "the second upgrade"
+        ]
+      }
+    ],
+    "licenses": []
+  },
+  "dependencyCount": 0,
+  "packageManager": "the package manager"
+}

--- a/hq/test/resources/logic/SnykDisplayTest/goodOrganisationResponse.json
+++ b/hq/test/resources/logic/SnykDisplayTest/goodOrganisationResponse.json
@@ -1,0 +1,33 @@
+{
+  "orgs": [
+    {
+      "name": "guardian-org-1",
+      "id": "id1",
+      "group": {
+        "name": "guardian",
+        "id": "id0"
+      }
+    },
+    {
+      "name": "guardian-org-2",
+      "id": "id2",
+      "group": {
+        "name": "guardian",
+        "id": "id0"
+      }
+    },
+    {
+      "name": "not-guardian-org-3",
+      "id": "id3",
+      "group": null
+    },
+    {
+      "name": "not-guardian-org-4",
+      "id": "id2",
+      "group": {
+        "name": "Someone Else",
+        "id": "id4"
+      }
+    }
+  ]
+}

--- a/hq/test/resources/logic/SnykDisplayTest/goodProjectResponse.json
+++ b/hq/test/resources/logic/SnykDisplayTest/goodProjectResponse.json
@@ -1,0 +1,16 @@
+{
+  "org": {
+    "name": "guardian",
+    "id": "1111111111"
+  },
+  "projects": [
+    {
+      "name": "project1",
+      "id": "2222222222"
+    },
+    {
+      "name": "project2",
+      "id": "3333333333"
+    }
+  ]
+}

--- a/hq/test/resources/logic/SnykDisplayTest/nogroup.json
+++ b/hq/test/resources/logic/SnykDisplayTest/nogroup.json
@@ -1,0 +1,8 @@
+{
+  "orgs": [
+    {
+      "name": "guardian-org-1",
+      "id": "id1"
+    }
+  ]
+}

--- a/hq/test/resources/logic/SnykDisplayTest/nullgroup.json
+++ b/hq/test/resources/logic/SnykDisplayTest/nullgroup.json
@@ -1,0 +1,9 @@
+{
+  "orgs": [
+    {
+      "name": "guardian-org-1",
+      "id": "id1",
+      "group": null
+    }
+  ]
+}

--- a/hq/test/resources/logic/SnykDisplayTest/realgroup.json
+++ b/hq/test/resources/logic/SnykDisplayTest/realgroup.json
@@ -1,0 +1,12 @@
+{
+  "orgs": [
+    {
+      "name": "guardian-org-1",
+      "id": "id1",
+      "group": {
+        "name": "guardian-org-2",
+        "id": "id2"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,10 @@
     "linter-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prettier": "prettier -o --write './**/*.{js,css}'",
     "sass-lint": "sass-lint -v -q hq/public/stylesheets/*.css",
-    "snyk-test": "PATH=.:$PATH snyk test --debug --org=guardian --json --file=build.sbt",
-    "snyk-monitor": "PATH=.:$PATH snyk monitor --debug --org=guardian --file=build.sbt"
+    "not-master": "test \"$BRANCH_NAME\" != \"master\" && echo \"BRANCH_NAME variable is '$BRANCH_NAME', not master\" ",
+    "snyk-test": "PATH=$(pwd):$PATH snyk test --debug --org=guardian-cuu --json --file=build.sbt ",
+    "snyk-test-master": "npm run not-master --silent || npm run snyk-test --silent ",
+    "snyk-monitor": "PATH=$(pwd):$PATH snyk monitor --debug --org=guardian-cuu --file=build.sbt ",
+    "snyk-monitor-master": "npm run not-master --silent || npm run snyk-monitor --silent "
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "prettier": "prettier -o --write './**/*.{js,css}'",
     "sass-lint": "sass-lint -v -q hq/public/stylesheets/*.css",
     "not-master": "test \"$BRANCH_NAME\" != \"master\" && echo \"BRANCH_NAME variable is '$BRANCH_NAME', not master\" ",
-    "snyk-test": "PATH=$(pwd):$PATH snyk test --debug --org=guardian-cuu --json --file=build.sbt ",
+    "snyk-test": "PATH=$(pwd):$PATH snyk test --debug --org=guardian-security --json --file=build.sbt ",
     "snyk-test-master": "npm run not-master --silent || npm run snyk-test --silent ",
-    "snyk-monitor": "PATH=$(pwd):$PATH snyk monitor --debug --org=guardian-cuu --file=build.sbt ",
+    "snyk-monitor": "PATH=$(pwd):$PATH snyk monitor --debug --org=guardian-security --file=build.sbt ",
     "snyk-monitor-master": "npm run not-master --silent || npm run snyk-monitor --silent "
   }
 }


### PR DESCRIPTION
## What does this change?

Calls the Snyk API and correctly parses the new form of response (groups).

## What is the value of this?

We have re-organised our Snyk accounts.  This change handles the resulting change in API responses.
It also handles error cases much better.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

## Any additional notes?

The token in ssm needs to be changed, as does the the organisation, which now takes the parent group id.