### PR TITLE
Switch to use the new Bionic LTS image

### DIFF
--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -18,6 +18,7 @@ deployments:
       cloudFormationStackName: security-hq
       templatePath: cfn.yaml
       amiTags:
-        Recipe: security-hq-xenial
+        Recipe: security-java-lts
         BuiltBy: amigo
         AmigoStage: PROD
+        amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Switches Security HQ to Amigo's newly-available 18.04 LTS image and enables encryption.

## What is the value of this?

Updates to the latest LTS and enables disk encryption for Security HQ.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No, this only changes the Riff Raff confirguration in the build artifact.

## Any additional notes?

Security HQ is the easiest place to test this new image. I'll roll it out to Janus next but SHQ already uses systemd so it's a trivial change here.