### PR TITLE
Update documentation

### DIFF
--- a/hq/markdown/aws-inspector.md
+++ b/hq/markdown/aws-inspector.md
@@ -5,16 +5,22 @@ vulnerable OS modules and packages, and poor runtime behaviour.
 
 It is provided as standard to all AWS accounts.
 
+## Usage
+
+Simply add the AWS Inspector agent to your boxes.
+
+The easiest way to do this is to add the `aws-inspector` role to your application's Amigo recipe.
+
 ## Implementation
 
 An application has been created, which will:
 
-  * Create a lambda to
-    * Search for App, Stack and Stage tags on instances in the target account
-    * Create a resource group, assessment target, and assessment template for each combination, unless they already exist
-    * Limit the resource group to a maximum of five instances
-    * Start an Assessment run of one hour for each target
-  * Schedule the lambda for 3am on Mondays and Thursdays.
+  1. Create a lambda to
+      1. Search for App, Stack and Stage tags on instances in the target account
+      2. Create a resource group, assessment target, and assessment template for each combination, unless they already exist
+      3. Limit the resource group to a maximum of five instances
+      4. Start an Assessment run of one hour for each target
+  2. Schedule the lambda for 3am on Mondays and Thursdays.
 
 ### Repo
 

--- a/hq/markdown/index.md
+++ b/hq/markdown/index.md
@@ -1,7 +1,12 @@
 # List of help pages
 
+GDPR tools:
+
    1. How to implement [Snyk](snyk) Vulnerability Analysis to check library dependencies.
-   2. How to implement [AWS run command (tutorial)](run-command) and remove the need for ssh/bastions.
-   3. How to use [Temporary SSH credentials](temporary-ssh).
-   4. Scanning for weaknesses with [AWS Inspector](aws-inspector)
-   5. Fetching 'secrets' on instances from [AWS Parameter Store](parameter-store)
+   2. Using our ssm-scala tool for [Temporary SSH credentials](temporary-ssh).
+   3. Scanning for weaknesses with [AWS Inspector](aws-inspector)
+
+Related documentation:
+
+   1. How to implement [AWS run command (tutorial)](run-command) and remove the need for ssh/bastions.
+   2. Fetching 'secrets' on instances from [AWS Parameter Store](parameter-store)


### PR DESCRIPTION
## What does this change?

Updates inspector documentation to include usage

Also update the index page to highlight the bits that are important to the reader.

MaterializeCSS has a bug and strips styles off all `ul`s. Switches to `ol`s as a workaround.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

We now have a reference for how teams actually enable AWS Inspector.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope.
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

Chances are no one will read this but it's there for our own reference is nothing else and the existing docs were missing the vital part "how do I actually use this".

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
