### PR TITLE
Revisions for DEV setup and new CFN template for DEV user

### DIFF
--- a/cloudformation/security-test-user.yaml
+++ b/cloudformation/security-test-user.yaml
@@ -1,0 +1,26 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: CloudFormation template to create user for DEV work
+
+Resources:
+  SecurityDev:
+    Type: AWS::IAM::User
+    Properties:
+      Policies:
+        - PolicyName: SecurityDevPolicy
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Resource:
+                - "*"
+              Action:
+                - iam:GetCredentialReport
+                - iam:GenerateCredentialReport
+                - ec2:DescribeNetworkInterfaces
+                - ec2:DescribeVpcs
+                - ec2:DescribeRegions
+                - cloudformation:DescribeStacks
+                - cloudformation:DescribeStackResources
+                - trustedadvisor:Describe*
+                - support:*
+

--- a/cloudformation/security-test-user.yaml
+++ b/cloudformation/security-test-user.yaml
@@ -22,5 +22,6 @@ Resources:
                 - cloudformation:DescribeStacks
                 - cloudformation:DescribeStackResources
                 - trustedadvisor:Describe*
-                - support:*
+                - support:RefreshTrustedAdvisorCheck
+                - support:DescribeTrustedAdvisor*
 

--- a/hq/README.md
+++ b/hq/README.md
@@ -60,53 +60,47 @@ See `watched-account` template under `cloudformation` folder for the security po
 
 ### nginx setup
 
-At this step we configure nginx.
+1. Install dev-nginx:
 
