### PR TITLE
Reduce Security HQ instance size and count

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -270,7 +270,7 @@ Resources:
         Ref: AMI
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      InstanceType: t2.small
+      InstanceType: t2.micro
       IamInstanceProfile:
         Ref: SecurityHQInstanceProfile
       AssociatePublicIpAddress: true
@@ -306,9 +306,9 @@ Resources:
         Ref: Subnets
       LaunchConfigurationName:
         Ref: LaunchConfig
-      MinSize: 2
-      MaxSize: 4
-      DesiredCapacity: 2
+      MinSize: 1
+      MaxSize: 2
+      DesiredCapacity: 1
       HealthCheckType: ELB
       HealthCheckGracePeriod: 120
       LoadBalancerNames:


### PR DESCRIPTION
## What does this change?

Returns SHQ to a single micro instance

## What is the value of this?

Larger instances / multiple instances are no longer required as the application is stable again.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes

## Has the CloudFormation or StackSet update been completed?

No

## Any additional notes?

No