### PR TITLE
Filter on assessment runs

### DIFF
--- a/hq/app/views/fragments/inspectorResult.scala.html
+++ b/hq/app/views/fragments/inspectorResult.scala.html
@@ -24,7 +24,7 @@
             </table>
         </div>
         <div class="card-action finding-card-action">
-            <a class="btn usage-cta" target="_blank" href='https://eu-west-1.console.aws.amazon.com/inspector/home?region=eu-west-1#/finding?filter={"assessmentTemplateArns":["@{assessmentRun.assessmentTemplateArn}"]}'>
+            <a class="btn usage-cta" target="_blank" href='https://eu-west-1.console.aws.amazon.com/inspector/home?region=eu-west-1#/finding?filter={"assessmentRunArns":["@{assessmentRun.arn}"]}'>
                 <i class="material-icons link_new_tab">open_in_new</i>
                 AWS console
             </a>


### PR DESCRIPTION
## What does this change?

Filters on assessment run instead of assessment target when opening the aws console for an inspector result.

## What is the value of this?

It's what is expected.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.