-1. Install nginx:
-	- Linux: `sudo apt-get install nginx`
-	- Mac OSX: `brew install nginx`
+[dev-nginx](https://github.com/guardian/dev-nginx) contains a number of generic useful scripts to:
+- issue certs locally (and automatically trust them)
+- [generate an nginx config file](https://github.com/guardian/dev-nginx#setup-app) from a yaml definition
 
-2. Make sure you have a sites-enabled folder under your nginx home. This should be:
-	- Linux: `/etc/nginx/sites-enabled`
-	- Mac OSX: `/usr/local/etc/nginx/sites-enabled`
+MacOS users:
 
-3. Ensure that your nginx.conf (found in the same location as the sites-enabled folder) contains the line `include sites-enabled/*` within the http block, for example:
+```bash
+brew tap guardian/homebrew-devtools
+brew install guardian/devtools/dev-nginx
+```
 
-  ```
-  http {
-      include sites-enabled/*;
-      ...
-  }
-  ```
+There are further instructions in the [dev-nginx](https://github.com/guardian/dev-nginx) repo.
 
-4. Checkout the [dev-nginx](https://github.com/guardian/dev-nginx) repo onto your machine and follow the directions regarding installing and trusting the certificates (see [dev-nginx readme](https://github.com/guardian/dev-nginx)).
+2. configure dev-nginx:
 
-5. Install the nginx config for the security-hq application:
+run each of these commands:
 
-  ```
-    cd <path_of_dev-nginx>
-    sudo ./setup-app.rb <path_of_security-hq>/nginx/nginx-mapping.yml
-  ```
+`dev-nginx add-to-hosts-file`
 
-6. To stop and restart ngnix you can now do
+`dev-nginx setup-cert security-hq.local.dev-gutools.co.uk`
 
-	```
-	sudo nginx -s stop
-	sudo nginx
-	```
+`dev-nginx setup-app nginx/nginx-mapping.yml`
 
-7. Now when you run the project (see next step for details), it will also be accessible via [https://security-hq.local.dev-gutools.co.uk/](https://security-hq.local.dev-gutools.co.uk/)
+1. To stop and restart nginx you can now run:
+
+`dev-nginx restart-nginx`
+
+4. Now when you run the project (see next step for details), it will also be accessible via [https://security-hq.local.dev-gutools.co.uk/](https://security-hq.local.dev-gutools.co.uk/)
 
 ### Running project
 From the root of the project:
 
 1. Get Security Janus credentials. 
 
-1. Run sbt: `$ ./sbt`
+2. Run sbt: `$ ./sbt`
 
-1. Select the project that you want to run: `sbt:security-hq> project hq`
+3. Select the project that you want to run: `sbt:security-hq> project hq`
 
-1. Start the application: `sbt:security-hq> run`
+4. Start the application: `sbt:security-hq> run`
 
 Once the sever has started, the webapp is accessible at [https://security-hq.local.dev-gutools.co.uk/](https://security-hq.local.dev-gutools.co.uk/)
 

--- a/hq/README.md
+++ b/hq/README.md
@@ -30,9 +30,13 @@ N.B. If you are using macOS you may need to install `coreutils` before you can r
 
 ### AWS Configuration
 
-Using the Security Admin account, go to AWS IAM console and clone the `security-hq-dev` user to `security-hq-<yourname>`.
+The security-test-user CloudFormation template should create a user with all the required permissions.
 
-At the last step of the creation of this new user, you will be presented with an *Access key ID* and a *Secret access key* that you are going to use during the next step.
+Once the CloudFormation is complete and the user created, you will need to create an access key for this user.
+
+In the console, select the user and then under `security credentials` click `create access key`.
+
+You will be presented with an *Access key ID* and a *Secret access key* that you are going to use during the next step.
 
 Create the file `~/.aws/credentials` with the following contents
 
@@ -137,3 +141,17 @@ To attempt to auto-fix the CSS and JS, you can try using Prettier:
 
 **N.B. Although Prettier will write to the files, changes will still need to be staged afterwards.**
 
+
+##### Checking CloudFormation
+
+The aws cli can perform some basic template validation.
+
+It requires AWS credentials to run, and can validate a single file like so:
+
+`aws cloudformation validate-template --template-body file:///${PWD}/cloudformation/security-test-user.yaml --profile <AWS_PROFILE>`
+
+[CFN nag](https://github.com/stelligent/cfn_nag) is a linting tool for CloudFormation templates that can help catch security issues.
+
+If you have it installed, you can run:
+
+`cfn_nag_scan --input-path cloudformation/*`

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -75,7 +75,7 @@ class AppComponents(context: Context)
         regionList <- EC2.getAvailableRegions(ec2Client)
         regionStringSet = regionList.map(_.getRegionName).toSet
       } yield Regions.values.filter(r => regionStringSet.contains(r.getName)).toList
-      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.get
+      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.getOrElse(List(Regions.EU_WEST_1))
     } finally {
       ec2Client.client.shutdown()
     }


### PR DESCRIPTION
## What does this change?

#### 👉 Update README for working with dev-nginx

[dev-nginx](https://github.com/guardian/dev-nginx) contains a number of generic useful scripts to:
- issue certs locally (and automatically trust them)
- [generate an nginx config file](https://github.com/guardian/dev-nginx#setup-app) from a yaml definition

#### 👉 Fix regions when running in DEV mode

Tried running the app today locally and ran into an error:

![Screenshot 2019-07-05 at 16 51 54](https://user-images.githubusercontent.com/8607683/60733596-39099580-9f45-11e9-901d-d963e85edcbe.png)

I probably ran into this due to not having `ec2:DescribeRegions` on my DEV user, so I have also given myself the missing permissions.

Any strong feelings on switching to using getOrElse? This allows SHQ to still run if ec2:DescribeRegions` is missing from a policy.

#### 👉 Add Dev user CFN template and guide to making a DEV user

This template includes minimal permissions for running Security HQ locally against a single account:

![Screenshot 2019-07-05 at 16 55 40](https://user-images.githubusercontent.com/8607683/60733768-bf25dc00-9f45-11e9-9992-5185a9749aea.png)

This means that setting up a dev environment no longer requires access to a specific AWS account.
Ideally, this template should be the single source of truth

🚀 ✨ 


#### 👉 Add some notes on validating CloudFormation to the README

Checking templates for security issues and misconfiguration is a good habit! 💛 🔒 

Validating templates before attempting to create a stack is good for developer sanity! ❤️🌀

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope
