### PR TITLE
Display AWS Inspector results

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-support" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-inspector" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",

--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -42,6 +42,9 @@ Resources:
             - iam:GenerateCredentialReport
             - iam:GetCredentialReport
             - cloudformation:DescribeStacks
+            # get AWS inspector results
+            - inspector:List*
+            - inspector:Describe*
 
 Outputs:
   SecurityHQRole:

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -61,6 +61,7 @@ class AppComponents(context: Context)
     new HQController(configuration, cacheService, googleAuthConfig),
     new SecurityGroupsController(configuration, cacheService, googleAuthConfig),
     new SnykController(configuration, configraun, googleAuthConfig),
+    new InspectorController(configuration, googleAuthConfig),
     new AuthController(environment, configuration, googleAuthConfig),
     new UtilityController(),
     assets

--- a/hq/app/aws/inspector/Inspector.scala
+++ b/hq/app/aws/inspector/Inspector.scala
@@ -1,0 +1,41 @@
+package aws.inspector
+
+import aws.AWS
+import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import com.amazonaws.auth.AWSCredentialsProviderChain
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.inspector.model._
+import com.amazonaws.services.inspector.{AmazonInspectorAsync, AmazonInspectorAsyncClientBuilder}
+import logic.InspectorResults._
+import model.{AwsAccount, InspectorAssessmentRun}
+import org.joda.time.DateTime
+import utils.attempt.Attempt
+
+import collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+
+object Inspector {
+  def client(auth: AWSCredentialsProviderChain, region: Regions): AmazonInspectorAsync = {
+    AmazonInspectorAsyncClientBuilder.standard()
+      .withCredentials(auth)
+      .withRegion(region)
+      .build()
+  }
+
+  def client(awsAccount: AwsAccount, region: Regions): AmazonInspectorAsync = {
+    val auth = AWS.credentialsProvider(awsAccount)
+    client(auth, region)
+  }
+
+  def listInspectorRuns(client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[String]] = {
+    val request = new ListAssessmentRunsRequest()
+    handleAWSErrs(awsToScala(client.listAssessmentRunsAsync)(request)).map(parseListAssessmentRunsResult)
+  }
+
+  def describeInspectorRuns(assessmentRunArns: List[String], client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
+    val request = new DescribeAssessmentRunsRequest()
+      .withAssessmentRunArns(assessmentRunArns.asJava)
+    handleAWSErrs(awsToScala(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
+  }
+}

--- a/hq/app/aws/inspector/Inspector.scala
+++ b/hq/app/aws/inspector/Inspector.scala
@@ -35,9 +35,14 @@ object Inspector {
   }
 
   def describeInspectorRuns(assessmentRunArns: List[String], client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
-    val request = new DescribeAssessmentRunsRequest()
-      .withAssessmentRunArns(assessmentRunArns.asJava)
-    handleAWSErrs(awsToScala(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
+    if (assessmentRunArns.isEmpty) {
+      // empty assessmentRunArns throws an exception, so we handle that here
+      Attempt.Right(Nil)
+    } else {
+      val request = new DescribeAssessmentRunsRequest()
+        .withAssessmentRunArns(assessmentRunArns.asJava)
+      handleAWSErrs(awsToScala(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
+    }
   }
 
   def inspectorRuns(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {

--- a/hq/app/controllers/InspectorController.scala
+++ b/hq/app/controllers/InspectorController.scala
@@ -1,0 +1,43 @@
+package controllers
+
+import auth.SecurityHQAuthActions
+import aws.AWS
+import aws.inspector.Inspector
+import com.amazonaws.regions.Regions
+import com.gu.googleauth.GoogleAuthConfig
+import config.Config
+import logic.InspectorResults
+import play.api.Configuration
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+import utils.attempt.PlayIntegration.attempt
+
+import scala.concurrent.ExecutionContext
+
+class InspectorController(val config: Configuration,
+                          val authConfig: GoogleAuthConfig)
+                         (implicit
+                          val ec: ExecutionContext,
+                          val wsClient: WSClient,
+                          val bodyParser: BodyParser[AnyContent],
+                          val controllerComponents: ControllerComponents,
+                          val assetsFinder: AssetsFinder)
+  extends BaseController with SecurityHQAuthActions
+{
+  // hard-coded for now
+  val region = Regions.EU_WEST_1
+
+  private val accounts = Config.getAwsAccounts(config)
+
+  def inspectorAccount(accountId: String) = authAction.async {
+    attempt {
+      for {
+        account <- AWS.lookupAccount(accountId, accounts)
+        inspectorClient = Inspector.client(account, Regions.EU_WEST_1)
+        inspectorRunArns <- Inspector.listInspectorRuns(inspectorClient)
+        assessmentRuns <- Inspector.describeInspectorRuns(inspectorRunArns, inspectorClient)
+        processedAssessmentRuns = InspectorResults.relevantRuns(assessmentRuns)
+      } yield Ok(views.html.inspector.inspectorAccount(processedAssessmentRuns, account))
+    }
+  }
+}

--- a/hq/app/controllers/InspectorController.scala
+++ b/hq/app/controllers/InspectorController.scala
@@ -6,7 +6,6 @@ import aws.inspector.Inspector
 import com.amazonaws.regions.Regions
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
-import logic.InspectorResults
 import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -33,7 +32,7 @@ class InspectorController(val config: Configuration,
   def inspector = authAction.async {
     attempt {
       for {
-        accountAssessmentRuns <- Attempt.labelledTraverse(accounts)(Inspector.inspectorRuns)
+        accountAssessmentRuns <- Attempt.labelledTaverseWithFailures(accounts)(Inspector.inspectorRuns)
       } yield Ok(views.html.inspector.inspector(accountAssessmentRuns))
     }
   }

--- a/hq/app/controllers/InspectorController.scala
+++ b/hq/app/controllers/InspectorController.scala
@@ -6,6 +6,7 @@ import aws.inspector.Inspector
 import com.amazonaws.regions.Regions
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
+import logic.InspectorResults
 import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -33,7 +34,8 @@ class InspectorController(val config: Configuration,
     attempt {
       for {
         accountAssessmentRuns <- Attempt.labelledTaverseWithFailures(accounts)(Inspector.inspectorRuns)
-      } yield Ok(views.html.inspector.inspector(accountAssessmentRuns))
+        sorted = InspectorResults.sortAccountResults(accountAssessmentRuns)
+      } yield Ok(views.html.inspector.inspector(sorted))
     }
   }
 

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 
 object InspectorResults {
   private val tagMatch = "[\\w\\-_\\.]"
-  val RunNameMatch = s"AWSInspection-($tagMatch+)-($tagMatch+)-($tagMatch+)-[\\d]+".r
+  val RunNameMatch = s"AWSInspection-($tagMatch+)--($tagMatch+)--($tagMatch+)--[\\d]+".r
 
   def appId(assessmentRunName: String): (String, String, String) = {
     assessmentRunName match {

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -83,4 +83,8 @@ object InspectorResults {
       findings.get("Informational").map("Informational" -> _)
     ).flatten ++ (findings - "High" - "Medium" - "Low" - "Informational").toList
   }
+
+  def totalFindings(key: String, assessmentRuns: List[InspectorAssessmentRun]): Int = {
+    assessmentRuns.map(_.findingCounts.getOrElse(key, 0)).sum
+  }
 }

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 
 object InspectorResults {
   private val tagMatch = "[\\w\\-_\\.]"
-  val RunNameMatch = s"AWSInspection-($tagMatch+)--($tagMatch+)--($tagMatch+)--[\\d]+".r
+  val RunNameMatch = s"AWSInspection--($tagMatch+)--($tagMatch+)--($tagMatch+)-[\\d]+".r
 
   def appId(assessmentRunName: String): (String, String, String) = {
     assessmentRunName match {

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -3,6 +3,7 @@ package logic
 import com.amazonaws.services.inspector.model.{AssessmentRun, DescribeAssessmentRunsResult, _}
 import model.InspectorAssessmentRun
 import org.joda.time.DateTime
+import utils.attempt.FailedAttempt
 
 import scala.collection.JavaConverters._
 
@@ -64,6 +65,19 @@ object InspectorResults {
       dataCollected = assessmentRun.getDataCollected,
       findingCounts = assessmentRun.getFindingCounts.asScala.toMap.mapValues(_.toInt)
     )
+  }
+
+  def sortAccountResults[A, B](accountResults: List[(A, scala.Either[B, List[InspectorAssessmentRun]])]): List[(A, scala.Either[B, List[InspectorAssessmentRun]])] = {
+    accountResults.sortBy {
+      case (_, Right(assessmentRuns)) =>
+        ( 0 - totalFindings("High", assessmentRuns)
+        , 0 - totalFindings("Medium", assessmentRuns)
+        , 0 - totalFindings("Low", assessmentRuns)
+        , 0 - totalFindings("Info", assessmentRuns)
+        )
+      case (_, Left(_)) =>
+        (1, 1, 1, 1)
+    }
   }
 
   def levelColour(assessmentFindings: Map[String, Int]): String = {

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -74,4 +74,13 @@ object InspectorResults {
 
     high.orElse(medium).orElse(low).orElse(info).getOrElse("grey")
   }
+
+  def sortedFindings(findings: Map[String, Int]): List[(String, Int)] = {
+    List(
+      findings.get("High").map("High" -> _),
+      findings.get("Medium").map("Medium" -> _),
+      findings.get("Low").map("Low" -> _),
+      findings.get("Informational").map("Informational" -> _)
+    ).flatten ++ (findings - "High" - "Medium" - "Low" - "Informational").toList
+  }
 }

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -70,10 +70,10 @@ object InspectorResults {
   def sortAccountResults[A, B](accountResults: List[(A, scala.Either[B, List[InspectorAssessmentRun]])]): List[(A, scala.Either[B, List[InspectorAssessmentRun]])] = {
     accountResults.sortBy {
       case (_, Right(assessmentRuns)) =>
-        ( 0 - totalFindings("High", assessmentRuns)
-        , 0 - totalFindings("Medium", assessmentRuns)
-        , 0 - totalFindings("Low", assessmentRuns)
-        , 0 - totalFindings("Info", assessmentRuns)
+        ( 0 - levelFindings("High", assessmentRuns)
+        , 0 - levelFindings("Medium", assessmentRuns)
+        , 0 - levelFindings("Low", assessmentRuns)
+        , 0 - levelFindings("Info", assessmentRuns)
         )
       case (_, Left(_)) =>
         (1, 1, 1, 1)
@@ -98,7 +98,11 @@ object InspectorResults {
     ).flatten ++ (findings - "High" - "Medium" - "Low" - "Informational").toList
   }
 
-  def totalFindings(key: String, assessmentRuns: List[InspectorAssessmentRun]): Int = {
-    assessmentRuns.map(_.findingCounts.getOrElse(key, 0)).sum
+  def levelFindings(level: String, assessmentRuns: List[InspectorAssessmentRun]): Int = {
+    assessmentRuns.map(_.findingCounts.getOrElse(level, 0)).sum
+  }
+
+  def totalFindings(assessmentRuns: List[InspectorAssessmentRun]): Int = {
+    assessmentRuns.flatMap(_.findingCounts.values).sum
   }
 }

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -1,0 +1,62 @@
+package logic
+
+import com.amazonaws.services.inspector.model.{AssessmentRun, DescribeAssessmentRunsResult, _}
+import model.InspectorAssessmentRun
+import org.joda.time.DateTime
+
+import scala.collection.JavaConverters._
+
+
+object InspectorResults {
+  private val tagMatch = "[\\w\\-_\\.]"
+  val RunNameMatch = s"AWSInspection-($tagMatch+)-($tagMatch+)-($tagMatch+)-[\\d]+".r
+
+  def appId(assessmentRunName: String): (String, String, String) = {
+    assessmentRunName match {
+      case RunNameMatch(stack, app, stage) =>
+        (stack, app, stage)
+      case _ =>
+        ("", assessmentRunName, "")
+    }
+  }
+
+  /**
+    * Take latest results for each App ID
+    *
+    * Sorts results by findings. TODO: prioritize high importance findings when keys are known.
+    */
+  def relevantRuns(runs: List[InspectorAssessmentRun]): List[((String, String, String), InspectorAssessmentRun)] = {
+    val result = runs.groupBy(_.appId).mapValues(_.maxBy(_.completedAt.getMillis))
+    result.toList.sortBy { case (_, assessmentRun) =>
+      // descending
+      0 - assessmentRun.findingCounts.values.sum
+    }
+  }
+
+  def parseListAssessmentRunsResult(result: ListAssessmentRunsResult): List[String] = {
+    result.getAssessmentRunArns.asScala.toList
+  }
+
+  def parseDescribeAssessmentRunsResult(result: DescribeAssessmentRunsResult): List[InspectorAssessmentRun] = {
+    result.getAssessmentRuns.asScala.toList.map(parseAssessmentRun)
+  }
+
+  private[logic] def parseAssessmentRun(assessmentRun: AssessmentRun): InspectorAssessmentRun = {
+    InspectorAssessmentRun(
+      arn = assessmentRun.getArn,
+      name = assessmentRun.getName,
+      appId = InspectorResults.appId(assessmentRun.getName),
+      assessmentTemplateArn = assessmentRun.getAssessmentTemplateArn,
+      state = assessmentRun.getState,
+      durationInSeconds = assessmentRun.getDurationInSeconds,
+      rulesPackageArns = assessmentRun.getRulesPackageArns.asScala.toList,
+      userAttributesForFindings = assessmentRun.getUserAttributesForFindings.asScala.toList.map(attr => (attr.getKey, attr.getValue)),
+      createdAt = new DateTime(assessmentRun.getCreatedAt),
+      startedAt = new DateTime(assessmentRun.getStartedAt),
+      completedAt = new DateTime(assessmentRun.getCompletedAt),
+      stateChangedAt = new DateTime(assessmentRun.getStateChangedAt),
+      dataCollected = assessmentRun.getDataCollected,
+      findingCounts = assessmentRun.getFindingCounts.asScala.toMap.mapValues(_.toInt)
+    )
+  }
+}

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -26,9 +26,9 @@ object InspectorResults {
     * Sorts results descending by findings (first by High, then Medium, Low, Informational).
     * Breaks remaining ties on the total number of results.
     */
-  def relevantRuns(runs: List[InspectorAssessmentRun]): List[((String, String, String), InspectorAssessmentRun)] = {
-    val result = runs.groupBy(_.appId).mapValues(_.maxBy(_.completedAt.getMillis))
-    result.toList.sortBy { case (_, assessmentRun) =>
+  def relevantRuns(runs: List[InspectorAssessmentRun]): List[InspectorAssessmentRun] = {
+    val result = runs.groupBy(_.appId).mapValues(_.maxBy(_.completedAt.getMillis)).values
+    result.toList.sortBy { assessmentRun =>
       // descending
       ( assessmentRun.findingCounts.get("High").map(_ * -1)
       , assessmentRun.findingCounts.get("Medium").map(_ * -1)

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 
 object InspectorResults {
   private val tagMatch = "[\\w\\-_\\.]"
-  val RunNameMatch = s"AWSInspection--($tagMatch+)--($tagMatch+)--($tagMatch+)-[\\d]+".r
+  val RunNameMatch = s"AWSInspection--($tagMatch+)--($tagMatch+)--($tagMatch+)--[\\d]+".r
 
   def appId(assessmentRunName: String): (String, String, String) = {
     assessmentRunName match {

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -172,3 +172,20 @@ case class SnykProjectIssues(project: Option[SnykProject], ok: Boolean, vulnerab
 }
 
 case class SnykError(error: String)
+
+case class InspectorAssessmentRun(
+  arn: String,
+  name: String,
+  appId: (String, String, String),
+  assessmentTemplateArn: String,
+  state: String,
+  durationInSeconds: Int,
+  rulesPackageArns: List[String],
+  userAttributesForFindings: List[(String, String)],
+  createdAt: DateTime,
+  startedAt: DateTime,
+  completedAt: DateTime,
+  stateChangedAt: DateTime,
+  dataCollected: Boolean,
+  findingCounts: Map[String, Int]
+)

--- a/hq/app/utils/attempt/Attempt.scala
+++ b/hq/app/utils/attempt/Attempt.scala
@@ -100,6 +100,18 @@ object Attempt {
   }
 
   /**
+    * Using the provided traversal function, sequence the resulting attempts
+    * into a list that:
+    * - preserves failures (by keeping the resulting Either)
+    * - creates a tuple who's first element is the value passed to the traversal function f
+    *
+    * Combines the behaviours of labelledTraverse and traverseWithFailures.
+    */
+  def labelledTaverseWithFailures[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[(A, Either[FailedAttempt, B])]] = {
+    Async.Right(Future.traverse(as)(a => f(a).asFuture.map(a -> _)))
+  }
+
+  /**
     * As with `Future.sequence`, changes `List[Attempt[A]]` to `Attempt[List[A]]`.
     *
     * This implementation returns the first failure in the list, or the successful result.

--- a/hq/app/views/fragments/inspectorResult.scala.html
+++ b/hq/app/views/fragments/inspectorResult.scala.html
@@ -24,7 +24,8 @@
             </table>
         </div>
         <div class="card-action finding-card-action">
-            <a class="btn usage-cta" href='https://eu-west-1.console.aws.amazon.com/inspector/home?region=eu-west-1#/finding?filter={"assessmentTemplateArns":["@{assessmentRun.assessmentTemplateArn}"]}'>
+            <a class="btn usage-cta" target="_blank" href='https://eu-west-1.console.aws.amazon.com/inspector/home?region=eu-west-1#/finding?filter={"assessmentTemplateArns":["@{assessmentRun.assessmentTemplateArn}"]}'>
+                <i class="material-icons link_new_tab">open_in_new</i>
                 AWS console
             </a>
         </div>

--- a/hq/app/views/fragments/openSecurityGroups.scala.html
+++ b/hq/app/views/fragments/openSecurityGroups.scala.html
@@ -30,9 +30,9 @@
     }
 }
 
-<div class="sg-container">
+<div class="finding-container">
 @for((flaggedSg, usages) <- flaggedSgs) {
-    <div class="sg-container__card sg-suppressed--@flaggedSg.isSuppressed">
+    <div class="finding-container__card finding-suppressed--@flaggedSg.isSuppressed">
         <div class="card @if(!shadow){z-depth-0}">
             <div class="card-content card-content--title">
                 <span class="card-title">@flaggedSg.name
@@ -45,7 +45,7 @@
                 flaggedSg.alertLevel.toLowerCase
             } darken-1"></div>
             <div class="card-content card-content--body">
-                <table class="sg-details__table">
+                <table class="finding-details__table">
                     <tbody>
                         <tr>
                             <th>Port</th>
@@ -96,7 +96,7 @@
                     </tbody>
                 </table>
             </div>
-            <div class="card-action sg-card-action">
+            <div class="card-action finding-card-action">
 
             @if(usages.isEmpty) {
                 <a class="btn usage-cta" href="#" disabled>Not in use</a>
@@ -106,9 +106,9 @@
                     @resourceList(flaggedSg, usages)
 
                 } else {
-                    <ul class="collapsible sg-details js-sg-details" data-collapsible="expandable">
-                        <li class="sg-details__list">
-                            <div class="collapsible-header sg-details__header"><i class="material-icons">expand_more</i>
+                    <ul class="collapsible finding-details js-finding-details" data-collapsible="expandable">
+                        <li class="finding-details__list">
+                            <div class="collapsible-header finding-details__header"><i class="material-icons">expand_more</i>
 
                               @defining(resourceIcons(usages.toList)) { iconCounts =>
                                   @if(iconCounts.instances > 0) {
@@ -126,7 +126,7 @@
                               }
 
                             </div>
-                        <div class="collapsible-body sg-details__body">
+                        <div class="collapsible-body finding-details__body">
                             @resourceList(flaggedSg, usages)
                         </div>
                         </li>

--- a/hq/app/views/header.scala.html
+++ b/hq/app/views/header.scala.html
@@ -25,6 +25,9 @@
                             <a href="/snyk"><i class="material-icons black-text">lock_open</i></a>
                         </li>
                         <li class="main-nav">
+                            <a href="/inspector"><i class="material-icons black-text">assignment</i></a>
+                        </li>
+                        <li class="main-nav">
                             <a href="/documentation/"><i class="material-icons black-text">description</i></a>
                         </li>
                     </ul>
@@ -41,6 +44,9 @@
                         </li>
                         <li class="main-nav">
                             <a href="/snyk"><i class="material-icons black-text">lock_open</i>Snyk</a>
+                        </li>
+                        <li class="main-nav">
+                            <a href="/inspector"><i class="material-icons black-text">assignment</i>Inspector</a>
                         </li>
                         <li class="main-nav">
                             <a href="/documentation/"><i class="material-icons black-text">description</i>Documentation</a>

--- a/hq/app/views/iam/exposedKeys.scala.html
+++ b/hq/app/views/iam/exposedKeys.scala.html
@@ -21,7 +21,7 @@
                 </div>
                 <div class="card-content--border red darken-1"></div>
                 <div class="card-content card-content--body">
-                    <table class="sg-details__table">
+                    <table class="finding-details__table">
                         <tbody>
                         <tr>
                             <th>Fraud type</th>

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -29,6 +29,7 @@
                 <ul class="tabs tabs-transparent">
                     <li class="tab col s3"><a target="_self" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                     <li class="tab col s3"><a target="_self" class="active" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
+                    <li class="tab col s3"><a target="_self" href="/inspector"><i class="material-icons left">assignment</i>Inspector</a></li>
                 </ul>
             </div>
         </div>

--- a/hq/app/views/iam/iamAccount.scala.html
+++ b/hq/app/views/iam/iamAccount.scala.html
@@ -13,7 +13,7 @@
             <ul class="tabs tabs-transparent">
                 <li class="tab col s3"><a target="_self" href="/security-groups/@awsAccount.id"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                 <li class="tab col s3"><a target="_self" class="active" href="/iam/@awsAccount.id"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
-                <li class="tab col s3"><a target="_self" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector results</a></li>
+                <li class="tab col s3"><a target="_self" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector</a></li>
             </ul>
         </div>
     </div>

--- a/hq/app/views/iam/iamAccount.scala.html
+++ b/hq/app/views/iam/iamAccount.scala.html
@@ -13,6 +13,7 @@
             <ul class="tabs tabs-transparent">
                 <li class="tab col s3"><a target="_self" href="/security-groups/@awsAccount.id"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                 <li class="tab col s3"><a target="_self" class="active" href="/iam/@awsAccount.id"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
+                <li class="tab col s3"><a target="_self" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector results</a></li>
             </ul>
         </div>
     </div>

--- a/hq/app/views/index.scala.html
+++ b/hq/app/views/index.scala.html
@@ -69,6 +69,9 @@
                                 <a href="/iam/@awsAccount.id" class="btn-flat accounts__link tooltipped" data-position="top" data-delay="50" data-tooltip="Credentials audits">
                                     <i class="material-icons">vpn_key</i>
                                 </a>
+                                <a href="/inspector/@awsAccount.id" class="btn-flat accounts__link tooltipped" data-position="top" data-delay="50" data-tooltip="Inspector results">
+                                    <i class="material-icons left">assignment</i>
+                                </a>
                             </div>
                         </div>
                     }

--- a/hq/app/views/index.scala.html
+++ b/hq/app/views/index.scala.html
@@ -50,7 +50,7 @@
             </div>
             <div class="card">
                 <div class="card-content">
-                    <a class="hp__link" href="/snyk">
+                    <a class="hp__link" href="/inspector">
                         <i class="right material-icons">assignment</i>
                         <span class="card-title">AWS Inspector</span>
                         <p>

--- a/hq/app/views/index.scala.html
+++ b/hq/app/views/index.scala.html
@@ -48,6 +48,17 @@
                     </a>
                 </div>
             </div>
+            <div class="card">
+                <div class="card-content">
+                    <a class="hp__link" href="/snyk">
+                        <i class="right material-icons">assignment</i>
+                        <span class="card-title">AWS Inspector</span>
+                        <p>
+                            Assessment run results.
+                        </p>
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
     <div class="accounts__container">

--- a/hq/app/views/inspector/inspector.scala.html
+++ b/hq/app/views/inspector/inspector.scala.html
@@ -1,6 +1,8 @@
 @import model.{AwsAccount, InspectorAssessmentRun}
+@import utils.attempt.FailedAttempt
+@import logic.InspectorResults.totalFindings
 
-@(accountAssessmentRuns: List[(AwsAccount, List[InspectorAssessmentRun])])(implicit assets: AssetsFinder)
+@(accountAssessmentRuns: List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])])(implicit assets: AssetsFinder)
 
 
 @main(List("AWS Inspector assessment runs")) { @* Header *@
@@ -30,27 +32,62 @@
 
         <div class="row">
             <ul class="collapsible" data-collapsible="accordion">
-            @for((account, assessmentRuns) <- accountAssessmentRuns) {
+            @for((account, assessmentRunsAttempt) <- accountAssessmentRuns) {
                 <li>
                     <div class="collapsible-header" tabindex="22">
                         <i class="material-icons">keyboard_arrow_down</i>
                         <span class="iam-header__name">@account.name</span>
+                        @assessmentRunsAttempt match {
+                            case Right(assessmentRuns) => {
+                                @if(totalFindings("High", assessmentRuns) > 0) {
+                                    <span class="icon-count">@totalFindings("High", assessmentRuns)</span>
+                                    <i class="material-icons red-text">error</i>
+                                }
+                                @if(totalFindings("Medium", assessmentRuns) > 0) {
+                                    <span class="icon-count">@totalFindings("Medium", assessmentRuns)</span>
+                                    <i class="material-icons amber-text">warning</i>
+                                }
+                                @if(totalFindings("Low", assessmentRuns) > 0) {
+                                    <span class="icon-count">@totalFindings("Low", assessmentRuns)</span>
+                                    <i class="material-icons purple-text">watch_later</i>
+                                }
+                                @if(totalFindings("Informational", assessmentRuns) > 0) {
+                                    <span class="icon-count">@totalFindings("Informational", assessmentRuns)</span>
+                                    <i class="material-icons">info_outline</i>
+                                }
+                            }
+                            case Left(_) => {
+                                <i class="material-icons">warning</i>
+                            }
+                        }
                     </div>
                     <div class="collapsible-body">
-                    @if(assessmentRuns.isEmpty) {
-                        <div class="col s12">
-                            <div class="card-panel valign-wrapper">
-                                <i class="material-icons medium green-text left">verified_user</i>
-                                <h5>No inspector runs found</h5>
-                            </div>
-                        </div>
-                    } else {
-                        <div class="finding-container">
-                        @for(assessmentRun <- assessmentRuns) {
-                            @inspectorResult(assessmentRun)
+                        @assessmentRunsAttempt match {
+                            case Right(assessmentRuns) => {
+                                @if(assessmentRuns.isEmpty) {
+                                    <div class="col s12">
+                                        <div class="card-panel valign-wrapper">
+                                            <i class="material-icons medium green-text left">verified_user</i>
+                                            <h5>No inspector runs found</h5>
+                                        </div>
+                                    </div>
+                                } else {
+                                    <div class="finding-container">
+                                    @for(assessmentRun <- assessmentRuns) {
+                                        @inspectorResult(assessmentRun)
+                                    }
+                                    </div>
+                                }
+                            }
+                            case Left(fa) => {
+                                <p class="p--warning">
+                                @for(err <- fa.failures) {
+                                    @err.friendlyMessage
+                                }
+                                </p>
+                            }
                         }
-                        </div>
-                    }
+
                     </div>
                 </li>
             }

--- a/hq/app/views/inspector/inspector.scala.html
+++ b/hq/app/views/inspector/inspector.scala.html
@@ -1,0 +1,60 @@
+@import model.{AwsAccount, InspectorAssessmentRun}
+
+@(accountAssessmentRuns: List[(AwsAccount, List[InspectorAssessmentRun])])(implicit assets: AssetsFinder)
+
+
+@main(List("AWS Inspector assessment runs")) { @* Header *@
+<div class="hq-sub-header">
+    <div class="container hq-sub-header__row">
+        <div class="hq-sub-header__name">
+            <h4 class="header light grey-text text-lighten-5">All accounts</h4>
+        </div>
+        <div class="hq-sub-header__tabs">
+            <ul class="tabs tabs-transparent">
+                <li class="tab col s3"><a target="_self" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
+                <li class="tab col s3"><a target="_self" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
+                <li class="tab col s3"><a target="_self" class="active" href="/inspector"><i class="material-icons left">assignment</i>Inspector results</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+} { @* Main content *@
+    <div class="container">
+        <div class="row">
+            <h2>AWS Inspector results</h2>
+            <p>
+                These are the results of the last inspector runs for each stack, app, stage combination.
+            </p>
+        </div>
+
+        <div class="row">
+            <ul class="collapsible" data-collapsible="accordion">
+            @for((account, assessmentRuns) <- accountAssessmentRuns) {
+                <li>
+                    <div class="collapsible-header" tabindex="22">
+                        <i class="material-icons">keyboard_arrow_down</i>
+                        <span class="iam-header__name">@account.name</span>
+                    </div>
+                    <div class="collapsible-body">
+                    @if(assessmentRuns.isEmpty) {
+                        <div class="col s12">
+                            <div class="card-panel valign-wrapper">
+                                <i class="material-icons medium green-text left">verified_user</i>
+                                <h5>No inspector runs found</h5>
+                            </div>
+                        </div>
+                    } else {
+                        <div class="finding-container">
+                        @for(assessmentRun <- assessmentRuns) {
+                            @inspectorResult(assessmentRun)
+                        }
+                        </div>
+                    }
+                    </div>
+                </li>
+            }
+            </ul>
+        </div>
+    </div>
+}

--- a/hq/app/views/inspector/inspector.scala.html
+++ b/hq/app/views/inspector/inspector.scala.html
@@ -15,7 +15,7 @@
             <ul class="tabs tabs-transparent">
                 <li class="tab col s3"><a target="_self" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                 <li class="tab col s3"><a target="_self" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
-                <li class="tab col s3"><a target="_self" class="active" href="/inspector"><i class="material-icons left">assignment</i>Inspector results</a></li>
+                <li class="tab col s3"><a target="_self" class="active" href="/inspector"><i class="material-icons left">assignment</i>Inspector</a></li>
             </ul>
         </div>
     </div>

--- a/hq/app/views/inspector/inspector.scala.html
+++ b/hq/app/views/inspector/inspector.scala.html
@@ -1,6 +1,6 @@
 @import model.{AwsAccount, InspectorAssessmentRun}
 @import utils.attempt.FailedAttempt
-@import logic.InspectorResults.totalFindings
+@import logic.InspectorResults.{levelFindings, totalFindings}
 
 @(accountAssessmentRuns: List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])])(implicit assets: AssetsFinder)
 
@@ -26,7 +26,7 @@
         <div class="row">
             <h2>AWS Inspector results</h2>
             <p>
-                These are the results of the last inspector runs for each stack, app, stage combination.
+                These are the results of the last inspector runs for each Stack, App, Stage combination.
             </p>
         </div>
 
@@ -39,25 +39,32 @@
                         <span class="iam-header__name">@account.name</span>
                         @assessmentRunsAttempt match {
                             case Right(assessmentRuns) => {
-                                @if(totalFindings("High", assessmentRuns) > 0) {
-                                    <span class="icon-count">@totalFindings("High", assessmentRuns)</span>
-                                    <i class="material-icons red-text">error</i>
-                                }
-                                @if(totalFindings("Medium", assessmentRuns) > 0) {
-                                    <span class="icon-count">@totalFindings("Medium", assessmentRuns)</span>
-                                    <i class="material-icons amber-text">warning</i>
-                                }
-                                @if(totalFindings("Low", assessmentRuns) > 0) {
-                                    <span class="icon-count">@totalFindings("Low", assessmentRuns)</span>
-                                    <i class="material-icons purple-text">watch_later</i>
-                                }
-                                @if(totalFindings("Informational", assessmentRuns) > 0) {
-                                    <span class="icon-count">@totalFindings("Informational", assessmentRuns)</span>
-                                    <i class="material-icons">info_outline</i>
+                                @if(assessmentRuns.isEmpty) {
+                                    <i class="material-icons green-text">highlight_off</i>
+                                } else {
+                                    @if(totalFindings(assessmentRuns) == 0) {
+                                        <i class="material-icons green-text">done</i>
+                                    }
+                                    @if(levelFindings("High", assessmentRuns) > 0) {
+                                        <span class="icon-count">@levelFindings("High", assessmentRuns)</span>
+                                        <i class="material-icons red-text">error</i>
+                                    }
+                                    @if(levelFindings("Medium", assessmentRuns) > 0) {
+                                        <span class="icon-count">@levelFindings("Medium", assessmentRuns)</span>
+                                        <i class="material-icons amber-text">warning</i>
+                                    }
+                                    @if(levelFindings("Low", assessmentRuns) > 0) {
+                                        <span class="icon-count">@levelFindings("Low", assessmentRuns)</span>
+                                        <i class="material-icons blue-text">watch_later</i>
+                                    }
+                                    @if(levelFindings("Informational", assessmentRuns) > 0) {
+                                        <span class="icon-count">@levelFindings("Informational", assessmentRuns)</span>
+                                        <i class="material-icons grey-text">info_outline</i>
+                                    }
                                 }
                             }
                             case Left(_) => {
-                                <i class="material-icons">warning</i>
+                                <i class="material-icons red-text">warning</i>
                             }
                         }
                     </div>
@@ -65,16 +72,11 @@
                         @assessmentRunsAttempt match {
                             case Right(assessmentRuns) => {
                                 @if(assessmentRuns.isEmpty) {
-                                    <div class="col s12">
-                                        <div class="card-panel valign-wrapper">
-                                            <i class="material-icons medium green-text left">verified_user</i>
-                                            <h5>No inspector runs found</h5>
-                                        </div>
-                                    </div>
+                                    No inspector runs found.
                                 } else {
                                     <div class="finding-container">
                                     @for(assessmentRun <- assessmentRuns) {
-                                        @inspectorResult(assessmentRun)
+                                        @views.html.fragments.inspectorResult(assessmentRun)
                                     }
                                     </div>
                                 }

--- a/hq/app/views/inspector/inspectorAccount.scala.html
+++ b/hq/app/views/inspector/inspectorAccount.scala.html
@@ -1,0 +1,38 @@
+@import model.{AwsAccount, InspectorAssessmentRun}
+
+@(assessmentRuns: List[((String, String, String), InspectorAssessmentRun)], awsAccount: AwsAccount)(implicit assets: AssetsFinder)
+
+
+@main(List(awsAccount.name)) { @* Header *@
+<div class="hq-sub-header">
+    <div class="container hq-sub-header__row">
+        <div class="hq-sub-header__name">
+            <h4 class="header light grey-text text-lighten-5">For @awsAccount.name</h4>
+        </div>
+        <div class="hq-sub-header__tabs">
+            <ul class="tabs tabs-transparent">
+                <li class="tab col s3"><a target="_self" href="/security-groups/@awsAccount.id"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
+                <li class="tab col s3"><a target="_self" href="/iam/@awsAccount.id"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
+                <li class="tab col s3"><a target="_self" class="active" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector results</a></li>
+            </ul>
+        </div>
+    </div>
+</div>
+
+} { @* Main content *@
+    <div class="container">
+        <ul>
+            @for(((stack, app, stage), assessmentRun) <- assessmentRuns) {
+                <li>
+                    @stack @app @stage
+                    @for((key, count) <- assessmentRun.findingCounts) {
+                        <dl>
+                            <dt>@key</dt>
+                            <dd>@count</dd>
+                        </dl>
+                    }
+                </li>
+            }
+        </ul>
+    </div>
+}

--- a/hq/app/views/inspector/inspectorAccount.scala.html
+++ b/hq/app/views/inspector/inspectorAccount.scala.html
@@ -25,7 +25,7 @@
         <div class="row">
             <h2>AWS Inspector results</h2>
             <p>
-                These are the results of the last inspector runs for each stack, app, stage combination.
+                These are the results of the last inspector runs for each Stack, App, Stage combination.
             </p>
         </div>
 
@@ -33,14 +33,14 @@
             @if(assessmentRuns.isEmpty) {
                 <div class="col s12">
                     <div class="card-panel valign-wrapper">
-                        <i class="material-icons medium green-text left">verified_user</i>
+                        <i class="material-icons medium green-text left">highlight_off</i>
                         <h5>No inspector runs found</h5>
                     </div>
                 </div>
             } else {
                 <div class="finding-container">
                     @for(assessmentRun <- assessmentRuns) {
-                        @inspectorResult(assessmentRun)
+                        @views.html.fragments.inspectorResult(assessmentRun)
                     }
                 </div>
             }

--- a/hq/app/views/inspector/inspectorAccount.scala.html
+++ b/hq/app/views/inspector/inspectorAccount.scala.html
@@ -1,4 +1,5 @@
 @import model.{AwsAccount, InspectorAssessmentRun}
+@import logic.InspectorResults.levelColour
 
 @(assessmentRuns: List[((String, String, String), InspectorAssessmentRun)], awsAccount: AwsAccount)(implicit assets: AssetsFinder)
 
@@ -21,18 +22,54 @@
 
 } { @* Main content *@
     <div class="container">
-        <ul>
-            @for(((stack, app, stage), assessmentRun) <- assessmentRuns) {
-                <li>
-                    @stack @app @stage
-                    @for((key, count) <- assessmentRun.findingCounts) {
-                        <dl>
-                            <dt>@key</dt>
-                            <dd>@count</dd>
-                        </dl>
+        <div class="row">
+            <h2>AWS Inspector results</h2>
+            <p>
+                These are the results of the last inspector runs for each stack, app, stage combination.
+            </p>
+        </div>
+
+        <div class="row">
+            @if(assessmentRuns.isEmpty) {
+                <div class="col s12">
+                    <div class="card-panel valign-wrapper">
+                        <i class="material-icons medium green-text left">verified_user</i>
+                        <h5>No inspector runs found</h5>
+                    </div>
+                </div>
+            } else {
+                <div class="finding-container">
+                    @for(((stack, app, stage), assessmentRun) <- assessmentRuns) {
+                        <div class="finding-container__card">
+                            <div class="card">
+                                <div class="card-content card-content--title">
+                                    <span class="card-title">@stack @app @stage</span>
+                                </div>
+                                <div class="card-content--border @{
+                                    levelColour(assessmentRun.findingCounts)
+                                } darken-1"></div>
+                                <div class="card-content card-content--body">
+                                    <table class="finding-details__table">
+                                        <tbody>
+                                            @for((level, count) <- assessmentRun.findingCounts) {
+                                                <tr>
+                                                    <th>@level</th>
+                                                    <td>@count</td>
+                                                </tr>
+                                            }
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div class="card-action finding-card-action">
+                                    <a class="btn usage-cta" href='https://eu-west-1.console.aws.amazon.com/inspector/home?region=eu-west-1#/finding?filter={"assessmentTemplateArns":["@{assessmentRun.assessmentTemplateArn}"]}'>
+                                        AWS console
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
                     }
-                </li>
+                </div>
             }
-        </ul>
+        </div>
     </div>
 }

--- a/hq/app/views/inspector/inspectorAccount.scala.html
+++ b/hq/app/views/inspector/inspectorAccount.scala.html
@@ -1,5 +1,5 @@
 @import model.{AwsAccount, InspectorAssessmentRun}
-@import logic.InspectorResults.levelColour
+@import logic.InspectorResults.{levelColour, sortedFindings}
 
 @(assessmentRuns: List[((String, String, String), InspectorAssessmentRun)], awsAccount: AwsAccount)(implicit assets: AssetsFinder)
 
@@ -51,7 +51,7 @@
                                 <div class="card-content card-content--body">
                                     <table class="finding-details__table">
                                         <tbody>
-                                            @for((level, count) <- assessmentRun.findingCounts) {
+                                            @for((level, count) <- sortedFindings(assessmentRun.findingCounts)) {
                                                 <tr>
                                                     <th>@level</th>
                                                     <td>@count</td>

--- a/hq/app/views/inspector/inspectorAccount.scala.html
+++ b/hq/app/views/inspector/inspectorAccount.scala.html
@@ -1,7 +1,7 @@
 @import model.{AwsAccount, InspectorAssessmentRun}
 @import logic.InspectorResults.{levelColour, sortedFindings}
 
-@(assessmentRuns: List[((String, String, String), InspectorAssessmentRun)], awsAccount: AwsAccount)(implicit assets: AssetsFinder)
+@(assessmentRuns: List[InspectorAssessmentRun], awsAccount: AwsAccount)(implicit assets: AssetsFinder)
 
 
 @main(List(awsAccount.name)) { @* Header *@
@@ -39,34 +39,8 @@
                 </div>
             } else {
                 <div class="finding-container">
-                    @for(((stack, app, stage), assessmentRun) <- assessmentRuns) {
-                        <div class="finding-container__card">
-                            <div class="card">
-                                <div class="card-content card-content--title">
-                                    <span class="card-title">@stack @app @stage</span>
-                                </div>
-                                <div class="card-content--border @{
-                                    levelColour(assessmentRun.findingCounts)
-                                } darken-1"></div>
-                                <div class="card-content card-content--body">
-                                    <table class="finding-details__table">
-                                        <tbody>
-                                            @for((level, count) <- sortedFindings(assessmentRun.findingCounts)) {
-                                                <tr>
-                                                    <th>@level</th>
-                                                    <td>@count</td>
-                                                </tr>
-                                            }
-                                        </tbody>
-                                    </table>
-                                </div>
-                                <div class="card-action finding-card-action">
-                                    <a class="btn usage-cta" href='https://eu-west-1.console.aws.amazon.com/inspector/home?region=eu-west-1#/finding?filter={"assessmentTemplateArns":["@{assessmentRun.assessmentTemplateArn}"]}'>
-                                        AWS console
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
+                    @for(assessmentRun <- assessmentRuns) {
+                        @inspectorResult(assessmentRun)
                     }
                 </div>
             }

--- a/hq/app/views/inspector/inspectorAccount.scala.html
+++ b/hq/app/views/inspector/inspectorAccount.scala.html
@@ -14,7 +14,7 @@
             <ul class="tabs tabs-transparent">
                 <li class="tab col s3"><a target="_self" href="/security-groups/@awsAccount.id"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                 <li class="tab col s3"><a target="_self" href="/iam/@awsAccount.id"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
-                <li class="tab col s3"><a target="_self" class="active" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector results</a></li>
+                <li class="tab col s3"><a target="_self" class="active" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector</a></li>
             </ul>
         </div>
     </div>

--- a/hq/app/views/inspector/inspectorResult.scala.html
+++ b/hq/app/views/inspector/inspectorResult.scala.html
@@ -1,0 +1,32 @@
+@import model.InspectorAssessmentRun
+@import logic.InspectorResults.{levelColour, sortedFindings}
+
+@(assessmentRun: InspectorAssessmentRun)
+
+<div class="finding-container__card">
+    <div class="card">
+        <div class="card-content card-content--title">
+            <span class="card-title">@assessmentRun.appId._1 @assessmentRun.appId._2 @assessmentRun.appId._3</span>
+        </div>
+        <div class="card-content--border @{
+            levelColour(assessmentRun.findingCounts)
+        } darken-1"></div>
+        <div class="card-content card-content--body">
+            <table class="finding-details__table">
+                <tbody>
+                @for((level, count) <- sortedFindings(assessmentRun.findingCounts)) {
+                    <tr>
+                        <th>@level</th>
+                        <td>@count</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+        <div class="card-action finding-card-action">
+            <a class="btn usage-cta" href='https://eu-west-1.console.aws.amazon.com/inspector/home?region=eu-west-1#/finding?filter={"assessmentTemplateArns":["@{assessmentRun.assessmentTemplateArn}"]}'>
+                AWS console
+            </a>
+        </div>
+    </div>
+</div>

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -34,6 +34,7 @@
                 <ul class="tabs tabs-transparent">
                     <li class="tab col s3"><a target="_self" class="active" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                     <li class="tab col s3"><a target="_self" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
+                    <li class="tab col s3"><a target="_self" href="/inspector"><i class="material-icons left">assignment</i>Inspector</a></li>
                 </ul>
             </div>
         </div>

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -3,21 +3,21 @@
 @(flaggedSgsByAccount: List[(model.AwsAccount, Either[utils.attempt.FailedAttempt, List[(model.SGOpenPortsDetail, Set[model.SGInUse])]])])(implicit assets: AssetsFinder)
 
 @floatingNav(accountId: String) = {
-  <div class="fixed-action-btn js-floating-nav sg-floating-nav">
+  <div class="fixed-action-btn js-floating-nav finding-floating-nav">
       <a class="btn-floating btn-large">
         <i class="large material-icons">menu</i>
       </a>
       <ul>
-          <li><a class="btn-floating red js-sg-pin-close">
+          <li><a class="btn-floating red js-finding-pin-close">
             <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="close current">close</i>
           </a></li>
-          <li><a class="btn-floating btn-floating yellow darken-1 js-sg-pin-top">
+          <li><a class="btn-floating btn-floating yellow darken-1 js-finding-pin-top">
             <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="go to top">vertical_align_top</i>
           </a></li>
-          <li><a class="btn-floating blue js-sg-pin-end">
+          <li><a class="btn-floating blue js-finding-pin-end">
             <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="go to end">vertical_align_bottom</i>
           </a></li>
-          <li><a href="/security-groups/@accountId" class="btn-floating purple js-sg-pin-acc">
+          <li><a href="/security-groups/@accountId" class="btn-floating purple js-finding-pin-acc">
               <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="go to account page">pageview</i>
           </a></li>
       </ul>
@@ -49,13 +49,13 @@
         <div class="row">
             <div class="card-panel valign-wrapper">
                 <i class="material-icons left">visibility_off</i>
-                <span class="sg-header__name">Some Security Groups may be ignored due to settings in AWS Trusted Advisor</span>
+                <span class="finding-header__name">Some Security Groups may be ignored due to settings in AWS Trusted Advisor</span>
 
-                <form class="sg-filter" action="#">
-                    <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
-                    <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
-                    <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />
-                    <label class="black-text sg-filter__label" for="show-ignored-sgs">Show ignored</label>
+                <form class="finding-filter" action="#">
+                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
+                    <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
+                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
+                    <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                 </form>
             </div>
         </div>
@@ -63,12 +63,12 @@
         @views.html.fragments.securityGroupHelp()
 
         <div class="row">
-            <ul class="collapsible space-between js-sg-collapsible" data-collapsible="accordion">
+            <ul class="collapsible space-between js-finding-collapsible" data-collapsible="accordion">
             @for((account, flaggedSgsAttempt) <- flaggedSgsByAccount) {
-                <li class="js-sg-scroll">
-                    <div class="collapsible-header sg-header" tabindex="22">
+                <li class="js-finding-scroll">
+                    <div class="collapsible-header finding-header" tabindex="22">
                         <i class="material-icons">keyboard_arrow_down</i>
-                        <span class="sg-header__name">@account.name</span>
+                        <span class="finding-header__name">@account.name</span>
                         @flaggedSgsAttempt match {
                             case Left(_) => {
                                 <i class="material-icons">warning</i>
@@ -79,13 +79,13 @@
                             case Right(flaggedSgs) => {
                                 @defining(reportSummary(flaggedSgs)) { summary =>
                                     @if(summary.active > 0) {
-                                        <span class="new badge red darken-3 sg-header__badge" data-badge-caption="in use">@summary.active</span>
+                                        <span class="new badge red darken-3 finding-header__badge" data-badge-caption="in use">@summary.active</span>
                                     }
                                     @if((summary.flagged - summary.active) > 0) {
-                                        <span class="new badge sg-header__badge" data-badge-caption="not in use">@{summary.flagged - summary.active}</span>
+                                        <span class="new badge finding-header__badge" data-badge-caption="not in use">@{summary.flagged - summary.active}</span>
                                     }
                                     @if(summary.suppressed > 0) {
-                                        <span class="new badge grey sg-header__badge" data-badge-caption="ignored">@summary.suppressed</span>
+                                        <span class="new badge grey finding-header__badge" data-badge-caption="ignored">@summary.suppressed</span>
                                     }
                                 }
                             }

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -15,6 +15,7 @@
             <ul class="tabs tabs-transparent">
                 <li class="tab col s3"><a target="_self" class="active" href="/security-groups/@awsAccount.id"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                 <li class="tab col s3"><a target="_self" href="/iam/@awsAccount.id"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
+                <li class="tab col s3"><a target="_self" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector results</a></li>
             </ul>
         </div>
     </div>

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -15,7 +15,7 @@
             <ul class="tabs tabs-transparent">
                 <li class="tab col s3"><a target="_self" class="active" href="/security-groups/@awsAccount.id"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                 <li class="tab col s3"><a target="_self" href="/iam/@awsAccount.id"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
-                <li class="tab col s3"><a target="_self" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector results</a></li>
+                <li class="tab col s3"><a target="_self" href="/inspector/@awsAccount.id"><i class="material-icons left">assignment</i>Inspector</a></li>
             </ul>
         </div>
     </div>

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -37,13 +37,13 @@
                 <div class="row">
                     <div class="card-panel valign-wrapper">
                         <i class="material-icons left">visibility_off</i>
-                        <span class="sg-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
+                        <span class="finding-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
 
-                        <form class="sg-filter" action="#">
-                            <input class="js-sg-filter" type="checkbox" id="show-flagged-sgs" checked="checked" />
-                            <label class="black-text sg-filter__label" for="show-flagged-sgs">Show flagged</label>
-                            <input class="js-sg-filter" type="checkbox" id="show-ignored-sgs" />
-                            <label class="black-text sg-filter__label" for="show-ignored-sgs">Show ignored</label>
+                        <form class="finding-filter" action="#">
+                            <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
+                            <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
+                            <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
+                            <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                         </form>
                     </div>
                 </div>

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -12,6 +12,7 @@ GET        /security-groups/:accountId                controllers.SecurityGroups
 
 GET        /snyk                                      controllers.SnykController.snyk
 
+GET        /inspector                                 controllers.InspectorController.inspector
 GET        /inspector/:accountId                      controllers.InspectorController.inspectorAccount(accountId)
 
 GET        /login                                     controllers.AuthController.login

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -4,20 +4,25 @@
 
 # An example controller showing a sample home page
 GET        /                                          controllers.HQController.index
-
 GET        /iam                                       controllers.HQController.iam
 GET        /iam/:accountId                            controllers.HQController.iamAccount(accountId)
+
 GET        /security-groups                           controllers.SecurityGroupsController.securityGroups
 GET        /security-groups/:accountId                controllers.SecurityGroupsController.securityGroupsAccount(accountId)
+
 GET        /snyk                                      controllers.SnykController.snyk
+
+GET        /inspector/:accountId                      controllers.InspectorController.inspectorAccount(accountId)
+
 GET        /login                                     controllers.AuthController.login
 GET        /loginError                                controllers.AuthController.loginError
 GET        /oauthCallback                             controllers.AuthController.oauthCallback
 GET        /logout                                    controllers.AuthController.logout
+
 GET        /documentation/                            controllers.UtilityController.documentation(file = "index")
 GET        /documentation/:file                       controllers.UtilityController.documentation(file)
-
 GET        /healthcheck                               controllers.UtilityController.healthcheck
+
 GET        /build                                     controllers.Assets.at(path = "/public", file = "build.json")
 
 # Map static resources from the /public folder to the /assets URL path

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -27,7 +27,7 @@ $(document).ready(function() {
   });
 
   // Extra interactions for the dropdowns on the Security Groups page
-  $('.js-sg-details').hover(
+  $('.js-finding-details').hover(
     function() {
       $(this).collapsible('open', 0);
     },
@@ -36,16 +36,16 @@ $(document).ready(function() {
     }
   );
 
-  $('.js-sg-filter').change(function() {
-    $('#show-ignored-sgs')[0].checked
-      ? $('.sg-suppressed--true').show()
-      : $('.sg-suppressed--true').hide();
-    $('#show-flagged-sgs')[0].checked
-      ? $('.sg-suppressed--false').show()
-      : $('.sg-suppressed--false').hide();
+  $('.js-finding-filter').change(function() {
+    $('#show-ignored-findings')[0].checked
+      ? $('.finding-suppressed--true').show()
+      : $('.finding-suppressed--true').hide();
+    $('#show-flagged-findings')[0].checked
+      ? $('.finding-suppressed--false').show()
+      : $('.finding-suppressed--false').hide();
   });
 
-  $('.js-sg-details').click(function() {
+  $('.js-finding-details').click(function() {
     $(this).collapsible('destroy');
 
     var clicks = $(this).data('clicks') || false;
@@ -59,7 +59,7 @@ $(document).ready(function() {
   });
 
   // Functionality for the floating menus on the Security Groups page
-  $('.js-sg-pin-close').click(function() {
+  $('.js-finding-pin-close').click(function() {
     $('html, body')
       .stop()
       .animate(
@@ -75,8 +75,8 @@ $(document).ready(function() {
     $('.collapsible').collapsible({ accordion: false });
   });
 
-  $('.js-sg-pin-top').click(function() {
-    const scrollTarget = $(this).closest('.js-sg-scroll');
+  $('.js-finding-pin-top').click(function() {
+    const scrollTarget = $(this).closest('.js-finding-scroll');
     $('html, body')
       .stop()
       .animate(
@@ -87,8 +87,8 @@ $(document).ready(function() {
       );
   });
 
-  $('.js-sg-pin-end').click(function() {
-    const scrollTarget = $(this).closest('.js-sg-scroll');
+  $('.js-finding-pin-end').click(function() {
+    const scrollTarget = $(this).closest('.js-finding-scroll');
     $('html, body')
       .stop()
       .animate(

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -205,24 +205,24 @@ nav {
 
 /* security group pages */
 
-.sg-filter {
+.finding-filter {
   min-width: 300px;
 }
 
-.sg-filter__label {
+.finding-filter__label {
   margin-left: 20px;
 }
 
-.sg-header__name {
+.finding-header__name {
   flex-grow: 2;
 }
 
-.sg-header span.sg-header__badge {
+.finding-header span.finding-header__badge {
   margin-left: 10px;
   width: 80px;
 }
 
-.sg-container {
+.finding-container {
   display: grid;
   grid-column-gap: 10px;
   grid-row-gap: 10px;
@@ -231,53 +231,53 @@ nav {
 }
 
 @media (min-width: 940px) {
-  .sg-container {
+  .finding-container {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (min-width: 1400px) {
-  .sg-container {
+  .finding-container {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
-.sg-suppressed--true {
+.finding-suppressed--true {
   display: none;
 }
 
-.sg-suppressed--true .card {
+.finding-suppressed--true .card {
   background-color: #f5f5f5;
 }
 
-.sg-container__card {
+.finding-container__card {
   min-width: 33%;
   padding: 0 10px;
 }
 
-.sg-card-action {
+.finding-card-action {
   min-height: 76px;
 }
 
-.sg-details__table td,
-.sg-details__table th {
+.finding-details__table td,
+.finding-details__table th {
   padding: 5px;
   word-wrap: break-word;
 }
 
-.sg-details {
+.finding-details {
   margin-top: 0;
   position: relative;
   width: 100%;
 }
 
-.sg-details__list {
+.finding-details__list {
   position: absolute;
   width: 100%;
   z-index: 200;
 }
 
-.sg-details__header {
+.finding-details__header {
   background-color: #009688;
   color: #ffffff;
   line-height: 36px;
@@ -285,7 +285,7 @@ nav {
   padding: 0 12px;
 }
 
-.sg-details__header i {
+.finding-details__header i {
   display: inline-grid;
   float: none;
   height: 36px;
@@ -294,12 +294,12 @@ nav {
   vertical-align: middle;
 }
 
-.sg-details__body {
+.finding-details__body {
   padding: 0 !important;
 }
 
 @media (max-width: 990px) {
-  .sg-floating-nav {
+  .finding-floating-nav {
     display: none;
   }
 }

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -29,7 +29,7 @@ class InspectorResultsTest extends FreeSpec with Matchers {
     "correctly extracts some of the important fields" in {
       val assessmentRun = new AssessmentRun()
         .withArn("arn:123")
-        .withName("AWSInspection-stack-app-stage-1520873440000")
+        .withName("AWSInspection--stack--app--stage-1520873440000")
         .withAssessmentTemplateArn("arn:template")
         .withState("state")
         .withDurationInSeconds(123)
@@ -43,7 +43,7 @@ class InspectorResultsTest extends FreeSpec with Matchers {
         .withFindingCounts(Map("low" -> new Integer(1)).asJava)
       parseAssessmentRun(assessmentRun) should have(
         'arn ("arn:123"),
-        'name ("AWSInspection-stack-app-stage-1520873440000"),
+        'name ("AWSInspection--stack--app--stage-1520873440000"),
         'appId ("stack", "app", "stage"),
         'rulesPackageArns (List("arn:rules1", "arn:rules2")),
         'completedAt (new DateTime(2018, 3 , 13, 0, 0, 0)),
@@ -54,11 +54,11 @@ class InspectorResultsTest extends FreeSpec with Matchers {
 
   "appId" - {
     "parses a valid lambda inspector name" in {
-      appId("AWSInspection-stack-app-stage-1520873440000") shouldEqual ("stack", "app", "stage")
+      appId("AWSInspection--stack--app--stage-1520873440000") shouldEqual ("stack", "app", "stage")
     }
 
     "parses a valid lambda inspector name with funny chars in the tags" in {
-      val result = appId("AWSInspection-stack-with-hyphens-app_with_underscores-stage.with.dots-1520873440000")
+      val result = appId("AWSInspection--stack-with-hyphens--app_with_underscores--stage.with.dots-1520873440000")
       result shouldEqual ("stack-with-hyphens", "app_with_underscores", "stage.with.dots")
     }
 

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -1,0 +1,73 @@
+package logic
+
+import java.util.{Date, GregorianCalendar}
+
+import com.amazonaws.services.inspector.model.{AssessmentRun, ListAssessmentRunsResult}
+import logic.InspectorResults._
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+
+class InspectorResultsTest extends FreeSpec with Matchers {
+
+  "parseListAssessmentRunsResult" - {
+    "returns the ARNs in the result" in {
+      val result = new ListAssessmentRunsResult().withAssessmentRunArns("arn:123", "arn:456")
+      parseListAssessmentRunsResult(result) shouldEqual List("arn:123", "arn:456")
+    }
+  }
+
+  "parseAssessmentRun" - {
+    "correctly extracts some of the important fields" in {
+      val assessmentRun = new AssessmentRun()
+        .withArn("arn:123")
+        .withName("AWSInspection-stack-app-stage-1520873440000")
+        .withAssessmentTemplateArn("arn:template")
+        .withState("state")
+        .withDurationInSeconds(123)
+        .withRulesPackageArns("arn:rules1", "arn:rules2")
+        .withUserAttributesForFindings()
+        .withCreatedAt(new Date())
+        .withStartedAt(new Date())
+        .withCompletedAt(new GregorianCalendar(2018, 2, 13, 0, 0, 0).getTime)
+        .withStartedAt(new Date())
+        .withDataCollected(true)
+        .withFindingCounts(Map("low" -> new Integer(1)).asJava)
+      parseAssessmentRun(assessmentRun) should have(
+        'arn ("arn:123"),
+        'name ("AWSInspection-stack-app-stage-1520873440000"),
+        'appId ("stack", "app", "stage"),
+        'rulesPackageArns (List("arn:rules1", "arn:rules2")),
+        'completedAt (new DateTime(2018, 3 , 13, 0, 0, 0)),
+        'findingCounts (Map("low" -> 1))
+      )
+    }
+  }
+
+  "appId" - {
+    "parses a valid lambda inspector name" in {
+      appId("AWSInspection-stack-app-stage-1520873440000") shouldEqual ("stack", "app", "stage")
+    }
+
+    "parses a valid lambda inspector name with funny chars in the tags" in {
+      val result = appId("AWSInspection-stack-with-hyphens-app_with_underscores-stage.with.dots-1520873440000")
+      result shouldEqual ("stack-with-hyphens", "app_with_underscores", "stage.with.dots")
+    }
+
+    "uses entire name as app if it does not match the expected format" in {
+      appId("something-else") shouldEqual ("", "something-else", "")
+    }
+  }
+
+  "relevantRuns" - {
+    "takes latest run for an app id" ignore {}
+
+    "takes latest run for multiple app ids" ignore {}
+
+    "sorts multiple app ids by the total number of findings in latest runs" ignore {}
+
+    "non-lambda runs are included with name as app, and sorted accordingly" ignore {}
+  }
+}

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -143,33 +143,46 @@ class InspectorResultsTest extends FreeSpec with Matchers {
     }
   }
 
-  "totalFindings" - {
+  "levelFindings" - {
     "returns total high findings" in {
       val results = List(
         arWithFindings(1, 0, 0, 0), arWithFindings(2, 0, 0, 0), arWithFindings(3, 0, 0, 0)
       )
-      totalFindings("High", results) shouldEqual 6
+      levelFindings("High", results) shouldEqual 6
     }
 
     "returns total medium findings" in {
       val results = List(
         arWithFindings(0, 1, 0, 0), arWithFindings(0, 2, 0, 0), arWithFindings(0, 3, 0, 0)
       )
-      totalFindings("Medium", results) shouldEqual 6
+      levelFindings("Medium", results) shouldEqual 6
     }
 
     "returns total low findings" in {
       val results = List(
         arWithFindings(0, 0, 1, 0), arWithFindings(0, 0, 2, 0), arWithFindings(0, 0, 3, 0)
       )
-      totalFindings("Low", results) shouldEqual 6
+      levelFindings("Low", results) shouldEqual 6
     }
 
     "returns total info findings" in {
       val results = List(
         arWithFindings(0, 0, 0, 1), arWithFindings(0, 0, 0, 2), arWithFindings(0, 0, 0, 3)
       )
-      totalFindings("Informational", results) shouldEqual 6
+      levelFindings("Informational", results) shouldEqual 6
+    }
+  }
+
+  "totalFindings" - {
+    "returns 0 for empty runs list" in {
+      totalFindings(Nil) shouldEqual 0
+    }
+
+    "returns sum for a list of runs" in {
+      val results = List(
+        arWithFindings(1, 0, 0, 0), arWithFindings(0, 1, 0, 0), arWithFindings(0, 0, 1, 0), arWithFindings(0, 0, 0, 1)
+      )
+      totalFindings(results) shouldEqual 4
     }
   }
 

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -70,4 +70,58 @@ class InspectorResultsTest extends FreeSpec with Matchers {
 
     "non-lambda runs are included with name as app, and sorted accordingly" ignore {}
   }
+
+  "levelColour" - {
+    "red if there is a high result" in {
+      levelColour(Map("High" -> 1)) shouldEqual "red"
+    }
+
+    "yellow if there is a medium result" in {
+      levelColour(Map("Medium" -> 1)) shouldEqual "yellow"
+    }
+
+    "blue if there is a low result" in {
+      levelColour(Map("Low" -> 1)) shouldEqual "blue"
+    }
+
+    "grey if there is an info result" in {
+      levelColour(Map("Informational" -> 1)) shouldEqual "grey"
+    }
+
+    "grey if there is are no results" in {
+      levelColour(Map()) shouldEqual "grey"
+    }
+
+    "does not show high with 0 results" in {
+      levelColour(Map("High" -> 0)) shouldEqual "grey"
+    }
+
+    "does not show medium with 0 results" in {
+      levelColour(Map("Medium" -> 0)) shouldEqual "grey"
+    }
+
+    "does not show low with 0 results" in {
+      levelColour(Map("Low" -> 0)) shouldEqual "grey"
+    }
+
+    "does not show info with 0 results" in {
+      levelColour(Map("Informational" -> 0)) shouldEqual "grey"
+    }
+
+    "does not high with 0 results" in {
+      levelColour(Map("High" -> 0)) shouldEqual "grey"
+    }
+
+    "high beats everything" in {
+      levelColour(Map("High" -> 1, "Medium" -> 1, "Low" -> 1, "Informational" -> 1)) shouldEqual "red"
+    }
+
+    "medium beats low and info" in {
+      levelColour(Map("High" -> 0, "Medium" -> 1, "Low" -> 1, "Informational" -> 1)) shouldEqual "yellow"
+    }
+
+    "info beats low" in {
+      levelColour(Map("High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1)) shouldEqual "blue"
+    }
+  }
 }

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -4,6 +4,7 @@ import java.util.{Date, GregorianCalendar}
 
 import com.amazonaws.services.inspector.model.{AssessmentRun, ListAssessmentRunsResult}
 import logic.InspectorResults._
+import model.InspectorAssessmentRun
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
 
@@ -134,6 +135,49 @@ class InspectorResultsTest extends FreeSpec with Matchers {
     "puts unexpected keys at the end" in {
       val result = sortedFindings(Map("Strange" -> 0, "High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1))
       result shouldEqual List("High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1, "Strange" -> 0)
+    }
+  }
+
+  "totalFindings" - {
+    "returns total high findings" in {
+      val results = List(
+        makeAR(1, 0, 0, 0), makeAR(2, 0, 0, 0), makeAR(3, 0, 0, 0)
+      )
+      totalFindings("High", results) shouldEqual 6
+    }
+
+    "returns total medium findings" in {
+      val results = List(
+        makeAR(0, 1, 0, 0), makeAR(0, 2, 0, 0), makeAR(0, 3, 0, 0)
+      )
+      totalFindings("Medium", results) shouldEqual 6
+    }
+
+    "returns total low findings" in {
+      val results = List(
+        makeAR(0, 0, 1, 0), makeAR(0, 0, 2, 0), makeAR(0, 0, 3, 0)
+      )
+      totalFindings("Low", results) shouldEqual 6
+    }
+
+    "returns total info findings" in {
+      val results = List(
+        makeAR(0, 0, 0, 1), makeAR(0, 0, 0, 2), makeAR(0, 0, 0, 3)
+      )
+      totalFindings("Informational", results) shouldEqual 6
+    }
+
+    def makeAR(high: Int, medium: Int, low: Int, info: Int): InspectorAssessmentRun = {
+      InspectorAssessmentRun(
+        "arn:run", "name", ("stack", "app", "stage"), "arn:template", "state", 1, Nil, Nil,
+        DateTime.now(), DateTime.now(), DateTime.now(), DateTime.now(), true,
+        Map(
+          "High" -> high,
+          "Medium" -> medium,
+          "Low" -> low,
+          "Informational" -> info
+        )
+      )
     }
   }
 }

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -124,4 +124,16 @@ class InspectorResultsTest extends FreeSpec with Matchers {
       levelColour(Map("High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1)) shouldEqual "blue"
     }
   }
+
+  "sortedFindings" - {
+    "sorts keys correctly" in {
+      val result = sortedFindings(Map("High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1))
+      result shouldEqual List("High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1)
+    }
+
+    "puts unexpected keys at the end" in {
+      val result = sortedFindings(Map("Strange" -> 0, "High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1))
+      result shouldEqual List("High" -> 0, "Medium" -> 0, "Low" -> 1, "Informational" -> 1, "Strange" -> 0)
+    }
+  }
 }

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -29,7 +29,7 @@ class InspectorResultsTest extends FreeSpec with Matchers {
     "correctly extracts some of the important fields" in {
       val assessmentRun = new AssessmentRun()
         .withArn("arn:123")
-        .withName("AWSInspection--stack--app--stage-1520873440000")
+        .withName("AWSInspection--stack--app--stage--1520873440000")
         .withAssessmentTemplateArn("arn:template")
         .withState("state")
         .withDurationInSeconds(123)
@@ -43,7 +43,7 @@ class InspectorResultsTest extends FreeSpec with Matchers {
         .withFindingCounts(Map("low" -> new Integer(1)).asJava)
       parseAssessmentRun(assessmentRun) should have(
         'arn ("arn:123"),
-        'name ("AWSInspection--stack--app--stage-1520873440000"),
+        'name ("AWSInspection--stack--app--stage--1520873440000"),
         'appId ("stack", "app", "stage"),
         'rulesPackageArns (List("arn:rules1", "arn:rules2")),
         'completedAt (new DateTime(2018, 3 , 13, 0, 0, 0)),
@@ -54,11 +54,11 @@ class InspectorResultsTest extends FreeSpec with Matchers {
 
   "appId" - {
     "parses a valid lambda inspector name" in {
-      appId("AWSInspection--stack--app--stage-1520873440000") shouldEqual ("stack", "app", "stage")
+      appId("AWSInspection--stack--app--stage--1520873440000") shouldEqual ("stack", "app", "stage")
     }
 
     "parses a valid lambda inspector name with funny chars in the tags" in {
-      val result = appId("AWSInspection--stack-with-hyphens--app_with_underscores--stage.with.dots-1520873440000")
+      val result = appId("AWSInspection--stack-with-hyphens--app_with_underscores--stage.with.dots--1520873440000")
       result shouldEqual ("stack-with-hyphens", "app_with_underscores", "stage.with.dots")
     }
 


### PR DESCRIPTION
## What does this change?

Adds AWS Inspector results for each account to the app.

<!-- Screenshots may be helpful to demonstrate -->

### Homepage
![homepage](https://user-images.githubusercontent.com/29761/37518051-7b581db4-290b-11e8-82bd-a5b073b4351d.png)

### All accounts
![all-inspector-results](https://user-images.githubusercontent.com/29761/37518056-80c28d3e-290b-11e8-8383-ab2761a9c772.png)

### Single account
![account-inspector-results](https://user-images.githubusercontent.com/29761/37518060-84c9692a-290b-11e8-82e9-315a209dab20.png)

## What is the value of this?

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
Yes, there is a change to `watched-account.template.yaml` to enable AWS Inspector calls.

**StackSet update required prior to deploy**

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
