### PR TITLE
Jr revert to observables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ yarn-error.log*
 
 # Dependency directories
 node_modules/
+
+# Local notes directory
+notes

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,6 @@ lazy val hq = (project in file("hq"))
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-      "org.quartz-scheduler" % "quartz" % "2.3.0",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -1,3 +1,4 @@
+import aws.AWS
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.gu.configraun.Configraun
 import com.gu.configraun.aws.AWSSimpleSystemsManagementFactory
@@ -52,8 +53,22 @@ class AppComponents(context: Context)
     }
   }
 
-  private val cacheService = new CacheService(configuration, applicationLifecycle, environment)
   private val googleAuthConfig = Config.googleSettings(httpConfiguration, configuration)
+  private val inspectorClients = AWS.inspectorClients(configuration)
+  private val ec2Clients = AWS.ec2Clients(configuration)
+  private val cfnClients = AWS.cfnClients(configuration)
+  private val taClients = AWS.taClients(configuration)
+  private val iamClients = AWS.iamClients(configuration)
+
+  private val cacheService = new CacheService(
+    configuration,
+    applicationLifecycle,
+    environment,
+    inspectorClients,
+    ec2Clients,
+    cfnClients,
+    taClients,
+    iamClients)
 
   override def router: Router = new Routes(
     httpErrorHandler,

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -1,13 +1,24 @@
 package aws
 
+import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{AWSCredentialsProviderChain, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.client.builder.AwsClientBuilder
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder}
+import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
+import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
+import com.amazonaws.services.inspector.{AmazonInspectorAsync, AmazonInspectorAsyncClientBuilder}
+import com.amazonaws.services.support.{AWSSupportAsync, AWSSupportAsyncClientBuilder}
+import config.Config
 import model.AwsAccount
+import play.api.Configuration
 import utils.attempt.{Attempt, Failure}
 
 
 object AWS {
-  def credentialsProvider(account: AwsAccount): AWSCredentialsProviderChain = {
+
+  private def credentialsProvider(account: AwsAccount): AWSCredentialsProviderChain = {
     new AWSCredentialsProviderChain(
       new STSAssumeRoleSessionCredentialsProvider.Builder(account.roleArn, "security-hq").build(),
       new ProfileCredentialsProvider(account.id)
@@ -20,4 +31,39 @@ object AWS {
       Failure.awsAccountNotFound(accountId).attempt
     )
   }
+
+  private[aws] def clients[A, B <: AwsClientBuilder[B, A]](
+    builder: AwsClientBuilder[B, A],
+    configuration: Configuration,
+    regionList: Regions*
+  ): Map[(String, Regions), A] = {
+    val list = for {
+      account <- Config.getAwsAccounts(configuration)
+      region <- regionList
+      client = builder
+        .withCredentials(credentialsProvider(account))
+        .withRegion(region)
+        .withClientConfiguration(new ClientConfiguration().withMaxConnections(10))
+        .build()
+    } yield (account.id, region) -> client
+    list.toMap
+  }
+
+  // Only needs Regions.EU_WEST_1
+  def inspectorClients(configuration: Configuration): Map[(String, Regions), AmazonInspectorAsync] =
+    clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, Regions.EU_WEST_1)
+
+  def ec2Clients(configuration: Configuration): Map[(String, Regions), AmazonEC2Async] =
+    clients(AmazonEC2AsyncClientBuilder.standard(), configuration, Regions.values():_*)
+
+  def cfnClients(configuration: Configuration): Map[(String, Regions), AmazonCloudFormationAsync] =
+    clients(AmazonCloudFormationAsyncClientBuilder.standard(), configuration, Regions.values():_*)
+
+  // Only needs Regions.US_EAST_1
+  def taClients(configuration: Configuration): Map[(String, Regions), AWSSupportAsync] =
+    clients(AWSSupportAsyncClientBuilder.standard(), configuration, Regions.US_EAST_1)
+
+  def iamClients(configuration: Configuration): Map[(String, Regions), AmazonIdentityManagementAsync] =
+    clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, Regions.values():_*)
+
 }

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -1,52 +1,52 @@
 package aws.cloudformation
 
-import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import aws.ec2.EC2
-import com.amazonaws.auth.AWSCredentialsProviderChain
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.cloudformation.model._
-import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder}
+import com.amazonaws.services.ec2.AmazonEC2Async
 import model.{AwsAccount, AwsStack}
