### PR TITLE
Re-use all AWS clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ yarn-error.log*
 
 # Dependency directories
 node_modules/
+
+# Local notes directory
+notes

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -1,3 +1,4 @@
+import aws.AWS
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.gu.configraun.Configraun
 import com.gu.configraun.aws.AWSSimpleSystemsManagementFactory
@@ -52,15 +53,29 @@ class AppComponents(context: Context)
     }
   }
 
-  private val cacheService = new CacheService(configuration, applicationLifecycle, environment)
   private val googleAuthConfig = Config.googleSettings(httpConfiguration, configuration)
+  private val inspectorClients = AWS.inspectorClients(configuration)
+  private val ec2Clients = AWS.ec2Clients(configuration)
+  private val cfnClients = AWS.cfnClients(configuration)
+  private val taClients = AWS.taClients(configuration)
+  private val iamClients = AWS.iamClients(configuration)
+
+  private val cacheService = new CacheService(
+    configuration,
+    applicationLifecycle,
+    environment,
+    inspectorClients,
+    ec2Clients,
+    cfnClients,
+    taClients,
+    iamClients)
 
   override def router: Router = new Routes(
     httpErrorHandler,
     new HQController(configuration, cacheService, googleAuthConfig),
     new SecurityGroupsController(configuration, cacheService, googleAuthConfig),
     new SnykController(configuration, configraun, googleAuthConfig),
-    new InspectorController(configuration, cacheService, googleAuthConfig),
+    new InspectorController(inspectorClients, configuration, cacheService, googleAuthConfig),
     new AuthController(environment, configuration, googleAuthConfig),
     new UtilityController(),
     assets

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -75,7 +75,7 @@ class AppComponents(context: Context)
     new HQController(configuration, cacheService, googleAuthConfig),
     new SecurityGroupsController(configuration, cacheService, googleAuthConfig),
     new SnykController(configuration, configraun, googleAuthConfig),
-    new InspectorController(inspectorClients, configuration, cacheService, googleAuthConfig),
+    new InspectorController(configuration, cacheService, googleAuthConfig),
     new AuthController(environment, configuration, googleAuthConfig),
     new UtilityController(),
     assets

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -30,14 +30,13 @@ object AWS {
     )
   }
 
