### PR TITLE
Adds inspector data to the CacheService

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -61,7 +61,7 @@ class AppComponents(context: Context)
     new HQController(configuration, cacheService, googleAuthConfig),
     new SecurityGroupsController(configuration, cacheService, googleAuthConfig),
     new SnykController(configuration, configraun, googleAuthConfig),
-    new InspectorController(configuration, googleAuthConfig),
+    new InspectorController(configuration, cacheService, googleAuthConfig),
     new AuthController(environment, configuration, googleAuthConfig),
     new UtilityController(),
     assets

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -14,6 +14,7 @@ GET        /snyk                                      controllers.SnykController
 
 GET        /inspector                                 controllers.InspectorController.inspector
 GET        /inspector/:accountId                      controllers.InspectorController.inspectorAccount(accountId)
+GET        /inspector/refresh/all                     controllers.InspectorController.refresh
 
 GET        /login                                     controllers.AuthController.login
 GET        /loginError                                controllers.AuthController.loginError


### PR DESCRIPTION
## What does this change?

Puts inspector data into the CacheService.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

The page loads quickly and we don't slam AWS if SHQ gets busy.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

This data is configured to refresh irregularly, so there is a manual refresh endpoint.


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
