### PR TITLE
Removes apt-get cmds from application bootstrap

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -277,10 +277,6 @@ Resources:
       UserData:
         'Fn::Base64': !Sub |
           #!/bin/bash -ev
-          locale-gen en_GB.UTF-8
-          apt-get -y update
-          apt-get -y upgrade
-          apt-get -y install ntp
           echo ${Stage} > /etc/stage
           # setup security-hq
           adduser --system --home /security-hq --disabled-password security-hq


### PR DESCRIPTION
## What does this change?

Removes apt-get commands from the userdata application setup steps, since this is done at bake time. 
<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

The app is currently not starting due to a grub configuration prompt that shouldn't be happening at all.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yep, CloudFormation change for the app itself.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
