### PR TITLE
Increase initial port binding timeout

### DIFF
--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -386,3 +386,5 @@ db {
   # https://www.playframework.com/documentation/latest/Highlights25#Logging-SQL-statements
   #default.logSql=true
 }
+
+play.server.akka.bindTimeout = 15 seconds


### PR DESCRIPTION
## What does this change?

Increases the initial port binding timeout from 5s to 15s.

## What is the value of this?

Currently, instances are failing at start because the application is failing and so the healthcheck fails.  This should eliminate this failure mode so that we can concentrate on the out-of-memory failure mode.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No