### PR TITLE
Fix region assumptions, increase instance size and overhaul AWS SDK failure logging

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -105,6 +105,11 @@ Resources:
           Resource: "*"
           Action:
           - ssm:GetParametersByPath
+        # Get the list of regions
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeRegions
       Roles:
       - !Ref SecurityHQInstanceRole
 

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -270,7 +270,7 @@ Resources:
         Ref: AMI
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      InstanceType: t2.small
+      InstanceType: t2.medium
       IamInstanceProfile:
         Ref: SecurityHQInstanceProfile
       AssociatePublicIpAddress: true

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -83,7 +83,7 @@ class AppComponents(context: Context)
 
   Logger.info(s"Polling in the following regions: ${availableRegions.map(_.getName).mkString(", ")}")
 
-  val regionsNotInSdk: Set[String] = Regions.values().map(_.getName).toSet -- availableRegions.map(_.getName).toSet
+  val regionsNotInSdk: Set[String] = availableRegions.map(_.getName).toSet -- Regions.values().map(_.getName).toSet
   if (regionsNotInSdk.nonEmpty) {
     Logger.warn(s"Regions exist that are not in the current SDK (${regionsNotInSdk.mkString(", ")}), update your SDK!")
   }

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -59,7 +59,7 @@ object AWS {
     clients(AmazonCloudFormationAsyncClientBuilder.standard(), configuration, regions:_*)
 
   // Only needs Regions.US_EAST_1
-  def taClients(configuration: Configuration, region: Regions = Regions.EU_WEST_1): AwsClients[AWSSupportAsync] =
+  def taClients(configuration: Configuration, region: Regions = Regions.US_EAST_1): AwsClients[AWSSupportAsync] =
     clients(AWSSupportAsyncClientBuilder.standard(), configuration, region)
 
   def iamClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonIdentityManagementAsync] =

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -32,12 +32,6 @@ object AWS {
     )
   }
 
-  private val continentBlacklist = List("cn-", "us-gov-")
-
-  def isRegionBlacklisted(region: Regions): Boolean = continentBlacklist.exists(region.getName.startsWith)
-
-  def regions: List[Regions] = Regions.values().filterNot(isRegionBlacklisted).toList
-
   private[aws] def clients[A, B <: AwsClientBuilder[B, A]](
     builder: AwsClientBuilder[B, A],
     configuration: Configuration,
@@ -56,20 +50,20 @@ object AWS {
   }
 
   // Only needs Regions.EU_WEST_1
-  def inspectorClients(configuration: Configuration): Map[(String, Regions), AmazonInspectorAsync] =
-    clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, Regions.EU_WEST_1)
+  def inspectorClients(configuration: Configuration, region: Regions = Regions.EU_WEST_1): Map[(String, Regions), AmazonInspectorAsync] =
+    clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, region)
 
-  def ec2Clients(configuration: Configuration): Map[(String, Regions), AmazonEC2Async] =
+  def ec2Clients(configuration: Configuration, regions: List[Regions]): Map[(String, Regions), AmazonEC2Async] =
     clients(AmazonEC2AsyncClientBuilder.standard(), configuration, regions:_*)
 
-  def cfnClients(configuration: Configuration): Map[(String, Regions), AmazonCloudFormationAsync] =
+  def cfnClients(configuration: Configuration, regions: List[Regions]): Map[(String, Regions), AmazonCloudFormationAsync] =
     clients(AmazonCloudFormationAsyncClientBuilder.standard(), configuration, regions:_*)
 
   // Only needs Regions.US_EAST_1
-  def taClients(configuration: Configuration): Map[(String, Regions), AWSSupportAsync] =
-    clients(AWSSupportAsyncClientBuilder.standard(), configuration, Regions.US_EAST_1)
+  def taClients(configuration: Configuration, region: Regions = Regions.EU_WEST_1): Map[(String, Regions), AWSSupportAsync] =
+    clients(AWSSupportAsyncClientBuilder.standard(), configuration, region)
 
-  def iamClients(configuration: Configuration): Map[(String, Regions), AmazonIdentityManagementAsync] =
+  def iamClients(configuration: Configuration, regions: List[Regions]): Map[(String, Regions), AmazonIdentityManagementAsync] =
     clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, regions:_*)
 
 }

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -32,6 +32,8 @@ object AWS {
     )
   }
 
+  def regions: List[Regions] = Regions.values().filterNot(r => r.getName.startsWith("CN_") || r.getName == "GovCloud").toList
+
   private[aws] def clients[A, B <: AwsClientBuilder[B, A]](
     builder: AwsClientBuilder[B, A],
     configuration: Configuration,
@@ -54,16 +56,16 @@ object AWS {
     clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, Regions.EU_WEST_1)
 
   def ec2Clients(configuration: Configuration): Map[(String, Regions), AmazonEC2Async] =
-    clients(AmazonEC2AsyncClientBuilder.standard(), configuration, Regions.values():_*)
+    clients(AmazonEC2AsyncClientBuilder.standard(), configuration, regions:_*)
 
   def cfnClients(configuration: Configuration): Map[(String, Regions), AmazonCloudFormationAsync] =
-    clients(AmazonCloudFormationAsyncClientBuilder.standard(), configuration, Regions.values():_*)
+    clients(AmazonCloudFormationAsyncClientBuilder.standard(), configuration, regions:_*)
 
   // Only needs Regions.US_EAST_1
   def taClients(configuration: Configuration): Map[(String, Regions), AWSSupportAsync] =
     clients(AWSSupportAsyncClientBuilder.standard(), configuration, Regions.US_EAST_1)
 
   def iamClients(configuration: Configuration): Map[(String, Regions), AmazonIdentityManagementAsync] =
-    clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, Regions.values():_*)
+    clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, regions:_*)
 
 }

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -32,7 +32,11 @@ object AWS {
     )
   }
 
