### PR TITLE
Correct RiffRaff configuration

### DIFF
--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -17,6 +17,7 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: security-hq
       templatePath: cfn.yaml
+      amiEncrypted: true
       amiTags:
         Recipe: security-java-lts
         BuiltBy: amigo


### PR DESCRIPTION
## What does this change?

Corrects the RiffRaff configuration for Security-HQs AMI.
<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Allows the service to use an encrypted AMI
<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

Previously the `amiEncrypted` was erroneously a child of `amiTags` instead of `parameters`.
<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
