### PR TITLE
Move to Quartz scheduler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ lazy val hq = (project in file("hq"))
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+      "org.quartz-scheduler" % "quartz" % "2.3.0",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -9,15 +9,15 @@ import config.Config
 import model._
 import play.api.inject.ApplicationLifecycle
 import play.api.{Configuration, Environment, Logger, Mode}
-import rx.lang.scala.Observable
 import utils.attempt.{FailedAttempt, Failure}
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
+import org.quartz._
+import org.quartz.impl.StdSchedulerFactory
+import org.quartz.spi.{JobFactory, TriggerFiredBundle}
 
+import scala.concurrent.ExecutionContext
 
-
-class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, environment: Environment)(implicit ec: ExecutionContext) {
+class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, environment: Environment)(implicit ec: ExecutionContext) extends JobFactory {
   private val accounts = Config.getAwsAccounts(config)
   private val startingCache = accounts.map(acc => (acc, Left(Failure.cacheServiceError(acc.id, "cache").attempt))).toMap
   private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(startingCache)
@@ -103,32 +103,58 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   }
 
   if (environment.mode != Mode.Test) {
-    val initialDelay =
-      if (environment.mode == Mode.Prod) 10.seconds
-      else Duration.Zero
+    // Frequent jobs are staggered over two minutes, giving one every 40 seconds
+    setUpQuartzScheduleJob(Cache.Credentials, "0 0-59/2 * * * ?")
+    setUpQuartzScheduleJob(Cache.ExposedKeys, "40 0-59/2 * * * ?")
+    setUpQuartzScheduleJob(Cache.SecurityGroups, "20 1-59/2 * * * ?")
+    // AWS Inspector Runs are only scheduled for the early hours of Mon & Thu at the time of writing, so
+    // less frequent updates in Security HQ are fine.  7am is the earliest people are likely to be at work.
+    setUpQuartzScheduleJob(Cache.AWSInspector, "45 20 1,7,13,19 * * ?")
+  }
 
-    val exposedKeysSubscription = Observable.interval(initialDelay + 2000.millis, 5.minutes).subscribe { _ =>
-      refreshExposedKeysBox()
-    }
+  private def setUpQuartzScheduleJob(cache: Cache.EnumVal, cronString: String) = {
+    val jobKey = JobKey.jobKey(cache.toString, "refresh")
+    val schedule = CronScheduleBuilder.cronSchedule(cronString)
 
-    val sgSubscription = Observable.interval(initialDelay + 3000.millis, 5.minutes).subscribe { _ =>
-      refreshSgsBox()
-    }
+    val jobDetail = JobBuilder
+      .newJob(classOf[Job])
+      .withIdentity(jobKey)
+      .build()
 
-    val credentialsSubscription = Observable.interval(initialDelay + 4000.millis, 15.minutes).subscribe { _ =>
-      refreshCredentialsBox()
-    }
+    val trigger = TriggerBuilder
+      .newTrigger()
+      .withIdentity(s"cron-${cache.toString}")
+      .withSchedule(schedule)
+      .build()
 
-    val inspectorSubscription = Observable.interval(initialDelay + 5000.millis, 6.hours).subscribe { _ =>
-      refreshInspectorBox()
-    }
+    val scheduler = new StdSchedulerFactory().getScheduler()
+    scheduler.setJobFactory(this)
+    scheduler.scheduleJob(jobDetail, trigger)
+    // Run once straight away, so that we don't have a delay on initial boot
+    scheduler.triggerJob(jobKey)
+    scheduler.start()
+  }
 
-    lifecycle.addStopHook { () =>
-      exposedKeysSubscription.unsubscribe()
-      sgSubscription.unsubscribe()
-      credentialsSubscription.unsubscribe()
-      inspectorSubscription.unsubscribe()
-      Future.successful(())
+  def refresh(cache: Cache.EnumVal): Unit = {
+    cache match {
+      case Cache.Credentials => refreshCredentialsBox()
+      case Cache.AWSInspector => refreshInspectorBox()
+      case Cache.ExposedKeys => refreshExposedKeysBox()
+      case Cache.SecurityGroups => refreshSgsBox()
     }
+  }
+
+  // Turns this class into a scheduler job factory.
+  override def newJob(bundle: TriggerFiredBundle, scheduler: Scheduler): Job =
+    (context: JobExecutionContext) => refresh(Cache.find(context.getJobDetail.getKey.getName))
+
+  object Cache {
+    sealed trait EnumVal
+    case object AWSInspector extends EnumVal
+    case object Credentials extends EnumVal
+    case object ExposedKeys extends EnumVal
+    case object SecurityGroups extends EnumVal
+    def find(name: String) = Set(AWSInspector, Credentials, ExposedKeys, SecurityGroups)
+      .find(c => c.toString.equals(name)).get
   }
 }

--- a/hq/conf/logback.xml
+++ b/hq/conf/logback.xml
@@ -26,6 +26,7 @@
 
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
+  <logger name="org.quartz" level="INFO" />
 
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
   <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />


### PR DESCRIPTION
## What does this change?

Update various caches by Quartz Scheduler instead of Play.

## What is the value of this?

Play threads were hanging around and taking up memory, leading to crashes, leading to instance cycling.  This change does not appear to do that.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No