### PR TITLE
Better logic to sort accounts by assessment runs

### DIFF
--- a/hq/app/logic/InspectorResults.scala
+++ b/hq/app/logic/InspectorResults.scala
@@ -78,16 +78,17 @@ object InspectorResults {
     }
   }
 
-  def sortAccountResults[A, B](accountResults: List[(A, scala.Either[B, List[InspectorAssessmentRun]])]): List[(A, scala.Either[B, List[InspectorAssessmentRun]])] = {
+  def sortAccountResults[A, B](accountResults: List[(A, Either[B, List[InspectorAssessmentRun]])]): List[(A, Either[B, List[InspectorAssessmentRun]])] = {
     accountResults.sortBy {
       case (_, Right(assessmentRuns)) =>
         ( 0 - levelFindings("High", assessmentRuns)
         , 0 - levelFindings("Medium", assessmentRuns)
         , 0 - levelFindings("Low", assessmentRuns)
         , 0 - levelFindings("Info", assessmentRuns)
+        , 0 - assessmentRuns.size
         )
       case (_, Left(_)) =>
-        (1, 1, 1, 1)
+        (1, 1, 1, 1, 1)
     }
   }
 

--- a/hq/test/logic/InspectorResultsTest.scala
+++ b/hq/test/logic/InspectorResultsTest.scala
@@ -3,7 +3,6 @@ package logic
 import java.util.{Date, GregorianCalendar}
 
 import com.amazonaws.services.inspector.model.{AssessmentRun, ListAssessmentRunsResult}
-import logic.InspectorResults._
 import model.InspectorAssessmentRun
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers, OptionValues}
@@ -12,6 +11,8 @@ import scala.collection.JavaConverters._
 
 
 class InspectorResultsTest extends FreeSpec with Matchers with OptionValues {
+  import logic.InspectorResults._
+
   val assessmentRun = InspectorAssessmentRun(
     "arn:run", "name", ("stack", "app", "stage"), "arn:template", "state", 1, Nil, Nil,
     DateTime.now(), DateTime.now(), DateTime.now(), DateTime.now(), true,
@@ -322,6 +323,19 @@ class InspectorResultsTest extends FreeSpec with Matchers with OptionValues {
         () -> Right(List(assessmentRun.withFindings(2, 2, 0, 0))),
         () -> Right(List(assessmentRun.withFindings(2, 1, 1, 0))),
         () -> Right(List(assessmentRun.withFindings(1, 1, 0, 0)))
+      )
+    }
+
+    "if there are no results, sorts by number of inspection runs to put empty after 'clean" in {
+      val results = List(
+        () -> Right(List(assessmentRun.withFindings(0, 0, 0, 0))),
+        () -> Right(Nil),
+        () -> Right(List(assessmentRun.withFindings(0, 0, 0, 0), assessmentRun.withFindings(0, 0, 0, 0)))
+      )
+      sortAccountResults(results) shouldEqual List(
+        () -> Right(List(assessmentRun.withFindings(0, 0, 0, 0), assessmentRun.withFindings(0, 0, 0, 0))),
+        () -> Right(List(assessmentRun.withFindings(0, 0, 0, 0))),
+        () -> Right(Nil)
       )
     }
   }


### PR DESCRIPTION
## What does this change?

If an account has multiple assessment runs but none of those have any findings, that is different to an account that has no assessment runs (and thus no findings).

<!-- Screenshots may be helpful to demonstrate -->

![bad-inspector-results-sort](https://user-images.githubusercontent.com/29761/40175971-b002daa8-59d1-11e8-969a-bcfd0d02a6ac.png)

## What is the value of this?

Fixes this so it's easy to see all the "results" together, separate to the accounts with no assessment runs

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

None
<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
