### PR TITLE
Remove amiEncrypted parameter to see if that fixes resolution

### DIFF
--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -21,4 +21,3 @@ deployments:
         Recipe: security-java-lts
         BuiltBy: amigo
         AmigoStage: PROD
-        amiEncrypted: true


### PR DESCRIPTION
## What does this change?

Simplifies the deployment AMI resolution, which isn't currently working. This should make it easier to work out what's going wrong.

## What is the value of this?

Fix the AMI update on deploy.

## Will this require CloudFormation and/or updates to the AWS StackSet?

N/A

## Any additional notes?

Nope