-  def regions: List[Regions] = Regions.values().filterNot(r => r.getName.startsWith("CN_") || r.getName == "GovCloud").toList
+  private val continentBlacklist = List("cn-", "us-gov-")
+
+  def isRegionBlacklisted(region: Regions): Boolean = continentBlacklist.exists(region.getName.startsWith)
+
+  def regions: List[Regions] = Regions.values().filterNot(isRegionBlacklisted).toList
 
   private[aws] def clients[A, B <: AwsClientBuilder[B, A]](
     builder: AwsClientBuilder[B, A],

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -36,8 +36,8 @@ object AWS {
     builder: AwsClientBuilder[B, A],
     configuration: Configuration,
     regionList: Regions*
-  ): Map[(String, Regions), A] = {
-    val list = for {
+  ): AwsClients[A] = {
+    for {
       account <- Config.getAwsAccounts(configuration)
       region <- regionList
       client = builder
@@ -45,25 +45,24 @@ object AWS {
         .withRegion(region)
         .withClientConfiguration(new ClientConfiguration().withMaxConnections(10))
         .build()
-    } yield (account.id, region) -> client
-    list.toMap
+    } yield AwsClient(client, account, region)
   }
 
   // Only needs Regions.EU_WEST_1
-  def inspectorClients(configuration: Configuration, region: Regions = Regions.EU_WEST_1): Map[(String, Regions), AmazonInspectorAsync] =
+  def inspectorClients(configuration: Configuration, region: Regions = Regions.EU_WEST_1): AwsClients[AmazonInspectorAsync] =
     clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, region)
 
-  def ec2Clients(configuration: Configuration, regions: List[Regions]): Map[(String, Regions), AmazonEC2Async] =
+  def ec2Clients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonEC2Async] =
     clients(AmazonEC2AsyncClientBuilder.standard(), configuration, regions:_*)
 
-  def cfnClients(configuration: Configuration, regions: List[Regions]): Map[(String, Regions), AmazonCloudFormationAsync] =
+  def cfnClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonCloudFormationAsync] =
     clients(AmazonCloudFormationAsyncClientBuilder.standard(), configuration, regions:_*)
 
   // Only needs Regions.US_EAST_1
-  def taClients(configuration: Configuration, region: Regions = Regions.EU_WEST_1): Map[(String, Regions), AWSSupportAsync] =
+  def taClients(configuration: Configuration, region: Regions = Regions.EU_WEST_1): AwsClients[AWSSupportAsync] =
     clients(AWSSupportAsyncClientBuilder.standard(), configuration, region)
 
-  def iamClients(configuration: Configuration, regions: List[Regions]): Map[(String, Regions), AmazonIdentityManagementAsync] =
+  def iamClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonIdentityManagementAsync] =
     clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, regions:_*)
 
 }