-import utils.attempt.Attempt
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 object CloudFormation {
-  private def client(auth: AWSCredentialsProviderChain, region: Region): AmazonCloudFormationAsync = {
-    AmazonCloudFormationAsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(region.getName)
-      .build()
-  }
-  private def client(awsAccount: AwsAccount, region: Region): AmazonCloudFormationAsync = {
-    val auth = AWS.credentialsProvider(awsAccount)
-    client(auth, region)
-  }
 
+  def client(cfnClients: Map[(String, Regions), AmazonCloudFormationAsync], awsAccount: AwsAccount, region: Regions): Attempt[AmazonCloudFormationAsync] =
+    Attempt.fromOption(cfnClients.get((awsAccount.id, region)), FailedAttempt(Failure(
+      s"No AWS Cloudformation Client exists for ${awsAccount.id} and $region",
+      s"Cannot find Cloudformation Client",
+      500
+    )
+  ))
   private def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
     val request = new DescribeStacksRequest()
     handleAWSErrs(awsToScala(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
   }
 
-  private def getStacks(account: AwsAccount, region: Region)(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
-    val cloudClient = CloudFormation.client(account, region)
+  private def getStacks(account: AwsAccount, region: Regions, cfnClients: Map[(String, Regions), AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
+      cloudClient <- client(cfnClients, account, region)
       stacks <- getStackDescriptions(cloudClient)
     } yield parseStacks(stacks, region)
   }
 
-  def getStacksFromAllRegions(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
-    val regionClient = EC2.client(account)
+  def getStacksFromAllRegions(
+    account: AwsAccount,
+    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    ec2Clients: Map[(String, Regions), AmazonEC2Async]
+  )(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
+      regionClient <- EC2.client(ec2Clients, account, Regions.EU_WEST_1)
       availableRegions <- EC2.getAvailableRegions(regionClient)
-      regions = availableRegions.map(region => Region.getRegion(Regions.fromName(region.getRegionName)))
-      stacks <- Attempt.flatTraverse(regions)(region => getStacks(account, region))
+      regions = availableRegions.map(region => Regions.fromName(region.getRegionName))
+      stacks <- Attempt.flatTraverse(regions)(region => getStacks(account, region, cfnClients))
     } yield stacks
   }
 
-  private[cloudformation] def parseStacks(stacks: List[Stack], region: Region): List[AwsStack] = {
+  private[cloudformation] def parseStacks(stacks: List[Stack], region: Regions): List[AwsStack] = {
     stacks.map { stack =>
       AwsStack(
         stack.getStackId,

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -1,27 +1,31 @@
 package aws.iam
 
-import aws.AWS
 import aws.AwsAsyncHandler._
 import aws.cloudformation.CloudFormation
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
+import com.amazonaws.services.ec2.AmazonEC2Async
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest}
-import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
 import logic.{ReportDisplay, Retry}
 import model.{AwsAccount, CredentialReportDisplay, IAMCredentialsReport}
-import utils.attempt.{Attempt, FailedAttempt}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 
 object IAMClient {
-  private def client(account: AwsAccount, region: Region = Region.getRegion(Regions.EU_WEST_1)): AmazonIdentityManagementAsync = {
-    val auth = AWS.credentialsProvider(account)
-    AmazonIdentityManagementAsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(Option(Regions.getCurrentRegion).getOrElse(region).getName)
-      .build()
+
+  def client(iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync], awsAccount: AwsAccount): Attempt[ AmazonIdentityManagementAsync] = {
+    val region = Regions.US_EAST_1
+    Attempt.fromOption(iamClients.get((awsAccount.id, region)), FailedAttempt(Failure(
+      s"No AWS IAM Client exists for ${awsAccount.id} and $region",
+      s"Cannot find IAM Client",
+      500
+    )))
   }
+
 
   private def generateCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[GenerateCredentialReportResult] = {
     val request = new GenerateCredentialReportRequest()
@@ -33,21 +37,32 @@ object IAMClient {
     handleAWSErrs(awsToScala(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
   }
 
-  def getCredentialReportDisplay(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
+  def getCredentialReportDisplay(
+    account: AwsAccount,
+    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    ec2Clients: Map[(String, Regions), AmazonEC2Async],
+    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync]
+  )(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
     val delay = 3.seconds
-    val client = IAMClient.client(account)
+
     for {
+      client <- IAMClient.client(iamClients, account)
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
-      stacks <- CloudFormation.getStacksFromAllRegions(account)
+      stacks <- CloudFormation.getStacksFromAllRegions(account, cfnClients, ec2Clients)
       enrichedReport = CredentialsReport.enrichReportWithStackDetails(report, stacks)
     } yield ReportDisplay.toCredentialReportDisplay(enrichedReport)
   }
 
-  def getAllCredentialReports(accounts: Seq[AwsAccount])(implicit executionContext: ExecutionContext): Attempt[Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]] = {
+  def getAllCredentialReports(
+    accounts: Seq[AwsAccount],
+    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    ec2Clients: Map[(String, Regions), AmazonEC2Async],
+    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync]
+  )(implicit executionContext: ExecutionContext): Attempt[Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]] = {
     Attempt.Async.Right {
       Future.traverse(accounts) { account =>
-        getCredentialReportDisplay(account).asFuture.map(account -> _)
+        getCredentialReportDisplay(account, cfnClients, ec2Clients, iamClients).asFuture.map(account -> _)
       }
     }
   }

--- a/hq/app/aws/inspector/Inspector.scala
+++ b/hq/app/aws/inspector/Inspector.scala
@@ -1,32 +1,25 @@
 package aws.inspector
 
-import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import com.amazonaws.auth.AWSCredentialsProviderChain
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.inspector.AmazonInspectorAsync
 import com.amazonaws.services.inspector.model._
-import com.amazonaws.services.inspector.{AmazonInspectorAsync, AmazonInspectorAsyncClientBuilder}
 import logic.InspectorResults
 import logic.InspectorResults._
 import model.{AwsAccount, InspectorAssessmentRun}
-import utils.attempt.{Attempt, FailedAttempt}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
-import collection.JavaConverters._
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
 
 object Inspector {
-  def client(auth: AWSCredentialsProviderChain, region: Regions): AmazonInspectorAsync = {
-    AmazonInspectorAsyncClientBuilder.standard()
-      .withCredentials(auth)
-      .withRegion(region)
-      .build()
-  }
 
-  def client(awsAccount: AwsAccount, region: Regions): AmazonInspectorAsync = {
-    val auth = AWS.credentialsProvider(awsAccount)
-    client(auth, region)
-  }
+  def client(inspectorClients: Map[(String, Regions), AmazonInspectorAsync], awsAccount: AwsAccount, region: Regions): Attempt[AmazonInspectorAsync] = Attempt.fromOption(inspectorClients.get((awsAccount.id, region)), FailedAttempt(Failure(
+    s"No AWS Inspector Client exists for ${awsAccount.id} and $region",
+    s"Cannot find Inspector Client",
+    500
+  )))
 
   def listInspectorRuns(client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val request = new ListAssessmentRunsRequest()
@@ -44,14 +37,15 @@ object Inspector {
     }
   }
 
-  def allInspectorRuns(accounts: List[AwsAccount])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])]] = {
-    Attempt.labelledTaverseWithFailures(accounts)(Inspector.inspectorRuns)
+  def allInspectorRuns(accounts: List[AwsAccount], inspectorClients: Map[(String, Regions), AmazonInspectorAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])]] = {
+    Attempt.labelledTraverseWithFailures(accounts)(Inspector.inspectorRuns(inspectorClients))
   }
 
-  def inspectorRuns(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
+  def inspectorRuns(inspectorClients: Map[(String, Regions), AmazonInspectorAsync])(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
     val region = Regions.EU_WEST_1  // we only automatically run inspections in Ireland
-    val inspectorClient = client(account, region)
+
     for {
+      inspectorClient <- client(inspectorClients, account, region)
       inspectorRunArns <- Inspector.listInspectorRuns(inspectorClient)
       assessmentRuns <- Inspector.describeInspectorRuns(inspectorRunArns, inspectorClient)
       processedAssessmentRuns = InspectorResults.relevantRuns(assessmentRuns)

--- a/hq/app/controllers/HQController.scala
+++ b/hq/app/controllers/HQController.scala
@@ -24,9 +24,9 @@ class HQController (val config: Configuration, cacheService: CacheService, val a
   }
 
   def iam = authAction {
-    val exposedKeys = cacheService.getAllExposedKeys()
+    val exposedKeys = cacheService.getAllExposedKeys
     val keysSummary = exposedKeysSummary(exposedKeys)
-    val accountsAndReports = cacheService.getAllCredentials()
+    val accountsAndReports = cacheService.getAllCredentials
     val sortedAccountsAndReports = sortAccountsByReportSummary(accountsAndReports.toList)
     Ok(views.html.iam.iam(sortedAccountsAndReports, keysSummary))
   }

--- a/hq/app/controllers/InspectorController.scala
+++ b/hq/app/controllers/InspectorController.scala
@@ -2,7 +2,6 @@ package controllers
 
 import auth.SecurityHQAuthActions
 import aws.AWS
-import aws.inspector.Inspector
 import com.amazonaws.regions.Regions
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
@@ -33,7 +32,7 @@ class InspectorController(val config: Configuration,
   private val accounts = Config.getAwsAccounts(config)
 
   def inspector = authAction {
-    val accountAssessmentRuns = cacheService.getAllInspectorResults()
+    val accountAssessmentRuns = cacheService.getAllInspectorResults
     val sorted = InspectorResults.sortAccountResults(accountAssessmentRuns.toList)
     Ok(views.html.inspector.inspector(sorted))
   }

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -21,7 +21,7 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
   private val accounts = Config.getAwsAccounts(config)
 
   def securityGroups = authAction {
-    val allFlaggedSgs = cacheService.getAllSgs()
+    val allFlaggedSgs = cacheService.getAllSgs
     val sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs.toList)
     Ok(views.html.sgs.sgs(sortedFlaggedSgs))
   }

--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -117,7 +117,7 @@ object InspectorResults {
     assessmentRuns.flatMap(_.findingCounts.values).sum
   }
 
-  def completedDaysAgo(assessmentRun: InspectorAssessmentRun): Int = Days.daysBetween(new DateTime(), assessmentRun.completedAt).getDays
+  def completedDaysAgo(assessmentRun: InspectorAssessmentRun): Int = Days.daysBetween(assessmentRun.completedAt, new DateTime()).getDays
 
   def formatCompletedAtTimeOnly(assessmentRun: InspectorAssessmentRun): String = DateTimeFormat.forPattern("HH:mm:ss").print(assessmentRun.completedAt)
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -4,6 +4,12 @@ import aws.ec2.EC2
 import aws.iam.IAMClient
 import aws.inspector.Inspector
 import aws.support.TrustedAdvisorExposedIAMKeys
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
+import com.amazonaws.services.ec2.AmazonEC2Async
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
+import com.amazonaws.services.inspector.AmazonInspectorAsync
+import com.amazonaws.services.support.AWSSupportAsync
 import com.gu.Box
 import config.Config
 import model._
@@ -15,9 +21,16 @@ import utils.attempt.{FailedAttempt, Failure}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-
-
-class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, environment: Environment)(implicit ec: ExecutionContext) {
+class CacheService(
+    config: Configuration,
+    lifecycle: ApplicationLifecycle,
+    environment: Environment,
+    inspectorClients: Map[(String, Regions), AmazonInspectorAsync],
+    ec2Clients: Map[(String, Regions), AmazonEC2Async],
+    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    taClients: Map[(String, Regions), AWSSupportAsync],
+    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync]
+  )(implicit ec: ExecutionContext) {
   private val accounts = Config.getAwsAccounts(config)
   private val startingCache = accounts.map(acc => (acc, Left(Failure.cacheServiceError(acc.id, "cache").attempt))).toMap
   private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(startingCache)
@@ -25,7 +38,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
   private val inspectorBox: Box[Map[AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]]]] = Box(startingCache)
 
-  def getAllCredentials(): Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = credentialsBox.get()
+  def getAllCredentials: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = credentialsBox.get()
 
   def getCredentialsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, CredentialReportDisplay] = {
     credentialsBox.get().getOrElse(
@@ -34,7 +47,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
     )
   }
 
-  def getAllExposedKeys(): Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]] = exposedKeysBox.get()
+  def getAllExposedKeys: Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]] = exposedKeysBox.get()
 
   def getExposedKeysForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[ExposedIAMKeyDetail]] = {
     exposedKeysBox.get().getOrElse(
@@ -43,7 +56,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
     )
   }
 
