### PR TITLE
Drop the `Stage`tags from the list of tags sent by lambdaSecurityGroups

### DIFF
--- a/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
+++ b/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
@@ -62,7 +62,6 @@ object Notifier extends StrictLogging {
   private def getTargetsFromTags(tags: List[Tag], account: String):List[Target] = {
     val stack = tags.find(t => t.key.equals("Stack")).map(t => Stack(t.value))
     val app = tags.find(t => t.key.equals("App")).map(t => App(t.value))
-    val stage = tags.find(t => t.key.equals("Stage")).map(t => Stage(t.value))
-    List(stack, app, stage, Some(AwsAccount(account))).flatten
+    List(stack, app, Some(AwsAccount(account))).flatten
   }
 }

--- a/lambda/security-groups/src/test/scala/com/gu/hq/NotifierTest.scala
+++ b/lambda/security-groups/src/test/scala/com/gu/hq/NotifierTest.scala
@@ -89,9 +89,9 @@ class NotifierTest extends FreeSpec with Matchers with OptionValues {
       notification.message should include(groupId)
     }
 
-    "adds stack stage and app to target" in {
+    "adds stack and app to target" in {
       val notification = createNotification(groupId, targetTags, accountId, accountName, regionName)
-      notification.target.toSet should contain allOf (Stack("stack"), App("app"), Stage("PROD"))
+      notification.target.toSet should contain allOf (Stack("stack"), App("app"))
     }
   }
 }


### PR DESCRIPTION
This change will, in particular, cause CODE stacks to emit security groups notifications.
