### PR TITLE
Inspector parsing support empty tags

### DIFF
--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 
 object InspectorResults {
   private val tagMatch = "[\\w\\-_\\.]"
-  val RunNameMatch = s"AWSInspection--($tagMatch+)--($tagMatch+)--($tagMatch+)--[\\d]+".r
+  val RunNameMatch = s"AWSInspection--($tagMatch*)--($tagMatch*)--($tagMatch*)--[\\d]+".r
 
   def appId(assessmentRunName: String): Option[(String, String, String)] = {
     assessmentRunName match {

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -76,6 +76,21 @@ class InspectorResultsTest extends FreeSpec with Matchers with OptionValues {
       result shouldEqual ("stack-with-hyphens", "app_with_underscores", "stage.with.dots")
     }
 
+    "parses a valid lambda inspector name with missing stack" in {
+      val result = appId("AWSInspection----app--stage--1520873440000").value
+      result shouldEqual ("", "app", "stage")
+    }
+
+    "parses a valid lambda inspector name with missing app" in {
+      val result = appId("AWSInspection--stack----stage--1520873440000").value
+      result shouldEqual ("stack", "", "stage")
+    }
+
+    "parses a valid lambda inspector name with missing stage" in {
+      val result = appId("AWSInspection--stack--app----1520873440000").value
+      result shouldEqual ("stack", "app", "")
+    }
+
     "returns None if it does not match the expected format" in {
       appId("something-else") shouldBe None
     }


### PR DESCRIPTION
## What does this change?

Support empty Stack/App/Stage tags when looking for inspector runs.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

The lambda runner will run *all combos* of stack/app/stage, including ones with missing tags. This will now pick all of them up.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
Based on https://github.com/guardian/security-hq/pull/114/files <- merge that first