--- a/hq/app/aws/AwsAsyncHandler.scala
+++ b/hq/app/aws/AwsAsyncHandler.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T], clientContext: AwsClient[_]) extends AsyncHandler[R, T] {
   def onError(e: Exception): Unit = {
     val context = Failure.contextString(clientContext)
-    Logger.warn(s"Failed to execute AWS SDK operation, $context", e)
+    Logger.warn(s"Failed to execute AWS SDK operation (${clientContext.client.getClass.getSimpleName}), $context", e)
     promise failure e
   }
   def onSuccess(r: R, t: T): Unit = {

--- a/hq/app/aws/AwsAsyncHandler.scala
+++ b/hq/app/aws/AwsAsyncHandler.scala
@@ -2,17 +2,15 @@ package aws
 
 import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
-import com.amazonaws.regions.Regions
-import model.AwsAccount
 import play.api.Logger
 import utils.attempt.{Attempt, Failure}
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
 
-class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T], account: Option[AwsAccount], region: Option[Regions]) extends AsyncHandler[R, T] {
+class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T], clientContext: AwsClient[_]) extends AsyncHandler[R, T] {
   def onError(e: Exception): Unit = {
-    val context = Failure.contextString(account, region)
+    val context = Failure.contextString(clientContext)
     Logger.warn(s"Failed to execute AWS SDK operation, $context", e)
     promise failure e
   }
@@ -23,28 +21,28 @@ class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T
 
 object AwsAsyncHandler {
   private val ServiceName = ".*Service: ([^;]+);.*".r
-  def awsToScala[R <: AmazonWebServiceRequest, T](account: Option[AwsAccount] = None, region: Option[Regions] = None)(sdkMethod: ( (R, AsyncHandler[R, T]) => java.util.concurrent.Future[T])): (R => Future[T]) = { req =>
+  def awsToScala[R <: AmazonWebServiceRequest, T, Client](client: AwsClient[Client])(sdkMethod: Client => ( (R, AsyncHandler[R, T]) => java.util.concurrent.Future[T])): (R => Future[T]) = { req =>
     val p = Promise[T]
-    sdkMethod(req, new AwsAsyncPromiseHandler(p, account, region))
+    sdkMethod(client.client)(req, new AwsAsyncPromiseHandler(p, client))
     p.future
   }
 
-  def handleAWSErrs[T](account: Option[AwsAccount] = None, region: Option[Regions] = None)(f: Future[T])(implicit ec: ExecutionContext): Attempt[T] = {
+  def handleAWSErrs[T, Client](awsClient: AwsClient[Client])(f: => Future[T])(implicit ec: ExecutionContext): Attempt[T] = {
     Attempt.fromFuture(f) { case e =>
       val serviceNameOpt = e.getMessage match {
         case ServiceName(serviceName) => Some(serviceName)
         case _ => None
       }
       if (e.getMessage.contains("The security token included in the request is expired")) {
-        Failure.expiredCredentials(serviceNameOpt, account, region).attempt
+        Failure.expiredCredentials(serviceNameOpt, awsClient).attempt
       } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
-        Failure.noCredentials(serviceNameOpt, account, region).attempt
+        Failure.noCredentials(serviceNameOpt, awsClient).attempt
       } else if (e.getMessage.contains("not authorized to perform")) {
-        Failure.insufficientPermissions(serviceNameOpt, account, region).attempt
+        Failure.insufficientPermissions(serviceNameOpt, awsClient).attempt
       } else if (e.getMessage.contains("Rate exceeded")) {
-        Failure.rateLimitExceeded(serviceNameOpt, account, region).attempt
+        Failure.rateLimitExceeded(serviceNameOpt, awsClient).attempt
       } else {
-        Failure.awsError(serviceNameOpt, account, region).attempt
+        Failure.awsError(serviceNameOpt, awsClient).attempt
       }
     }
   }

--- a/hq/app/aws/AwsClient.scala
+++ b/hq/app/aws/AwsClient.scala
@@ -1,0 +1,10 @@
+package aws
+
+import com.amazonaws.regions.Regions
+import model.AwsAccount
+
+case class AwsClient[A](
+  client: A,
+  account: AwsAccount,
+  region: Regions
+)

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -1,12 +1,10 @@
 package aws.cloudformation
 
-import aws.AWS
+import aws.{AwsClient, AwsClients}
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import aws.ec2.EC2
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.cloudformation.model._
-import com.amazonaws.services.ec2.AmazonEC2Async
 import model.{AwsAccount, AwsStack}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -15,28 +13,21 @@ import scala.concurrent.ExecutionContext
 
 object CloudFormation {
 
-  def client(cfnClients: Map[(String, Regions), AmazonCloudFormationAsync], awsAccount: AwsAccount, region: Regions): Attempt[AmazonCloudFormationAsync] =
-    Attempt.fromOption(cfnClients.get((awsAccount.id, region)), FailedAttempt(Failure(
-      s"No AWS Cloudformation Client exists for ${awsAccount.id} and $region",
-      s"Cannot find Cloudformation Client",
-      500
-    )
-  ))
-  private def getStackDescriptions(client: AmazonCloudFormationAsync, account: AwsAccount, region: Regions)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
+  private def getStackDescriptions(client: AwsClient[AmazonCloudFormationAsync], account: AwsAccount, region: Regions)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
     val request = new DescribeStacksRequest()
-    handleAWSErrs(Some(account), Some(region))(awsToScala(Some(account), Some(region))(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
+    handleAWSErrs(client)(awsToScala(client)(_.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
   }
 
-  private def getStacks(account: AwsAccount, region: Regions, cfnClients: Map[(String, Regions), AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
+  private def getStacks(account: AwsAccount, region: Regions, cfnClients: AwsClients[AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
-      cloudClient <- client(cfnClients, account, region)
+      cloudClient <- cfnClients.get(account, region)
       stacks <- getStackDescriptions(cloudClient, account, region)
     } yield parseStacks(stacks, region)
   }
 
   def getStacksFromAllRegions(
     account: AwsAccount,
-    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
+    cfnClients: AwsClients[AmazonCloudFormationAsync],
     regions: List[Regions]
   )(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -39,10 +39,7 @@ object CloudFormation {
     ec2Clients: Map[(String, Regions), AmazonEC2Async]
   )(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
-      regionClient <- EC2.client(ec2Clients, account, Regions.EU_WEST_1)
-      availableRegions <- EC2.getAvailableRegions(regionClient)
-      regions = availableRegions.map(region => Regions.fromName(region.getRegionName))
-      stacks <- Attempt.flatTraverse(regions)(region => getStacks(account, region, cfnClients))
+      stacks <- Attempt.flatTraverse(Regions.values().toList)(region => getStacks(account, region, cfnClients))
     } yield stacks
   }
 

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -23,7 +23,7 @@ object CloudFormation {
   ))
   private def getStackDescriptions(client: AmazonCloudFormationAsync, account: AwsAccount, region: Regions)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
     val request = new DescribeStacksRequest()
-    handleAWSErrs(Some(account), Some(region))(awsToScala(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
+    handleAWSErrs(Some(account), Some(region))(awsToScala(Some(account), Some(region))(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
   }
 
   private def getStacks(account: AwsAccount, region: Regions, cfnClients: Map[(String, Regions), AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -37,10 +37,10 @@ object CloudFormation {
   def getStacksFromAllRegions(
     account: AwsAccount,
     cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
-    ec2Clients: Map[(String, Regions), AmazonEC2Async]
+    regions: List[Regions]
   )(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
-      stacks <- Attempt.flatTraverse(AWS.regions)(region => getStacks(account, region, cfnClients))
+      stacks <- Attempt.flatTraverse(regions)(region => getStacks(account, region, cfnClients))
     } yield stacks
   }
 

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -1,5 +1,6 @@
 package aws.cloudformation
 
+import aws.AWS
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
 import aws.ec2.EC2
 import com.amazonaws.regions.Regions
@@ -39,7 +40,7 @@ object CloudFormation {
     ec2Clients: Map[(String, Regions), AmazonEC2Async]
   )(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
-      stacks <- Attempt.flatTraverse(Regions.values().toList)(region => getStacks(account, region, cfnClients))
+      stacks <- Attempt.flatTraverse(AWS.regions)(region => getStacks(account, region, cfnClients))
     } yield stacks
   }
 

--- a/hq/app/aws/cloudformation/CloudFormation.scala
+++ b/hq/app/aws/cloudformation/CloudFormation.scala
@@ -21,15 +21,15 @@ object CloudFormation {
       500
     )
   ))
-  private def getStackDescriptions(client: AmazonCloudFormationAsync)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
+  private def getStackDescriptions(client: AmazonCloudFormationAsync, account: AwsAccount, region: Regions)(implicit ec: ExecutionContext): Attempt[List[Stack]] = {
     val request = new DescribeStacksRequest()
-    handleAWSErrs(awsToScala(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
+    handleAWSErrs(Some(account), Some(region))(awsToScala(client.describeStacksAsync)(request)).map(_.getStacks.asScala.toList)
   }
 
   private def getStacks(account: AwsAccount, region: Regions, cfnClients: Map[(String, Regions), AmazonCloudFormationAsync])(implicit ec: ExecutionContext): Attempt[List[AwsStack]] = {
     for {
       cloudClient <- client(cfnClients, account, region)
-      stacks <- getStackDescriptions(cloudClient)
+      stacks <- getStackDescriptions(cloudClient, account, region)
     } yield parseStacks(stacks, region)
   }
 

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -27,7 +27,7 @@ object EC2 {
 
   def getAvailableRegions(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Region]] = {
     val request = new DescribeRegionsRequest()
-    handleAWSErrs()(awsToScala(client.describeRegionsAsync)(request)).map { result =>
+    handleAWSErrs()(awsToScala()(client.describeRegionsAsync)(request)).map { result =>
       result.getRegions.asScala.toList
     }
   }
@@ -121,7 +121,7 @@ object EC2 {
   private def describeSecurityGroups(sgIds: List[String])(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[DescribeSecurityGroupsResult] = {
     val request = new DescribeSecurityGroupsRequest()
       .withFilters(new Filter("group-id", sgIds.asJava))
-    handleAWSErrs()(awsToScala(client.describeSecurityGroupsAsync)(request))
+    handleAWSErrs()(awsToScala()(client.describeSecurityGroupsAsync)(request))
   }
 
   private[ec2] def extractTagsForSecurityGroups(describeSecurityGroupsResult: DescribeSecurityGroupsResult): Map[String, List[Tag]] = {
@@ -145,7 +145,7 @@ object EC2 {
   private[ec2] def getSgsUsageForRegion(sgIds: List[String], client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[DescribeNetworkInterfacesResult] = {
     val request = new DescribeNetworkInterfacesRequest()
         .withFilters(new Filter("group-id", sgIds.asJava))
-    handleAWSErrs()(awsToScala(client.describeNetworkInterfacesAsync)(request))
+    handleAWSErrs()(awsToScala()(client.describeNetworkInterfacesAsync)(request))
   }
 
   private[ec2] def parseDescribeNetworkInterfacesResults(dnir: DescribeNetworkInterfacesResult, sgIds: List[String]): Map[String, Set[SGInUse]] = {
@@ -205,7 +205,7 @@ object EC2 {
 
   private def getVpcsDetails(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Map[String, Vpc]] = {
     val request = new DescribeVpcsRequest()
-    val vpcsResult = handleAWSErrs()(awsToScala(client.describeVpcsAsync)(request))
+    val vpcsResult = handleAWSErrs()(awsToScala()(client.describeVpcsAsync)(request))
     vpcsResult.map { result =>
       result.getVpcs.asScala.map(vpc => vpc.getVpcId -> vpc).toMap
     }

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -27,7 +27,7 @@ object EC2 {
 
   def getAvailableRegions(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[List[Region]] = {
     val request = new DescribeRegionsRequest()
-    handleAWSErrs(awsToScala(client.describeRegionsAsync)(request)).map { result =>
+    handleAWSErrs()(awsToScala(client.describeRegionsAsync)(request)).map { result =>
       result.getRegions.asScala.toList
     }
   }
@@ -121,7 +121,7 @@ object EC2 {
   private def describeSecurityGroups(sgIds: List[String])(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[DescribeSecurityGroupsResult] = {
     val request = new DescribeSecurityGroupsRequest()
       .withFilters(new Filter("group-id", sgIds.asJava))
-    handleAWSErrs(awsToScala(client.describeSecurityGroupsAsync)(request))
+    handleAWSErrs()(awsToScala(client.describeSecurityGroupsAsync)(request))
   }
 
   private[ec2] def extractTagsForSecurityGroups(describeSecurityGroupsResult: DescribeSecurityGroupsResult): Map[String, List[Tag]] = {
@@ -145,7 +145,7 @@ object EC2 {
   private[ec2] def getSgsUsageForRegion(sgIds: List[String], client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[DescribeNetworkInterfacesResult] = {
     val request = new DescribeNetworkInterfacesRequest()
         .withFilters(new Filter("group-id", sgIds.asJava))
-    handleAWSErrs(awsToScala(client.describeNetworkInterfacesAsync)(request))
+    handleAWSErrs()(awsToScala(client.describeNetworkInterfacesAsync)(request))
   }
 
   private[ec2] def parseDescribeNetworkInterfacesResults(dnir: DescribeNetworkInterfacesResult, sgIds: List[String]): Map[String, Set[SGInUse]] = {
@@ -205,7 +205,7 @@ object EC2 {
 
   private def getVpcsDetails(client: AmazonEC2Async)(implicit ec: ExecutionContext): Attempt[Map[String, Vpc]] = {
     val request = new DescribeVpcsRequest()
-    val vpcsResult = handleAWSErrs(awsToScala(client.describeVpcsAsync)(request))
+    val vpcsResult = handleAWSErrs()(awsToScala(client.describeVpcsAsync)(request))
     vpcsResult.map { result =>
       result.getVpcs.asScala.map(vpc => vpc.getVpcId -> vpc).toMap
     }

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -2,14 +2,14 @@ package aws.iam
 
 import aws.AwsAsyncHandler._
 import aws.cloudformation.CloudFormation
+import aws.{AwsClient, AwsClients}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
-import com.amazonaws.services.ec2.AmazonEC2Async
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest}
 import logic.{ReportDisplay, Retry}
 import model.{AwsAccount, CredentialReportDisplay, IAMCredentialsReport}
-import utils.attempt.{Attempt, FailedAttempt, Failure}
+import utils.attempt.{Attempt, FailedAttempt}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,36 +17,28 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object IAMClient {
 
-  def client(iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync], awsAccount: AwsAccount): Attempt[ AmazonIdentityManagementAsync] = {
-    val region = Regions.US_EAST_1
-    Attempt.fromOption(iamClients.get((awsAccount.id, region)), FailedAttempt(Failure(
-      s"No AWS IAM Client exists for ${awsAccount.id} and $region",
-      s"Cannot find IAM Client",
-      500
-    )))
-  }
+  val SOLE_REGION = Regions.US_EAST_1
 
-
-  private def generateCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[GenerateCredentialReportResult] = {
+  private def generateCredentialsReport(client: AwsClient[AmazonIdentityManagementAsync])(implicit ec: ExecutionContext): Attempt[GenerateCredentialReportResult] = {
     val request = new GenerateCredentialReportRequest()
-    handleAWSErrs()(awsToScala()(client.generateCredentialReportAsync)(request))
+    handleAWSErrs(client)(awsToScala(client)(_.generateCredentialReportAsync)(request))
   }
 
-  private def getCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[IAMCredentialsReport] = {
+  private def getCredentialsReport(client: AwsClient[AmazonIdentityManagementAsync])(implicit ec: ExecutionContext): Attempt[IAMCredentialsReport] = {
     val request = new GetCredentialReportRequest()
-    handleAWSErrs()(awsToScala()(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
+    handleAWSErrs(client)(awsToScala(client)(_.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
   }
 
   def getCredentialReportDisplay(
     account: AwsAccount,
-    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
-    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync],
+    cfnClients: AwsClients[AmazonCloudFormationAsync],
+    iamClients: AwsClients[AmazonIdentityManagementAsync],
     regions: List[Regions]
   )(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
     val delay = 3.seconds
 
     for {
-      client <- IAMClient.client(iamClients, account)
+      client <- iamClients.get(account, SOLE_REGION)
       _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
       report <- getCredentialsReport(client)
       stacks <- CloudFormation.getStacksFromAllRegions(account, cfnClients, regions)
@@ -56,8 +48,8 @@ object IAMClient {
 
   def getAllCredentialReports(
     accounts: Seq[AwsAccount],
-    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
-    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync],
+    cfnClients: AwsClients[AmazonCloudFormationAsync],
+    iamClients: AwsClients[AmazonIdentityManagementAsync],
     regions: List[Regions]
   )(implicit executionContext: ExecutionContext): Attempt[Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]] = {
     Attempt.Async.Right {

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -29,12 +29,12 @@ object IAMClient {
 
   private def generateCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[GenerateCredentialReportResult] = {
     val request = new GenerateCredentialReportRequest()
-    handleAWSErrs(awsToScala(client.generateCredentialReportAsync)(request))
+    handleAWSErrs()(awsToScala(client.generateCredentialReportAsync)(request))
   }
 
   private def getCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[IAMCredentialsReport] = {
     val request = new GetCredentialReportRequest()
-    handleAWSErrs(awsToScala(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
+    handleAWSErrs()(awsToScala(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
   }
 
   def getCredentialReportDisplay(

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -29,12 +29,12 @@ object IAMClient {
 
   private def generateCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[GenerateCredentialReportResult] = {
     val request = new GenerateCredentialReportRequest()
-    handleAWSErrs()(awsToScala(client.generateCredentialReportAsync)(request))
+    handleAWSErrs()(awsToScala()(client.generateCredentialReportAsync)(request))
   }
 
   private def getCredentialsReport(client: AmazonIdentityManagementAsync)(implicit ec: ExecutionContext): Attempt[IAMCredentialsReport] = {
     val request = new GetCredentialReportRequest()
-    handleAWSErrs()(awsToScala(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
+    handleAWSErrs()(awsToScala()(client.getCredentialReportAsync)(request)).flatMap(CredentialsReport.extractReport)
   }
 
   def getCredentialReportDisplay(

--- a/hq/app/aws/inspector/Inspector.scala
+++ b/hq/app/aws/inspector/Inspector.scala
@@ -23,7 +23,7 @@ object Inspector {
 
   def listInspectorRuns(client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val request = new ListAssessmentRunsRequest()
-    handleAWSErrs()(awsToScala(client.listAssessmentRunsAsync)(request)).map(parseListAssessmentRunsResult)
+    handleAWSErrs()(awsToScala()(client.listAssessmentRunsAsync)(request)).map(parseListAssessmentRunsResult)
   }
 
   def describeInspectorRuns(assessmentRunArns: List[String], client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
@@ -33,7 +33,7 @@ object Inspector {
     } else {
       val request = new DescribeAssessmentRunsRequest()
         .withAssessmentRunArns(assessmentRunArns.asJava)
-      handleAWSErrs()(awsToScala(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
+      handleAWSErrs()(awsToScala()(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
     }
   }
 

--- a/hq/app/aws/inspector/Inspector.scala
+++ b/hq/app/aws/inspector/Inspector.scala
@@ -1,13 +1,14 @@
 package aws.inspector
 
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import aws.{AwsClient, AwsClients}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.inspector.AmazonInspectorAsync
 import com.amazonaws.services.inspector.model._
 import logic.InspectorResults
 import logic.InspectorResults._
 import model.{AwsAccount, InspectorAssessmentRun}
-import utils.attempt.{Attempt, FailedAttempt, Failure}
+import utils.attempt.{Attempt, FailedAttempt}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -15,37 +16,31 @@ import scala.concurrent.ExecutionContext
 
 object Inspector {
 
-  def client(inspectorClients: Map[(String, Regions), AmazonInspectorAsync], awsAccount: AwsAccount, region: Regions): Attempt[AmazonInspectorAsync] = Attempt.fromOption(inspectorClients.get((awsAccount.id, region)), FailedAttempt(Failure(
-    s"No AWS Inspector Client exists for ${awsAccount.id} and $region",
-    s"Cannot find Inspector Client",
-    500
-  )))
-
-  def listInspectorRuns(client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[String]] = {
+  def listInspectorRuns(client: AwsClient[AmazonInspectorAsync])(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val request = new ListAssessmentRunsRequest()
-    handleAWSErrs()(awsToScala()(client.listAssessmentRunsAsync)(request)).map(parseListAssessmentRunsResult)
+    handleAWSErrs(client)(awsToScala(client)(_.listAssessmentRunsAsync)(request)).map(parseListAssessmentRunsResult)
   }
 
-  def describeInspectorRuns(assessmentRunArns: List[String], client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
+  def describeInspectorRuns(assessmentRunArns: List[String], client: AwsClient[AmazonInspectorAsync])(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
     if (assessmentRunArns.isEmpty) {
       // empty assessmentRunArns throws an exception, so we handle that here
       Attempt.Right(Nil)
     } else {
       val request = new DescribeAssessmentRunsRequest()
         .withAssessmentRunArns(assessmentRunArns.asJava)
-      handleAWSErrs()(awsToScala()(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
+      handleAWSErrs(client)(awsToScala(client)(_.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
     }
   }
 
-  def allInspectorRuns(accounts: List[AwsAccount], inspectorClients: Map[(String, Regions), AmazonInspectorAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])]] = {
+  def allInspectorRuns(accounts: List[AwsAccount], inspectorClients: AwsClients[AmazonInspectorAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]])]] = {
     Attempt.labelledTraverseWithFailures(accounts)(Inspector.inspectorRuns(inspectorClients))
   }
 
-  def inspectorRuns(inspectorClients: Map[(String, Regions), AmazonInspectorAsync])(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
+  def inspectorRuns(inspectorClients: AwsClients[AmazonInspectorAsync])(account: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
     val region = Regions.EU_WEST_1  // we only automatically run inspections in Ireland
 
     for {
-      inspectorClient <- client(inspectorClients, account, region)
+      inspectorClient <- inspectorClients.get(account, region)
       inspectorRunArns <- Inspector.listInspectorRuns(inspectorClient)
       assessmentRuns <- Inspector.describeInspectorRuns(inspectorRunArns, inspectorClient)
       processedAssessmentRuns = InspectorResults.relevantRuns(assessmentRuns)

--- a/hq/app/aws/inspector/Inspector.scala
+++ b/hq/app/aws/inspector/Inspector.scala
@@ -23,7 +23,7 @@ object Inspector {
 
   def listInspectorRuns(client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val request = new ListAssessmentRunsRequest()
-    handleAWSErrs(awsToScala(client.listAssessmentRunsAsync)(request)).map(parseListAssessmentRunsResult)
+    handleAWSErrs()(awsToScala(client.listAssessmentRunsAsync)(request)).map(parseListAssessmentRunsResult)
   }
 
   def describeInspectorRuns(assessmentRunArns: List[String], client: AmazonInspectorAsync)(implicit ec: ExecutionContext): Attempt[List[InspectorAssessmentRun]] = {
@@ -33,7 +33,7 @@ object Inspector {
     } else {
       val request = new DescribeAssessmentRunsRequest()
         .withAssessmentRunArns(assessmentRunArns.asJava)
-      handleAWSErrs(awsToScala(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
+      handleAWSErrs()(awsToScala(client.describeAssessmentRunsAsync)(request)).map(parseDescribeAssessmentRunsResult)
     }
   }
 

--- a/hq/app/aws/package.scala
+++ b/hq/app/aws/package.scala
@@ -1,0 +1,42 @@
+import com.amazonaws.regions.Regions
+import model.AwsAccount
+import utils.attempt.{Attempt, FailedAttempt, Failure}
+
+import scala.reflect.ClassTag
+
+package object aws {
+  type AwsClients[A] = List[AwsClient[A]]
+
+  implicit class AwsClientsList[A](clients: AwsClients[A])(implicit classTag: ClassTag[A]) {
+    def get(account: AwsAccount, region: Regions): Attempt[AwsClient[A]] = {
+      val maybeClient = clients.find { client =>
+        client.account == account && client.region.getName == region.getName
+      }
+      Attempt.fromOption(maybeClient, FailedAttempt(Failure(
+        s"No ${classTag.runtimeClass.getSimpleName} client exists for ${account.id} and $region",
+        s"Cannot find AWS client",
+        500
+      )))
+    }
+
+    // this method assumes that there is only one region per account and if this isn't true it will fail
+    def get(account: AwsAccount): Attempt[AwsClient[A]] = {
+      val clientsForAccount = clients.filter { client =>
+        client.account == account
+      }
+      clientsForAccount match {
+        case singleClient :: Nil => Attempt.Right(singleClient)
+        case Nil => Attempt.Left(FailedAttempt(Failure(
+          s"No ${classTag.runtimeClass.getSimpleName} client exists for ${account.id}",
+          s"Cannot find AWS client",
+          500
+        )))
+        case multipleClients => Attempt.Left(FailedAttempt(Failure(
+          s"More than one ${classTag.runtimeClass.getSimpleName} client exists for ${account.id} - perhaps you need to use get(account, region)??",
+          s"Multiple AWS clients found when only one was expected",
+          500
+        )))
+      }
+    }
+  }
+}

--- a/hq/app/aws/support/TrustedAdvisor.scala
+++ b/hq/app/aws/support/TrustedAdvisor.scala
@@ -51,13 +51,13 @@ object TrustedAdvisor {
 
   def getTrustedAdvisorChecks(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[List[TrustedAdvisorCheck]] = {
     val request = new DescribeTrustedAdvisorChecksRequest().withLanguage("en")
-    handleAWSErrs(awsToScala(client.describeTrustedAdvisorChecksAsync)(request).map(parseTrustedAdvisorChecksResult))
+    handleAWSErrs()(awsToScala(client.describeTrustedAdvisorChecksAsync)(request).map(parseTrustedAdvisorChecksResult))
   }
 
   def refreshTrustedAdvisorChecks(client: AWSSupportAsync, checkId: String)(implicit ec: ExecutionContext): Attempt[RefreshTrustedAdvisorCheckResult] = {
     val request = new RefreshTrustedAdvisorCheckRequest()
       .withCheckId(checkId)
-    handleAWSErrs(awsToScala(client.refreshTrustedAdvisorCheckAsync)(request))
+    handleAWSErrs()(awsToScala(client.refreshTrustedAdvisorCheckAsync)(request))
   }
 
   def parseTrustedAdvisorChecksResult(result: DescribeTrustedAdvisorChecksResult): List[TrustedAdvisorCheck] = {
@@ -77,7 +77,7 @@ object TrustedAdvisor {
     val request = new DescribeTrustedAdvisorCheckResultRequest()
       .withLanguage("en")
       .withCheckId(checkId)
-    handleAWSErrs(awsToScala(client.describeTrustedAdvisorCheckResultAsync)(request))
+    handleAWSErrs()(awsToScala(client.describeTrustedAdvisorCheckResultAsync)(request))
   }
 
   private[support] def findPortPriorityIndex(port: String) = {

--- a/hq/app/aws/support/TrustedAdvisor.scala
+++ b/hq/app/aws/support/TrustedAdvisor.scala
@@ -51,13 +51,13 @@ object TrustedAdvisor {
 
   def getTrustedAdvisorChecks(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[List[TrustedAdvisorCheck]] = {
     val request = new DescribeTrustedAdvisorChecksRequest().withLanguage("en")
-    handleAWSErrs()(awsToScala(client.describeTrustedAdvisorChecksAsync)(request).map(parseTrustedAdvisorChecksResult))
+    handleAWSErrs()(awsToScala()(client.describeTrustedAdvisorChecksAsync)(request).map(parseTrustedAdvisorChecksResult))
   }
 
   def refreshTrustedAdvisorChecks(client: AWSSupportAsync, checkId: String)(implicit ec: ExecutionContext): Attempt[RefreshTrustedAdvisorCheckResult] = {
     val request = new RefreshTrustedAdvisorCheckRequest()
       .withCheckId(checkId)
-    handleAWSErrs()(awsToScala(client.refreshTrustedAdvisorCheckAsync)(request))
+    handleAWSErrs()(awsToScala()(client.refreshTrustedAdvisorCheckAsync)(request))
   }
 
   def parseTrustedAdvisorChecksResult(result: DescribeTrustedAdvisorChecksResult): List[TrustedAdvisorCheck] = {
@@ -77,7 +77,7 @@ object TrustedAdvisor {
     val request = new DescribeTrustedAdvisorCheckResultRequest()
       .withLanguage("en")
       .withCheckId(checkId)
-    handleAWSErrs()(awsToScala(client.describeTrustedAdvisorCheckResultAsync)(request))
+    handleAWSErrs()(awsToScala()(client.describeTrustedAdvisorCheckResultAsync)(request))
   }
 
   private[support] def findPortPriorityIndex(port: String) = {

--- a/hq/app/aws/support/TrustedAdvisorRDSSGs.scala
+++ b/hq/app/aws/support/TrustedAdvisorRDSSGs.scala
@@ -1,6 +1,7 @@
 package aws.support
 
 import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult}
+import aws.AwsClient
 import com.amazonaws.services.support.AWSSupportAsync
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
 import model.{RDSSGsDetail, TrustedAdvisorDetailsResult}
@@ -13,7 +14,7 @@ import scala.concurrent.ExecutionContext
 object TrustedAdvisorRDSSGs {
   val AWS_RDS_SECURITY_GROUP_ACCESS_RISK_IDENTIFIER = "nNauJisYIT"
 
-  def getRDSSecurityGroupDetail(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[RDSSGsDetail]] = {
+  def getRDSSecurityGroupDetail(client: AwsClient[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[RDSSGsDetail]] = {
     getTrustedAdvisorCheckDetails(client, AWS_RDS_SECURITY_GROUP_ACCESS_RISK_IDENTIFIER)
       .flatMap(parseTrustedAdvisorCheckResult(parseRDSSGDetail, ec))
   }

--- a/hq/app/aws/support/TrustedAdvisorSGOpenPorts.scala
+++ b/hq/app/aws/support/TrustedAdvisorSGOpenPorts.scala
@@ -1,12 +1,12 @@
 package aws.support
 
 import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult, refreshTrustedAdvisorChecks}
+import aws.AwsClient
 import com.amazonaws.services.support.AWSSupportAsync
 import com.amazonaws.services.support.model.{RefreshTrustedAdvisorCheckResult, TrustedAdvisorResourceDetail}
 import logic.Retry
 import model.{SGOpenPortsDetail, TrustedAdvisorDetailsResult}
 import utils.attempt.{Attempt, Failure}
-
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -17,7 +17,7 @@ object TrustedAdvisorSGOpenPorts {
   val AWS_SECURITY_GROUPS_PORTS_UNRESTRICTED_IDENTIFIER = "HCP4007jGY"
   val SGIds = "^(sg-[\\w]+) \\((vpc-[\\w]+)\\)$".r
 
-  def getSGOpenPorts(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[SGOpenPortsDetail]] = {
+  def getSGOpenPorts(client: AwsClient[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[SGOpenPortsDetail]] = {
     getTrustedAdvisorCheckDetails(client, AWS_SECURITY_GROUPS_PORTS_UNRESTRICTED_IDENTIFIER)
       .flatMap(parseTrustedAdvisorCheckResult(parseSGOpenPortsDetail, ec))
   }
@@ -64,7 +64,7 @@ object TrustedAdvisorSGOpenPorts {
     }
   }
 
-  def refreshSGOpenPorts(client: AWSSupportAsync)(implicit ec: ExecutionContext): Attempt[RefreshTrustedAdvisorCheckResult] = {
+  def refreshSGOpenPorts(client: AwsClient[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[RefreshTrustedAdvisorCheckResult] = {
     val delay = 3.seconds
     val checkId = AWS_SECURITY_GROUPS_PORTS_UNRESTRICTED_IDENTIFIER
     Retry.until(refreshTrustedAdvisorChecks(client, checkId), _.getStatus.getStatus == "success", s"Failed to refresh $checkId report", delay)

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.amazonaws.regions.Region
+import com.amazonaws.regions.{Region, Regions}
 import org.joda.time.DateTime
 
 case class AwsAccount(

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -33,7 +33,8 @@ class CacheService(
     ec2Clients: Map[(String, Regions), AmazonEC2Async],
     cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
     taClients: Map[(String, Regions), AWSSupportAsync],
-    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync]
+    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync],
+    regions: List[Regions]
   )(implicit ec: ExecutionContext) {
   private val accounts = Config.getAwsAccounts(config)
   private val startingCache = accounts.map(acc => (acc, Left(Failure.cacheServiceErrorPerAccount(acc.id, "cache").attempt))).toMap
@@ -94,7 +95,7 @@ class CacheService(
   def refreshCredentialsBox(): Unit = {
     Logger.info("Started refresh of the Credentials data")
     for {
-      allCredentialReports <- IAMClient.getAllCredentialReports(accounts, cfnClients, ec2Clients, iamClients)
+      allCredentialReports <- IAMClient.getAllCredentialReports(accounts, cfnClients, iamClients, regions)
     } yield {
       Logger.info("Sending the refreshed data to the Credentials Box")
       credentialsBox.send(allCredentialReports.toMap)

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -5,6 +5,7 @@ import aws.ec2.EC2
 import aws.iam.IAMClient
 import aws.inspector.Inspector
 import aws.support.{TrustedAdvisorExposedIAMKeys, TrustedAdvisorS3}
+import aws.AwsClients
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.ec2.AmazonEC2Async
@@ -29,11 +30,11 @@ class CacheService(
     environment: Environment,
     configraun: com.gu.configraun.models.Configuration,
     wsClient: WSClient,
-    inspectorClients: Map[(String, Regions), AmazonInspectorAsync],
-    ec2Clients: Map[(String, Regions), AmazonEC2Async],
-    cfnClients: Map[(String, Regions), AmazonCloudFormationAsync],
-    taClients: Map[(String, Regions), AWSSupportAsync],
-    iamClients: Map[(String, Regions),  AmazonIdentityManagementAsync],
+    inspectorClients: AwsClients[AmazonInspectorAsync],
+    ec2Clients: AwsClients[AmazonEC2Async],
+    cfnClients: AwsClients[AmazonCloudFormationAsync],
+    taClients: AwsClients[AWSSupportAsync],
+    iamClients: AwsClients[AmazonIdentityManagementAsync],
     regions: List[Regions]
   )(implicit ec: ExecutionContext) {
   private val accounts = Config.getAwsAccounts(config)

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -34,8 +34,10 @@ class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
     )
     val configuration = Configuration(config)
 
-    //Two accounts, all regions.
-    val allRegionsSize = AWS.regions.size * 2
+    val regions = List(Regions.EU_WEST_1, Regions.EU_WEST_2, Regions.EU_WEST_3, Regions.EU_CENTRAL_1)
+
+    //Two accounts, three regions.
+    val allRegionsSize = regions.size * 2
     // Only in one region.
     val singleRegionSize = 2
 
@@ -43,11 +45,11 @@ class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
       AWS.inspectorClients(configuration) should have size(singleRegionSize)
     }
     "ec2" in {
-      AWS.ec2Clients(configuration) should have size(allRegionsSize)
+      AWS.ec2Clients(configuration, regions) should have size(allRegionsSize)
     }
 
     "cloudformation" in {
-      AWS.cfnClients(configuration) should have size(allRegionsSize)
+      AWS.cfnClients(configuration, regions) should have size(allRegionsSize)
     }
 
     "trusted advisor" in {
@@ -55,7 +57,7 @@ class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
     }
 
     "iam" in {
-      AWS.iamClients(configuration) should have size(allRegionsSize)
+      AWS.iamClients(configuration, regions) should have size(allRegionsSize)
     }
 
   }

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -35,7 +35,7 @@ class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
     val configuration = Configuration(config)
 
     //Two accounts, all regions.
-    val allRegionsSize = Regions.values().size * 2
+    val allRegionsSize = AWS.regions.size * 2
     // Only in one region.
     val singleRegionSize = 2
 

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -82,8 +82,8 @@ class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
     val configuration = Configuration(config)
 
     "correct account and region" in {
-      val keys = AWS.clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, Regions.EU_WEST_1).keys
-      keys should contain (("mock", Regions.EU_WEST_1))
+      val clients = AWS.clients(AmazonInspectorAsyncClientBuilder.standard(), configuration, Regions.EU_WEST_1).map(c => c.account.id -> c.region)
+      clients should contain (("mock", Regions.EU_WEST_1))
     }
   }
 

--- a/hq/test/aws/ec2/EC2Test.scala
+++ b/hq/test/aws/ec2/EC2Test.scala
@@ -1,5 +1,7 @@
 package aws.ec2
 
+import akka.actor.FSM.->
+import aws.AwsClient
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.ec2.AmazonEC2AsyncClientBuilder
 import com.amazonaws.services.ec2.model._
@@ -246,9 +248,9 @@ class EC2Test extends FreeSpec with Matchers with Checkers with PropertyChecks w
       "vpc-3" -> new Vpc().withVpcId("vpc-3")
     )
     val vpcsResult = Attempt.Right(vpcsMap)
-    val clients = Map(
-      ("security-test", Regions.EU_WEST_1) -> AmazonEC2AsyncClientBuilder.standard().withRegion(Regions.EU_WEST_1).build(),
-      ("security-test", Regions.EU_WEST_2) -> AmazonEC2AsyncClientBuilder.standard().withRegion(Regions.EU_WEST_2).build()
+    val clients = List(
+      AwsClient(AmazonEC2AsyncClientBuilder.standard().withRegion(Regions.EU_WEST_1).build(), AwsAccount("security-test", "security", "security-test"), Regions.EU_WEST_1),
+      AwsClient(AmazonEC2AsyncClientBuilder.standard().withRegion(Regions.EU_WEST_2).build(), AwsAccount("security-test", "security", "security-test"), Regions.EU_WEST_2)
     )
 
     "getVpcs" - {


### PR DESCRIPTION
## What does this change?
Security HQ has been down / flaky for a while and was tricky to troubleshoot.

The initial failure was down to AWS launching a new region which didn't exist in the SDK version we were using:
```scala
  describeAwsRegions.map(Regions.fromName)
```

It turns out this was done for good reasons - we want to process all regions but not Chinese or the US GovCloud as both of these need special AWS accounts. The `describeAvailableRegions` command will only include regions you can access, but will also include regions that are not in your SDK.

In initially fixing this we accidentally tried to run security HQ against China/GovCloud and this was hard to troubleshoot as there was no context of the account or region at the call site.

To solve this we introduced context via an `AwsClient` case class which wraps every AWS client and includes the `AwsAccount` and `Region`. When an error occurs, this context is now also included in logs and failures.

Finally the instance was running out of heap at startup. This seem to be transient as the size settles down after it has initialised. Further profiling should be done to determine the root cause but in the interim this problem has been solved by moving Security HQ to a `t2.medium`.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Security HQ wasn't running and now it is.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No, although it should now be possible to remove permission to call DescribeAvailableRegion

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