-  def getAllSgs(): Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]] = sgsBox.get()
+  def getAllSgs: Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]] = sgsBox.get()
 
   def getSgsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]] = {
     sgsBox.get().getOrElse(
@@ -52,7 +65,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
     )
   }
 
-  def getAllInspectorResults(): Map[AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]]] = inspectorBox.get()
+  def getAllInspectorResults: Map[AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]]] = inspectorBox.get()
 
   def getInspectorResultsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[InspectorAssessmentRun]] = {
     inspectorBox.get().getOrElse(
@@ -64,7 +77,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   private def refreshCredentialsBox(): Unit = {
     Logger.info("Started refresh of the Credentials data")
     for {
-      allCredentialReports <- IAMClient.getAllCredentialReports(accounts)
+      allCredentialReports <- IAMClient.getAllCredentialReports(accounts, cfnClients, ec2Clients, iamClients)
     } yield {
       Logger.info("Sending the refreshed data to the Credentials Box")
       credentialsBox.send(allCredentialReports.toMap)
@@ -74,7 +87,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   private def refreshExposedKeysBox(): Unit = {
     Logger.info("Started refresh of the Exposed Keys data")
     for {
-      allExposedKeys <- TrustedAdvisorExposedIAMKeys.getAllExposedKeys(accounts)
+      allExposedKeys <- TrustedAdvisorExposedIAMKeys.getAllExposedKeys(accounts, taClients)
     } yield {
       Logger.info("Sending the refreshed data to the Exposed Keys Box")
       exposedKeysBox.send(allExposedKeys.toMap)
@@ -84,8 +97,8 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   private def refreshSgsBox(): Unit = {
     Logger.info("Started refresh of the Security Groups data")
     for {
-      _ <- EC2.refreshSGSReports(accounts)
-      allFlaggedSgs <- EC2.allFlaggedSgs(accounts)
+      _ <- EC2.refreshSGSReports(accounts, taClients)
+      allFlaggedSgs <- EC2.allFlaggedSgs(accounts, ec2Clients, taClients)
     } yield {
       Logger.info("Sending the refreshed data to the Security Groups Box")
       sgsBox.send(allFlaggedSgs.toMap)
@@ -95,7 +108,7 @@ class CacheService(config: Configuration, lifecycle: ApplicationLifecycle, envir
   def refreshInspectorBox(): Unit = {
     Logger.info("Started refresh of the AWS Inspector data")
     for {
-      allInspectorRuns <- Inspector.allInspectorRuns(accounts)
+      allInspectorRuns <- Inspector.allInspectorRuns(accounts, inspectorClients)
     } yield {
       Logger.info("Sending the refreshed data to the AWS Inspector Box")
       inspectorBox.send(allInspectorRuns.toMap)

--- a/hq/app/utils/attempt/Attempt.scala
+++ b/hq/app/utils/attempt/Attempt.scala
@@ -107,7 +107,7 @@ object Attempt {
     *
     * Combines the behaviours of labelledTraverse and traverseWithFailures.
     */
-  def labelledTaverseWithFailures[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[(A, Either[FailedAttempt, B])]] = {
+  def labelledTraverseWithFailures[A, B](as: List[A])(f: A => Attempt[B])(implicit ec: ExecutionContext): Attempt[List[(A, Either[FailedAttempt, B])]] = {
     Async.Right(Future.traverse(as)(a => f(a).asFuture.map(a -> _)))
   }
 

--- a/hq/conf/logback.xml
+++ b/hq/conf/logback.xml
@@ -26,7 +26,6 @@
 
   <logger name="play" level="INFO" />
   <logger name="application" level="DEBUG" />
-  <logger name="org.quartz" level="INFO" />
 
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
   <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -1,0 +1,88 @@
+package aws
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.inspector.AmazonInspectorAsyncClientBuilder
+import com.typesafe.config.ConfigFactory
+import org.scalatest.prop.{Checkers, PropertyChecks}
+import org.scalatest.{FreeSpec, Matchers}
+import play.api.Configuration
+import utils.attempt.AttemptValues
+
+class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks with AttemptValues {
+
+  "real clients" - {
+
+    val config = ConfigFactory.parseString(
+      s"""
+         | {
+         |   "hq": {
+         |     "accounts" : [
+         |       {
+         |         "name": "Test1"
+         |         "id": "test1"
+         |         "roleArn": ""
+         |       },
+         |       {
+         |         "name": "Test2"
+         |         "id": "test2"
+         |         "roleArn": ""
+         |       }
+         |     ]
+         |   }
+         | }
+       """.stripMargin
+    )
+    val configuration = Configuration(config)
+
+    //Two accounts, all regions.
+    val allRegionsSize = Regions.values().size * 2
+    // Only in one region.
+    val singleRegionSize = 2
+
+    "inspector" in {
+      AWS.inspectorClients(configuration) should have size(singleRegionSize)
+    }
+    "ec2" in {
+      AWS.ec2Clients(configuration) should have size(allRegionsSize)
+    }
+
+    "cloudformation" in {
+      AWS.cfnClients(configuration) should have size(allRegionsSize)
+    }
+
+    "trusted advisor" in {
+      AWS.taClients(configuration) should have size(singleRegionSize)
+    }
+
+    "iam" in {
+      AWS.iamClients(configuration) should have size(allRegionsSize)
+    }
+
+  }
+
+  "mock clients" - {
+
+    val config = ConfigFactory.parseString(
+      s"""
+         | {
+         |   "hq": {
+         |     "accounts" : [
+         |       {
+         |         "name": "Mock"
+         |         "id": "mock"
+         |         "roleArn": ""
+         |       }
+         |     ]
+         |   }
+         | }
+       """.stripMargin
+    )
+    val configuration = Configuration(config)
+
+    "correct account and region" in {
+      val keys = AWS.clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, Regions.EU_WEST_1).keys
+      keys should contain (("mock", Regions.EU_WEST_1))
+    }
+  }
+
+}

--- a/hq/test/aws/cloudformation/CloudFormationTest.scala
+++ b/hq/test/aws/cloudformation/CloudFormationTest.scala
@@ -1,6 +1,6 @@
 package aws.cloudformation
 
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.model.Stack
 import model.AwsStack
 import org.scalatest.{FreeSpec, Matchers}
@@ -9,7 +9,7 @@ class CloudFormationTest extends FreeSpec with Matchers {
 
   "parseStacks" - {
     val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"
-    val region = Region.getRegion(Regions.EU_WEST_1)
+    val region = Regions.EU_WEST_1
     val exampleStack = new Stack().withStackId(stackId).withStackName("example-stack-A")
 
     "will parse and extract each stack, including setting the the region" in {


### PR DESCRIPTION
## What does this change?

Reverts the previous change which introduced Quartz schedular, and re-instates Observables.

## What is the value of this?

Previous change did not fix the threading problem.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

No