### PR TITLE
Give app more time to start the server in PROD mode

### DIFF
--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -103,26 +103,30 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   }
 
   if (environment.mode != Mode.Test) {
-    val credentialsSubscription = Observable.interval(500.millis, 5.minutes).subscribe { _ =>
-      refreshCredentialsBox()
-    }
+    val initialDelay =
+      if (environment.mode == Mode.Prod) 10.seconds
+      else Duration.Zero
 
-    val exposedKeysSubscription = Observable.interval(1000.millis, 5.minutes).subscribe { _ =>
+    val exposedKeysSubscription = Observable.interval(initialDelay + 2000.millis, 5.minutes).subscribe { _ =>
       refreshExposedKeysBox()
     }
 
-    val sgSubscription = Observable.interval(1500.millis, 5.minutes).subscribe { _ =>
+    val sgSubscription = Observable.interval(initialDelay + 3000.millis, 5.minutes).subscribe { _ =>
       refreshSgsBox()
     }
 
-    val inspectorSubscription = Observable.interval(2000.millis, 6.hours).subscribe { _ =>
+    val credentialsSubscription = Observable.interval(initialDelay + 4000.millis, 15.minutes).subscribe { _ =>
+      refreshCredentialsBox()
+    }
+
+    val inspectorSubscription = Observable.interval(initialDelay + 5000.millis, 6.hours).subscribe { _ =>
       refreshInspectorBox()
     }
 
     lifecycle.addStopHook { () =>
-      credentialsSubscription.unsubscribe()
       exposedKeysSubscription.unsubscribe()
       sgSubscription.unsubscribe()
+      credentialsSubscription.unsubscribe()
       inspectorSubscription.unsubscribe()
       Future.successful(())
     }


### PR DESCRIPTION
## What does this change?

Instead of piling in with loads of IO, we let Play start the server and then start caching. Riff Raff waits a bit before finishing deploys, so the impact on the service from this delay should be minimal.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Might fix the "cannto start server" issue.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

No
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
