### PR TITLE
Snyk: Upversion Jackson and parts of AWS SDK, and Snyk

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-inspector" % awsSdkVersion,
-      "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
+      "com.vladsch.flexmark" % "flexmark" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
@@ -95,7 +95,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
   )
 
 lazy val root = (project in file(".")).
-  aggregate(hq, lambda).
+  aggregate(hq, lambdaCommon).
   settings(
     name := """security-hq"""
   )

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val hq = (project in file("hq"))
       "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test
@@ -85,17 +85,16 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "com.amazonaws" % "aws-java-sdk-config" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-elasticloadbalancing" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-config" % awsSdkVersion,
       "com.typesafe.play" %% "play-json" % playVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
       "ch.qos.logback" %  "logback-classic" % "1.2.3",
-      "com.amazonaws" % "aws-java-sdk-config" % "1.11.246",
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11"
     )
   )
 
-
 lazy val root = (project in file(".")).
-  aggregate(hq, lambdaCommon).
+  aggregate(hq, lambda).
   settings(
     name := """security-hq"""
   )

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ resolvers += DefaultMavenRepository
 
 val awsSdkVersion = "1.11.258"
 val playVersion = "2.6.7"
+val jacksonVersion = "2.8.11.1"
 
 lazy val hq = (project in file("hq"))
   .enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin, SbtWeb)
@@ -37,7 +38,7 @@ lazy val hq = (project in file("hq"))
       "com.vladsch.flexmark" % "flexmark-all" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test
@@ -89,7 +90,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "com.typesafe.play" %% "play-json" % playVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
       "ch.qos.logback" %  "logback-classic" % "1.2.3",
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11"
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     )
   )
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "materialize-css": "0.100.2",
     "prettier": "1.8.0",
     "sass-lint": "1.12.1",
-    "snyk": "1.69.3"
+    "snyk": "1.70.2"
   },
   "prettier": {
     "singleQuote": true


### PR DESCRIPTION
## What does this change?

Upversion Jackson databind and brings all AWS SDK entries in line.
Fixes Jackson value to a single value.
Upversions Snyk tooling.

## What is the value of this?

Removes (hopefully) vulnerabilities reported by Snyk

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No