-  private def client[T, S <: AwsClientBuilder[S, T]](
+  private def clientMapping[T, S <: AwsClientBuilder[S, T]](
     account: AwsAccount,
     region: Regions,
     builder: AwsClientBuilder[S, T]
   ): ((String, Regions), T) = {
-    val auth = credentialsProvider(account)
     val client = builder
-      .withCredentials(auth)
+      .withCredentials(credentialsProvider(account))
       .withRegion(region)
       .build()
     (account.id, region) -> client
@@ -51,7 +50,7 @@ object AWS {
     val list = for {
       account <- Config.getAwsAccounts(configuration)
       region <- regionList
-    } yield client[T, S](account, region, builder)
+    } yield clientMapping[T, S](account, region, builder)
     Map(list: _*)
   }
 

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -18,8 +18,6 @@ import utils.attempt.{Attempt, Failure}
 
 object AWS {
 
-  //  availableRegions <- EC2.getAvailableRegions(regionClient)
-
   private def credentialsProvider(account: AwsAccount): AWSCredentialsProviderChain = {
     new AWSCredentialsProviderChain(
       new STSAssumeRoleSessionCredentialsProvider.Builder(account.roleArn, "security-hq").build(),

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -32,7 +32,7 @@ object AWS {
     )
   }
 
-  private def clients[A, B <: AwsClientBuilder[B, A]](
+  private[aws] def clients[A, B <: AwsClientBuilder[B, A]](
     builder: AwsClientBuilder[B, A],
     configuration: Configuration,
     regionList: Regions*

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -29,6 +29,7 @@ object AWS {
     )
   }
 
+  // Only needs Regions.EU_WEST_1
   def inspectorClients(configuration: Configuration): Map[(String, Regions), AmazonInspectorAsync] = Config.getAwsAccounts(configuration).flatMap(account => Regions.values().map(
     region => {
       val auth = credentialsProvider(account)
@@ -63,6 +64,7 @@ object AWS {
     }
   )).toMap
 
+  // Only needs Regions.US_EAST_1
   def taClients(configuration: Configuration): Map[(String, Regions), AWSSupportAsync] = Config.getAwsAccounts(configuration).flatMap(account => List(Regions.US_EAST_1).map(
     region => {
       val auth = credentialsProvider(account)

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -56,32 +56,32 @@ object AWS {
   }
 
   // Only needs Regions.EU_WEST_1
-  def inspectorClients(configuration: Configuration) =
+  def inspectorClients(configuration: Configuration): Map[(String, Regions), AmazonInspectorAsync] =
     clients[AmazonInspectorAsync, AmazonInspectorAsyncClientBuilder](
       configuration,
       List(Regions.EU_WEST_1),
       AmazonInspectorAsyncClientBuilder.standard())
 
-  def ec2Clients(configuration: Configuration) =
+  def ec2Clients(configuration: Configuration): Map[(String, Regions), AmazonEC2Async] =
     clients[AmazonEC2Async, AmazonEC2AsyncClientBuilder](
       configuration,
       Regions.values().toList,
       AmazonEC2AsyncClientBuilder.standard())
 
-  def cfnClients(configuration: Configuration) =
+  def cfnClients(configuration: Configuration): Map[(String, Regions), AmazonCloudFormationAsync] =
     clients[AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder](
       configuration,
       Regions.values().toList,
       AmazonCloudFormationAsyncClientBuilder.standard())
 
   // Only needs Regions.US_EAST_1
-  def taClients(configuration: Configuration) =
+  def taClients(configuration: Configuration): Map[(String, Regions), AWSSupportAsync] =
     clients[AWSSupportAsync, AWSSupportAsyncClientBuilder](
       configuration,
       List(Regions.US_EAST_1),
       AWSSupportAsyncClientBuilder.standard())
 
-  def iamClients(configuration: Configuration) =
+  def iamClients(configuration: Configuration): Map[(String, Regions), AmazonIdentityManagementAsync] =
     clients[AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder](
       configuration,
       Regions.values().toList,

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -31,7 +31,7 @@ object AWS {
 
   def inspectorClients(configuration: Configuration): Map[(String, Regions), AmazonInspectorAsync] = Config.getAwsAccounts(configuration).flatMap(account => Regions.values().map(
     region => {
-      val auth = AWS.credentialsProvider(account)
+      val auth = credentialsProvider(account)
       val inspectorClient = AmazonInspectorAsyncClientBuilder.standard()
         .withCredentials(auth)
         .withRegion(region)
@@ -43,7 +43,7 @@ object AWS {
 
   def ec2Clients(configuration: Configuration): Map[(String, Regions), AmazonEC2Async] = Config.getAwsAccounts(configuration).flatMap(account => Regions.values().map(
     region => {
-      val auth = AWS.credentialsProvider(account)
+      val auth = credentialsProvider(account)
       val inspectorClient = AmazonEC2AsyncClientBuilder.standard()
         .withCredentials(auth)
         .withRegion(region)
@@ -54,7 +54,7 @@ object AWS {
 
   def cfnClients(configuration: Configuration): Map[(String, Regions), AmazonCloudFormationAsync] = Config.getAwsAccounts(configuration).flatMap(account => Regions.values().map(
     region => {
-      val auth = AWS.credentialsProvider(account)
+      val auth = credentialsProvider(account)
       val cloudFormationClient = AmazonCloudFormationAsyncClientBuilder.standard()
         .withCredentials(auth)
         .withRegion(region)
@@ -65,7 +65,7 @@ object AWS {
 
   def taClients(configuration: Configuration): Map[(String, Regions), AWSSupportAsync] = Config.getAwsAccounts(configuration).flatMap(account => List(Regions.US_EAST_1).map(
     region => {
-      val auth = AWS.credentialsProvider(account)
+      val auth = credentialsProvider(account)
       val cloudFormationClient = AWSSupportAsyncClientBuilder.standard()
         .withCredentials(auth)
         .withRegion(region)
@@ -76,7 +76,7 @@ object AWS {
 
   def iamClients(configuration: Configuration): Map[(String, Regions), AmazonIdentityManagementAsync] = Config.getAwsAccounts(configuration).flatMap(account => List(Regions.US_EAST_1).map(
     region => {
-      val auth = AWS.credentialsProvider(account)
+      val auth = credentialsProvider(account)
       val cloudFormationClient = AmazonIdentityManagementAsyncClientBuilder.standard()
         .withCredentials(auth)
         .withRegion(region)

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -32,11 +32,11 @@ object AWS {
     )
   }
 
-  private def clients[T, S <: AwsClientBuilder[S, T]](
-    builder: AwsClientBuilder[S, T],
+  private def clients[A, B <: AwsClientBuilder[B, A]](
+    builder: AwsClientBuilder[B, A],
     configuration: Configuration,
     regionList: Regions*
-  ): Map[(String, Regions), T] = {
+  ): Map[(String, Regions), A] = {
     val list = for {
       account <- Config.getAwsAccounts(configuration)
       region <- regionList

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -16,7 +16,7 @@ import utils.attempt.{Attempt, Failure}
 
 
 object AWS {
-  def credentialsProvider(account: AwsAccount): AWSCredentialsProviderChain = {
+  private def credentialsProvider(account: AwsAccount): AWSCredentialsProviderChain = {
     new AWSCredentialsProviderChain(
       new STSAssumeRoleSessionCredentialsProvider.Builder(account.roleArn, "security-hq").build(),
       new ProfileCredentialsProvider(account.id)

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -26,7 +26,7 @@ object CloudFormation {
     handleAWSErrs(awsToScala(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
   }
 
-  private def getStacks(account: AwsAccount, region: Regions, cfnClients: Map[(String, Regions),AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
+  private def getStacks(account: AwsAccount, region: Regions, cfnClients: Map[(String, Regions), AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
       cloudClient <- client(cfnClients, account, region)
       stacks <- getStackDescriptions(cloudClient)

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -1,52 +1,52 @@
 package aws.cloudformation
 
-import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import aws.ec2.EC2
-import com.amazonaws.auth.AWSCredentialsProviderChain
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.cloudformation.model._
-import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder}
+import com.amazonaws.services.ec2.AmazonEC2Async
 import model.{AwsAccount, AwsStack}
-import utils.attempt.Attempt
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 object CloudFormation {
-  private def client(auth: AWSCredentialsProviderChain, region: Region): AmazonCloudFormationAsync = {
-    AmazonCloudFormationAsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(region.getName)
-      .build()
-  }
-  private def client(awsAccount: AwsAccount, region: Region): AmazonCloudFormationAsync = {
-    val auth = AWS.credentialsProvider(awsAccount)
-    client(auth, region)
-  }
 
+  def client(cfnClients: Map[(String, Regions),AmazonCloudFormationAsync], awsAccount: AwsAccount, region: Regions): Attempt[AmazonCloudFormationAsync] =
+    Attempt.fromOption(cfnClients.get((awsAccount.id, region)), FailedAttempt(Failure(
+      s"No AWS Cloudformation Client exists for ${awsAccount.id} and $region",
+      s"Cannot find Cloudformation Client",
+      500
+    )
+  ))
   private def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
     val request = new DescribeStacksRequest()
     handleAWSErrs(awsToScala(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
   }
 
-  private def getStacks(account: AwsAccount, region: Region)(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
-    val cloudClient = CloudFormation.client(account, region)
+  private def getStacks(account: AwsAccount, region: Regions, cfnClients: Map[(String, Regions),AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
+      cloudClient <- client(cfnClients, account, region)
       stacks <- getStackDescriptions(cloudClient)
     } yield parseStacks(stacks, region)
   }
 
-  def getStacksFromAllRegions(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
-    val regionClient = EC2.client(account)
+  def getStacksFromAllRegions(
+    account: AwsAccount,
+    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    ec2Clients: Map[(String, Regions), AmazonEC2Async]
+  )(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
+      regionClient <- EC2.client(ec2Clients, account, Regions.EU_WEST_1)
       availableRegions <- EC2.getAvailableRegions(regionClient)
-      regions = availableRegions.map(region => Region.getRegion(Regions.fromName(region.getRegionName)))
-      stacks <- Attempt.flatTraverse(regions)(region => getStacks(account, region))
+      regions = availableRegions.map(region => Regions.fromName(region.getRegionName))
+      stacks <- Attempt.flatTraverse(regions)(region => getStacks(account, region, cfnClients))
     } yield stacks
   }
 
-  private[cloudformation] def parseStacks(stacks: List[Stack], region: Region): List[AwsStack] = {
+  private[cloudformation] def parseStacks(stacks: List[Stack], region: Regions): List[AwsStack] = {
     stacks.map { stack =>
       AwsStack(
         stack.getStackId,

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 
 object CloudFormation {
 
-  def client(cfnClients: Map[(String, Regions),AmazonCloudFormationAsync], awsAccount: AwsAccount, region: Regions): Attempt[AmazonCloudFormationAsync] =
+  def client(cfnClients: Map[(String, Regions), AmazonCloudFormationAsync], awsAccount: AwsAccount, region: Regions): Attempt[AmazonCloudFormationAsync] =
     Attempt.fromOption(cfnClients.get((awsAccount.id, region)), FailedAttempt(Failure(
       s"No AWS Cloudformation Client exists for ${awsAccount.id} and $region",
       s"Cannot find Cloudformation Client",

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -196,11 +196,7 @@ object EC2 {
     Attempt.traverse(flaggedSgs.map(_.region).distinct) { region =>
       val awsRegion = Regions.fromName(region)
       for {
-        ec2Client <- Attempt.fromOption(ec2Clients.get((account.id, awsRegion)), FailedAttempt(Failure(
-          s"No AWS EC2 Client exists for ${account.id} and $region",
-          s"Cannot find EC2 Client",
-          500
-        )))
+        ec2Client <- client(ec2Clients, account, awsRegion)
         vpcDetails <- vpcsDetailsF(ec2Client)
       } yield vpcDetails
 

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -19,7 +19,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object EC2 {
 
-  def client(ec2Clients: Map[(String, Regions),AmazonEC2Async], awsAccount: AwsAccount, region: Regions): Attempt[AmazonEC2Async] = Attempt.fromOption(ec2Clients.get((awsAccount.id, region)), FailedAttempt(Failure(
+  def client(ec2Clients: Map[(String, Regions), AmazonEC2Async], awsAccount: AwsAccount, region: Regions): Attempt[AmazonEC2Async] = Attempt.fromOption(ec2Clients.get((awsAccount.id, region)), FailedAttempt(Failure(
     s"No AWS EC2 Client exists for ${awsAccount.id} and $region",
     s"Cannot find EC2 Client",
     500

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -1,35 +1,29 @@
 package aws.ec2
 
-import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import aws.support.{TrustedAdvisor, TrustedAdvisorSGOpenPorts}
 import cats.instances.map._
 import cats.instances.set._
 import cats.syntax.semigroup._
-import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.ec2.AmazonEC2Async
 import com.amazonaws.services.ec2.model._
-import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
+import com.amazonaws.services.support.AWSSupportAsync
 import com.amazonaws.services.support.model.RefreshTrustedAdvisorCheckResult
 import model._
-import utils.attempt.{Attempt, FailedAttempt}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 
 object EC2 {
-  def client(auth: AWSCredentialsProviderChain, region: Regions): AmazonEC2Async = {
-    AmazonEC2AsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(region)
-      .build()
-  }
 
-  def client(awsAccount: AwsAccount, region: Regions = Regions.EU_WEST_1): AmazonEC2Async = {
-    val auth = AWS.credentialsProvider(awsAccount)
-    client(auth, region)
-  }
+  def client(ec2Clients: Map[(String, Regions),AmazonEC2Async], awsAccount: AwsAccount, region: Regions): Attempt[AmazonEC2Async] = Attempt.fromOption(ec2Clients.get((awsAccount.id, region)), FailedAttempt(Failure(
+    s"No AWS EC2 Client exists for ${awsAccount.id} and $region",
+    s"Cannot find EC2 Client",
+    500
+  )))
 
   def getAvailableRegions(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Region]] = {
     val request = new DescribeRegionsRequest()
@@ -43,13 +37,22 @@ object EC2 {
     * makes EC2 calls in each region to look up the Network Interfaces
     * attached to each flagged Security Group.
     */
-  def getSgsUsage(sgReport: TrustedAdvisorDetailsResult[SGOpenPortsDetail], awsAccount: AwsAccount)(implicit ec: ExecutionContext): Attempt[Map[String, Set[SGInUse]]] = {
+  def getSgsUsage(
+      sgReport: TrustedAdvisorDetailsResult[SGOpenPortsDetail],
+      awsAccount: AwsAccount,
+      ec2Clients: Map[(String, Regions), AmazonEC2Async]
+    )(implicit ec: ExecutionContext): Attempt[Map[String, Set[SGInUse]]] = {
     val allSgIds = TrustedAdvisorSGOpenPorts.sgIds(sgReport)
     val activeRegions = sgReport.flaggedResources.map(sgInfo => Regions.fromName(sgInfo.region)).distinct
 
     for {
+
       dnirs <- Attempt.traverse(activeRegions){ region =>
-        getSgsUsageForRegion(allSgIds, client(awsAccount, region))
+        for {
+          ec2Client <- client(ec2Clients, awsAccount, region)
+          usage <- getSgsUsageForRegion(allSgIds, ec2Client)
+        } yield usage
+
       }
     } yield {
       dnirs
@@ -58,34 +61,36 @@ object EC2 {
     }
   }
 
-  def flaggedSgsForAccount(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[(SGOpenPortsDetail, Set[SGInUse])]] = {
-    val supportClient = TrustedAdvisor.client(account)
+  def flaggedSgsForAccount(account: AwsAccount, ec2Clients: Map[(String, Regions), AmazonEC2Async], taClients: Map[(String, Regions), AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[(SGOpenPortsDetail, Set[SGInUse])]] = {
     for {
+      supportClient <- TrustedAdvisor.client(taClients, account)
       sgResult <- TrustedAdvisorSGOpenPorts.getSGOpenPorts(supportClient)
-      sgUsage <- getSgsUsage(sgResult, account)
+      sgUsage <- getSgsUsage(sgResult, account, ec2Clients)
       flaggedSgs = sgResult.flaggedResources.filter(_.status != "ok")
       flaggedSgsIds = flaggedSgs.map(_.id)
       regions = flaggedSgs.map(sg => Regions.fromName(sg.region)).distinct
-      clients = regions.map(client(account, _))
+      clients <- Attempt.traverse(regions)(region => client(ec2Clients, account, region))
       describeSecurityGroupsResults <- Attempt.traverse(clients)(EC2.describeSecurityGroups(flaggedSgsIds))
       sgTagDetails = describeSecurityGroupsResults.flatMap(extractTagsForSecurityGroups).toMap
       enrichedFlaggedSgs = enrichSecurityGroups(flaggedSgs, sgTagDetails)
-      vpcs <- getVpcs(account, enrichedFlaggedSgs)(getVpcsDetails)
+      vpcs <- getVpcs(account, enrichedFlaggedSgs, ec2Clients)(getVpcsDetails)
       flaggedSgsWithVpc = addVpcName(enrichedFlaggedSgs, vpcs)
     } yield sortSecurityGroupsByInUse(flaggedSgsWithVpc, sgUsage)
   }
 
-  def refreshSGSReports(accounts: List[AwsAccount])(implicit ec: ExecutionContext): Attempt[List[Either[FailedAttempt, RefreshTrustedAdvisorCheckResult]]] = {
+  def refreshSGSReports(accounts: List[AwsAccount], taClients: Map[(String, Regions), AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[Either[FailedAttempt, RefreshTrustedAdvisorCheckResult]]] = {
     Attempt.traverseWithFailures(accounts) { account =>
-      val supportClient = TrustedAdvisor.client(account)
-      TrustedAdvisorSGOpenPorts.refreshSGOpenPorts(supportClient)
+      for {
+        supportClient <- TrustedAdvisor.client(taClients, account)
+        result <- TrustedAdvisorSGOpenPorts.refreshSGOpenPorts(supportClient)
+      } yield result
     }
   }
 
-  def allFlaggedSgs(accounts: List[AwsAccount])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]])]] = {
+  def allFlaggedSgs(accounts: List[AwsAccount], ec2Clients: Map[(String, Regions), AmazonEC2Async], taClients: Map[(String, Regions), AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]])]] = {
     Attempt.Async.Right {
       Future.traverse(accounts) { account =>
-        flaggedSgsForAccount(account).asFuture.map(account -> _)
+        flaggedSgsForAccount(account, ec2Clients, taClients).asFuture.map(account -> _)
       }
     }
   }
@@ -187,10 +192,18 @@ object EC2 {
     }
   }
 
-  private[ec2] def getVpcs(account: AwsAccount, flaggedSgs: List[SGOpenPortsDetail])(vpcsDetailsF: AmazonEC2Async => Attempt[Map[String, Vpc]])(implicit ec: ExecutionContext): Attempt[Map[String, Vpc]] = {
+  private[ec2] def getVpcs(account: AwsAccount, flaggedSgs: List[SGOpenPortsDetail], ec2Clients: Map[(String, Regions), AmazonEC2Async])(vpcsDetailsF: AmazonEC2Async => Attempt[Map[String, Vpc]])(implicit ec: ExecutionContext): Attempt[Map[String, Vpc]] = {
     Attempt.traverse(flaggedSgs.map(_.region).distinct) { region =>
-      val ec2Client = client(account, Regions.fromName(region))
-      vpcsDetailsF(ec2Client)
+      val awsRegion = Regions.fromName(region)
+      for {
+        ec2Client <- Attempt.fromOption(ec2Clients.get((account.id, awsRegion)), FailedAttempt(Failure(
+          s"No AWS EC2 Client exists for ${account.id} and $region",
+          s"Cannot find EC2 Client",
+          500
+        )))
+        vpcDetails <- vpcsDetailsF(ec2Client)
+      } yield vpcDetails
+
     }.map(_.fold(Map.empty)(_ ++ _))
   }
 

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -20,8 +20,8 @@ object IAMClient {
   def client(iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync], awsAccount: AwsAccount): Attempt[ AmazonIdentityManagementAsync] = {
     val region = Regions.US_EAST_1
     Attempt.fromOption(iamClients.get((awsAccount.id, region)), FailedAttempt(Failure(
-      s"No AWS Trusted Advisor Client exists for ${awsAccount.id} and $region",
-      s"Cannot find Trusted Advisor Client",
+      s"No AWS IAM Client exists for ${awsAccount.id} and $region",
+      s"Cannot find IAM Client",
       500
     )))
   }

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -1,27 +1,31 @@
 package aws.iam
 
-import aws.AWS
 import aws.AwsAsyncHandler._
 import aws.cloudformation.CloudFormation
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
+import com.amazonaws.services.ec2.AmazonEC2Async
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest}
-import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
 import logic.{ReportDisplay, Retry}
 import model.{AwsAccount, CredentialReportDisplay, IAMCredentialsReport}
-import utils.attempt.{Attempt, FailedAttempt}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 
 object IAMClient {
-  private def client(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonIdentityManagementAsync = {
-    val auth = AWS.credentialsProvider(account)
-    AmazonIdentityManagementAsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName)
-      .build()
+
+  def client(iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync], awsAccount: AwsAccount): Attempt[ AmazonIdentityManagementAsync] = {
+    val region = Regions.US_EAST_1
+    Attempt.fromOption(iamClients.get((awsAccount.id, region)), FailedAttempt(Failure(
+      s"No AWS Trusted Advisor Client exists for ${awsAccount.id} and $region",
+      s"Cannot find Trusted Advisor Client",
+      500
+    )))
   }
+
 
   private def generateCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[GenerateCredentialReportResult] = {
     val request = new GenerateCredentialReportRequest()
@@ -33,21 +37,32 @@ object IAMClient {
     handleAWSErrs(awsToScala(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
   }
 
-  def getCredentialReportDisplay(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
+  def getCredentialReportDisplay(
+    account: AwsAccount,
+    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    ec2Clients: Map[(String, Regions), AmazonEC2Async],
+    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync]
+  )(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
     val delay = 3.seconds
-    val client = IAMClient.client(account)
+
     for {
+      client <- IAMClient.client(iamClients, account)
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
-      stacks <- CloudFormation.getStacksFromAllRegions(account)
+      stacks <- CloudFormation.getStacksFromAllRegions(account, cfnClients, ec2Clients)
       enrichedReport = CredentialsReport.enrichReportWithStackDetails(report, stacks)
     } yield ReportDisplay.toCredentialReportDisplay(enrichedReport)
   }
 
-  def getAllCredentialReports(accounts: Seq[AwsAccount])(implicit executionContext: ExecutionContext): Attempt[Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]] = {
+  def getAllCredentialReports(
+    accounts: Seq[AwsAccount],
+    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    ec2Clients: Map[(String, Regions), AmazonEC2Async],
+    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync]
+  )(implicit executionContext: ExecutionContext): Attempt[Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]] = {
     Attempt.Async.Right {
       Future.traverse(accounts) { account =>
-        getCredentialReportDisplay(account).asFuture.map(account -> _)
+        getCredentialReportDisplay(account, cfnClients, ec2Clients, iamClients).asFuture.map(account -> _)
       }
     }
   }

--- a/hq/app/aws/inspector/Inspector.scala
+++ b/hq/app/aws/inspector/Inspector.scala
@@ -1,32 +1,19 @@
 package aws.inspector
 
-import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.inspector.AmazonInspectorAsync
 import com.amazonaws.services.inspector.model._
-import com.amazonaws.services.inspector.{AmazonInspectorAsync, AmazonInspectorAsyncClientBuilder}
 import logic.InspectorResults
 import logic.InspectorResults._
 import model.{AwsAccount, InspectorAssessmentRun}
-import utils.attempt.{Attempt, FailedAttempt}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 
 object Inspector {
-  def client(auth: AWSCredentialsProviderChain, region: Regions): AmazonInspectorAsync = {
-    AmazonInspectorAsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(region)
-      .build()
-  }
-
-  def client(awsAccount: AwsAccount, region: Regions): AmazonInspectorAsync = {
-    val auth = AWS.credentialsProvider(awsAccount)
-    client(auth, region)
-  }
 
   def listInspectorRuns(client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val request = new ListAssessmentRunsRequest()
@@ -44,14 +31,19 @@ object Inspector {
     }
   }
 
-  def allInspectorRuns(accounts: List[AwsAccount])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])]] = {
-    Attempt.labelledTaverseWithFailures(accounts)(Inspector.inspectorRuns)
+  def allInspectorRuns(accounts: List[AwsAccount], inspectorClients: Map[(String, Regions), AmazonInspectorAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])]] = {
+    Attempt.labelledTraverseWithFailures(accounts)(Inspector.inspectorRuns(inspectorClients))
   }
 
-  def inspectorRuns(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
+  def inspectorRuns(inspectorClients: Map[(String, Regions), AmazonInspectorAsync])(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
     val region = Regions.EU_WEST_1  // we only automatically run inspections in Ireland
-    val inspectorClient = client(account, region)
+
     for {
+      inspectorClient <- Attempt.fromOption(inspectorClients.get((account.id, region)), FailedAttempt(Failure(
+          s"No AWS Inspector Client exists for ${account.id} and $region",
+          s"Cannot find Inspector Client",
+          500
+      )))
       inspectorRunArns <- Inspector.listInspectorRuns(inspectorClient)
       assessmentRuns <- Inspector.describeInspectorRuns(inspectorRunArns, inspectorClient)
       processedAssessmentRuns = InspectorResults.relevantRuns(assessmentRuns)

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -24,9 +24,9 @@ class HQController (val config: Configuration, cacheService: CacheService, val a
   }
 
   def iam = authAction {
-    val exposedKeys = cacheService.getAllExposedKeys()
+    val exposedKeys = cacheService.getAllExposedKeys
     val keysSummary = exposedKeysSummary(exposedKeys)
-    val accountsAndReports = cacheService.getAllCredentials()
+    val accountsAndReports = cacheService.getAllCredentials
     val sortedAccountsAndReports = sortAccountsByReportSummary(accountsAndReports.toList)
     Ok(views.html.iam.iam(sortedAccountsAndReports, keysSummary))
   }

--- a/hq/app/controllers/InspectorController.scala
+++ b/hq/app/controllers/InspectorController.scala
@@ -3,7 +3,6 @@ package controllers
 import auth.SecurityHQAuthActions
 import aws.AWS
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.inspector.AmazonInspectorAsync
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
 import logic.InspectorResults
@@ -16,8 +15,7 @@ import utils.attempt.PlayIntegration.attempt
 
 import scala.concurrent.ExecutionContext
 
-class InspectorController(val inspectorClients: Map[(String, Regions), AmazonInspectorAsync],
-                          val config: Configuration,
+class InspectorController(val config: Configuration,
                           val cacheService: CacheService,
                           val authConfig: GoogleAuthConfig)
                          (implicit

--- a/hq/app/controllers/InspectorController.scala
+++ b/hq/app/controllers/InspectorController.scala
@@ -2,8 +2,8 @@ package controllers
 
 import auth.SecurityHQAuthActions
 import aws.AWS
-import aws.inspector.Inspector
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.inspector.AmazonInspectorAsync
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
 import logic.InspectorResults
@@ -16,7 +16,8 @@ import utils.attempt.PlayIntegration.attempt
 
 import scala.concurrent.ExecutionContext
 
-class InspectorController(val config: Configuration,
+class InspectorController(val inspectorClients: Map[(String, Regions), AmazonInspectorAsync],
+                          val config: Configuration,
                           val cacheService: CacheService,
                           val authConfig: GoogleAuthConfig)
                          (implicit
@@ -33,7 +34,7 @@ class InspectorController(val config: Configuration,
   private val accounts = Config.getAwsAccounts(config)
 
   def inspector = authAction {
-    val accountAssessmentRuns = cacheService.getAllInspectorResults()
+    val accountAssessmentRuns = cacheService.getAllInspectorResults
     val sorted = InspectorResults.sortAccountResults(accountAssessmentRuns.toList)
     Ok(views.html.inspector.inspector(sorted))
   }

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -21,7 +21,7 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
   private val accounts = Config.getAwsAccounts(config)
 
   def securityGroups = authAction {
-    val allFlaggedSgs = cacheService.getAllSgs()
+    val allFlaggedSgs = cacheService.getAllSgs
     val sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs.toList)
     Ok(views.html.sgs.sgs(sortedFlaggedSgs))
   }

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -117,7 +117,7 @@ object InspectorResults {
     assessmentRuns.flatMap(_.findingCounts.values).sum
   }
 
-  def completedDaysAgo(assessmentRun: InspectorAssessmentRun): Int = Days.daysBetween(new DateTime(), assessmentRun.completedAt).getDays
+  def completedDaysAgo(assessmentRun: InspectorAssessmentRun): Int = Days.daysBetween(assessmentRun.completedAt, new DateTime()).getDays
 
   def formatCompletedAtTimeOnly(assessmentRun: InspectorAssessmentRun): String = DateTimeFormat.forPattern("HH:mm:ss").print(assessmentRun.completedAt)
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -126,7 +126,7 @@ class CacheService(
     setUpQuartzScheduleJob(Cache.AWSInspector, "45 20 1,7,13,19 * * ?")
   }
 
-  private def setUpQuartzScheduleJob(cache: Cache.EnumVal, cronString: String) = {
+  private def setUpQuartzScheduleJob(cache: Cache.EnumVal, cronString: String): Unit = {
     val jobKey = JobKey.jobKey(cache.toString, "refresh")
     val schedule = CronScheduleBuilder.cronSchedule(cronString)
 
@@ -168,7 +168,7 @@ class CacheService(
     case object Credentials extends EnumVal
     case object ExposedKeys extends EnumVal
     case object SecurityGroups extends EnumVal
-    def find(name: String) = Set(AWSInspector, Credentials, ExposedKeys, SecurityGroups)
+    def find(name: String): Cache.EnumVal = Set(AWSInspector, Credentials, ExposedKeys, SecurityGroups)
       .find(c => c.toString.equals(name)).get
   }
 }

--- a/hq/app/utils/attempt/Attempt.scala
+++ b/hq/app/utils/attempt/Attempt.scala
@@ -107,7 +107,7 @@ object Attempt {
     *
     * Combines the behaviours of labelledTraverse and traverseWithFailures.
     */
-  def labelledTaverseWithFailures[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[(A, Either[FailedAttempt, B])]] = {
+  def labelledTraverseWithFailures[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[(A, Either[FailedAttempt, B])]] = {
     Async.Right(Future.traverse(as)(a => f(a).asFuture.map(a -> _)))
   }
 

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -1,6 +1,7 @@
 package aws
 
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.inspector.AmazonInspectorAsyncClientBuilder
 import com.typesafe.config.ConfigFactory
 import org.scalatest.prop.{Checkers, PropertyChecks}
 import org.scalatest.{FreeSpec, Matchers}
@@ -9,7 +10,7 @@ import utils.attempt.AttemptValues
 
 class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks with AttemptValues {
 
-  "clients" - {
+  "real clients" - {
 
     val config = ConfigFactory.parseString(
       s"""
@@ -58,4 +59,30 @@ class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
     }
 
   }
+
+  "mock clients" - {
+
+    val config = ConfigFactory.parseString(
+      s"""
+         | {
+         |   "hq": {
+         |     "accounts" : [
+         |       {
+         |         "name": "Mock"
+         |         "id": "mock"
+         |         "roleArn": ""
+         |       }
+         |     ]
+         |   }
+         | }
+       """.stripMargin
+    )
+    val configuration = Configuration(config)
+
+    "correct account and region" in {
+      val keys = AWS.clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, Regions.EU_WEST_1).keys
+      keys should contain (("mock", Regions.EU_WEST_1))
+    }
+  }
+
 }

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -1,0 +1,61 @@
+package aws
+
+import com.amazonaws.regions.Regions
+import com.typesafe.config.ConfigFactory
+import org.scalatest.prop.{Checkers, PropertyChecks}
+import org.scalatest.{FreeSpec, Matchers}
+import play.api.Configuration
+import utils.attempt.AttemptValues
+
+class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks with AttemptValues {
+
+  "clients" - {
+
+    val config = ConfigFactory.parseString(
+      s"""
+         | {
+         |   "hq": {
+         |     "accounts" : [
+         |       {
+         |         "name": "Test1"
+         |         "id": "test1"
+         |         "roleArn": ""
+         |       },
+         |       {
+         |         "name": "Test2"
+         |         "id": "test2"
+         |         "roleArn": ""
+         |       }
+         |     ]
+         |   }
+         | }
+       """.stripMargin
+    )
+    val configuration = Configuration(config)
+    
+    //Two accounts, all regions.
+    val allRegionsSize = Regions.values().size * 2
+    // Only in one region.
+    val singleRegionSize = 2
+
+    "inspector" in {
+      AWS.inspectorClients(configuration) should have size(singleRegionSize)
+    }
+    "ec2" in {
+      AWS.ec2Clients(configuration) should have size(allRegionsSize)
+    }
+
+    "cloudformation" in {
+      AWS.cfnClients(configuration) should have size(allRegionsSize)
+    }
+
+    "trusted advisor" in {
+      AWS.taClients(configuration) should have size(singleRegionSize)
+    }
+
+    "iam" in {
+      AWS.iamClients(configuration) should have size(allRegionsSize)
+    }
+
+  }
+}

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -32,7 +32,7 @@ class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
        """.stripMargin
     )
     val configuration = Configuration(config)
-    
+
     //Two accounts, all regions.
     val allRegionsSize = Regions.values().size * 2
     // Only in one region.

--- a/hq/test/aws/cloudformation/CloudFormationTest.scala
+++ b/hq/test/aws/cloudformation/CloudFormationTest.scala
@@ -1,6 +1,6 @@
 package aws.cloudformation
 
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.model.Stack
 import model.AwsStack
 import org.scalatest.{FreeSpec, Matchers}
@@ -9,7 +9,7 @@ class CloudFormationTest extends FreeSpec with Matchers {
 
   "parseStacks" - {
     val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
-    val region = Region.getRegion(Regions.EU_WEST_1)
+    val region = Regions.EU_WEST_1
     val exampleStack = new Stack().withStackId(stackId).withStackName("example-stack-A")
 
     "will parse and extract each stack, including setting the the region" in {


### PR DESCRIPTION
## What does this change?

Never create AWS Clients on demand, but re-use pre-created clients instead.

## What is the value of this?

AWS Clients wrap thread pools and have their own root threads, and thus are not garbage collected.  If a new client is created, it must be explicitly shutdown to avoid a leak.  Alternatively, create one per account per region at the start, and re-use it forevery.  This is what we have done.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No