### PR TITLE
Remove Inspector from cloud-init

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -236,9 +236,6 @@ Resources:
           apt-get -y update
           apt-get -y upgrade
           apt-get -y install ntp
-          # setup Amazon Inspector
-          /usr/bin/wget https://d1wk0tztpsntt1.cloudfront.net/linux/latest/install
-          /bin/bash install
           echo ${Stage} > /etc/stage
           # setup security-hq
           adduser --system --home /security-hq --disabled-password security-hq


### PR DESCRIPTION
## What does this change?

Remove AWS Inspector agent install from cloud-init

## What is the value of this?

This feature can now be installed via Amigo and should not be installed in cloud-init as it increases
the startup time for an instance.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes

<!-- Have you committed your changes to the CloudFormation templates? -->

Yes 

<!-- Has the CloudFormation or StackSet update been completed? -->

No

## Any additional notes?

No