### PR TITLE
Increase instance size

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -270,7 +270,7 @@ Resources:
         Ref: AMI
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      InstanceType: t2.micro
+      InstanceType: t2.small
       IamInstanceProfile:
         Ref: SecurityHQInstanceProfile
       AssociatePublicIpAddress: true


### PR DESCRIPTION
## What does this change?

Reverts my change back to micro, so we go to t2.small permanently.

## What is the value of this?

Previously we had upscaled to small because we suspected memory issues.  Having resolved those, we believed we could downscale again, back to micro.  However it appears that SHQ has grown, and it is now killed on a micro instance.  upscaling to small permanently fixes the issue.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes

## Have you committed your changes to the CloudFormation templates?

Yes

## Has the CloudFormation or StackSet update been completed? 

No

## Any additional notes?

No
