### PR TITLE
Order accounts and buckets but report status

### DIFF
--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -7,7 +7,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest}
-import logic.{ReportDisplay, Retry}
+import logic.{CredentialsReportDisplay, Retry}
 import model.{AwsAccount, CredentialReportDisplay, IAMCredentialsReport}
 import utils.attempt.{Attempt, FailedAttempt}
 
@@ -43,7 +43,7 @@ object IAMClient {
       report <- getCredentialsReport(client)
       stacks <- CloudFormation.getStacksFromAllRegions(account, cfnClients, regions)
       enrichedReport = CredentialsReport.enrichReportWithStackDetails(report, stacks)
-    } yield ReportDisplay.toCredentialReportDisplay(enrichedReport)
+    } yield CredentialsReportDisplay.toCredentialReportDisplay(enrichedReport)
   }
 
   def getAllCredentialReports(

--- a/hq/app/aws/support/TrustedAdvisorS3.scala
+++ b/hq/app/aws/support/TrustedAdvisorS3.scala
@@ -21,11 +21,6 @@ object TrustedAdvisorS3 {
     }
   }
 
-  // The TA report actually includes all buckets, even if they are status green
-  private def removePrivateBuckets(buckets: List[BucketDetail]): List[BucketDetail] = {
-    buckets.filter( _.status != "green" )
-  }
-
   private def getBucketReport(client: AwsClient[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[BucketDetail]] = {
     getTrustedAdvisorCheckDetails(client, S3_Bucket_Permissions)
       .flatMap(parseTrustedAdvisorCheckResult(parseBucketDetail, ec))
@@ -35,7 +30,7 @@ object TrustedAdvisorS3 {
     for {
       supportClient <- taClients.get(account)
       bucketResult <- getBucketReport(supportClient)
-      publicBuckets = removePrivateBuckets(bucketResult.flaggedResources)
+      publicBuckets = bucketResult.flaggedResources
     } yield publicBuckets
   }
 

--- a/hq/app/aws/support/TrustedAdvisorS3.scala
+++ b/hq/app/aws/support/TrustedAdvisorS3.scala
@@ -2,7 +2,6 @@ package aws.support
 
 import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult}
 import aws.{AwsClient, AwsClients}
-import com.amazonaws.regions.Regions
 import com.amazonaws.services.support.AWSSupportAsync
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
 import model._

--- a/hq/app/aws/support/TrustedAdvisorS3.scala
+++ b/hq/app/aws/support/TrustedAdvisorS3.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ExecutionContext, Future}
 object TrustedAdvisorS3 {
   private val S3_Bucket_Permissions = "Pfx0RwqBli"
 
-  def getAllPublicBuckets(accounts: List[AwsAccount], taClients: AwsClients[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[PublicS3BucketDetail]])]] = {
+  def getAllPublicBuckets(accounts: List[AwsAccount], taClients: AwsClients[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[BucketDetail]])]] = {
     Attempt.Async.Right {
       Future.traverse(accounts) { account =>
         publicBucketsForAccount(account, taClients).asFuture.map(account -> _)
@@ -22,29 +22,34 @@ object TrustedAdvisorS3 {
     }
   }
 
-  private def getPublicS3Buckets(client: AwsClient[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[PublicS3BucketDetail]] = {
-    getTrustedAdvisorCheckDetails(client, S3_Bucket_Permissions)
-      .flatMap(parseTrustedAdvisorCheckResult(parsePublicS3BucketDetail, ec))
+  // The TA report actually includes all buckets, even if they are status green
+  private def removePrivateBuckets(buckets: List[BucketDetail]): List[BucketDetail] = {
+    buckets.filter( _.status != "green" )
   }
 
-  private def publicBucketsForAccount(account: AwsAccount, taClients: AwsClients[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[PublicS3BucketDetail]] = {
+  private def getBucketReport(client: AwsClient[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[TrustedAdvisorDetailsResult[BucketDetail]] = {
+    getTrustedAdvisorCheckDetails(client, S3_Bucket_Permissions)
+      .flatMap(parseTrustedAdvisorCheckResult(parseBucketDetail, ec))
+  }
+
+  private def publicBucketsForAccount(account: AwsAccount, taClients: AwsClients[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[BucketDetail]] = {
     for {
       supportClient <- taClients.get(account)
-      publicBucketsResult <- getPublicS3Buckets(supportClient)
-      publicBuckets = publicBucketsResult.flaggedResources
+      bucketResult <- getBucketReport(supportClient)
+      publicBuckets = removePrivateBuckets(bucketResult.flaggedResources)
     } yield publicBuckets
   }
 
-  private[support] def parsePublicS3BucketDetail(detail: TrustedAdvisorResourceDetail): Attempt[PublicS3BucketDetail] = {
+  private[support] def parseBucketDetail(detail: TrustedAdvisorResourceDetail): Attempt[BucketDetail] = {
     def toBoolean(str: String): Boolean = str.toLowerCase.contentEquals("yes")
 
     detail.getMetadata.asScala.toList match {
       case region :: _ :: bucketName :: aclAllowsRead :: aclAllowsWrite :: status :: policyAllowsAccess ::  _ =>
         Attempt.Right {
-          PublicS3BucketDetail(
+          BucketDetail(
             region,
             bucketName,
-            status,
+            status.toLowerCase,
             toBoolean(aclAllowsRead),
             toBoolean(aclAllowsWrite),
             toBoolean(policyAllowsAccess),

--- a/hq/app/controllers/BucketsController.scala
+++ b/hq/app/controllers/BucketsController.scala
@@ -20,7 +20,7 @@ class BucketsController(val config: Configuration, cacheService: CacheService, v
   private val accounts = Config.getAwsAccounts(config)
 
   def buckets: Action[AnyContent] = authAction {
-    val viewData = PublicBucketsDisplay.accountsBucketData(cacheService.getAllPublicBuckets.toList)
+    val viewData = PublicBucketsDisplay.allAccountsBucketData(cacheService.getAllPublicBuckets.toList)
     Ok(views.html.s3.publicBuckets(viewData))
   }
 

--- a/hq/app/controllers/BucketsController.scala
+++ b/hq/app/controllers/BucketsController.scala
@@ -19,7 +19,7 @@ class BucketsController(val config: Configuration, cacheService: CacheService, v
 
   private val accounts = Config.getAwsAccounts(config)
 
-  def buckets = authAction {
+  def buckets: Action[AnyContent] = authAction {
     val viewData = PublicBucketsDisplay.accountsBucketData(cacheService.getAllPublicBuckets.toList)
     Ok(views.html.s3.publicBuckets(viewData))
   }

--- a/hq/app/controllers/BucketsController.scala
+++ b/hq/app/controllers/BucketsController.scala
@@ -4,6 +4,7 @@ import auth.SecurityHQAuthActions
 import aws.AWS
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
+import logic.PublicBucketsDisplay
 import play.api._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -19,15 +20,15 @@ class BucketsController(val config: Configuration, cacheService: CacheService, v
   private val accounts = Config.getAwsAccounts(config)
 
   def buckets = authAction {
-    val allPublicBuckets = cacheService.getAllPublicBuckets.toList
-    Ok(views.html.s3.publicBuckets(allPublicBuckets))
+    val viewData = PublicBucketsDisplay.accountsBucketData(cacheService.getAllPublicBuckets.toList)
+    Ok(views.html.s3.publicBuckets(viewData))
   }
 
   def bucketsAccount(accountId: String): Action[AnyContent] = authAction.async {
     attempt {
       for {
         account <- AWS.lookupAccount(accountId, accounts)
-        publicBuckets = cacheService.getPublicBucketsForAccount(account)
+        (_, publicBuckets) = PublicBucketsDisplay.accountBucketData((account, cacheService.getPublicBucketsForAccount(account)))
       } yield Ok(views.html.s3.publicBucketsAccount(account, publicBuckets))
     }
   }

--- a/hq/app/controllers/CredentialsController.scala
+++ b/hq/app/controllers/CredentialsController.scala
@@ -4,7 +4,7 @@ import auth.SecurityHQAuthActions
 import aws.AWS
 import com.gu.googleauth.GoogleAuthConfig
 import config.Config
-import logic.ReportDisplay.{exposedKeysSummary, sortAccountsByReportSummary}
+import logic.CredentialsReportDisplay.{exposedKeysSummary, sortAccountsByReportSummary}
 import play.api._
 import play.api.libs.ws.WSClient
 import play.api.mvc._

--- a/hq/app/controllers/SecurityGroupsController.scala
+++ b/hq/app/controllers/SecurityGroupsController.scala
@@ -20,7 +20,7 @@ class SecurityGroupsController(val config: Configuration, cacheService: CacheSer
 
   private val accounts = Config.getAwsAccounts(config)
 
-  def securityGroups = authAction {
+  def securityGroups: Action[AnyContent] = authAction {
     val allFlaggedSgs = cacheService.getAllSgs
     val sortedFlaggedSgs = EC2.sortAccountByFlaggedSgs(allFlaggedSgs.toList)
     Ok(views.html.sgs.sgs(sortedFlaggedSgs))

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -7,7 +7,7 @@ import utils.attempt.FailedAttempt
 import java.net.URLEncoder
 
 
-object ReportDisplay {
+object CredentialsReportDisplay {
 
   case class ReportSummary(warnings: Int, errors: Int, other: Int)
 

--- a/hq/app/logic/PublicBucketsDisplay.scala
+++ b/hq/app/logic/PublicBucketsDisplay.scala
@@ -39,7 +39,7 @@ object PublicBucketsDisplay {
   }
 
   private def bucketDetailsSort(bucketDetail: BucketDetail): (Int, String) = {
-    val severity = bucketDetail.reportStatus.getOrElse(10) match {
+    val severity = bucketDetail.reportStatus.getOrElse(Blue) match {
       case Red => 0
       case Amber => 1
       case Green => 2

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -106,7 +106,7 @@ case class ExposedIAMKeyDetail(
   deadline: String,
   usage: String
 ) extends TrustedAdvisorCheckDetails
-case class PublicS3BucketDetail(
+case class BucketDetail(
   region: String,
   bucketName: String,
   status: String,

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -39,16 +39,16 @@ class CacheService(
   )(implicit ec: ExecutionContext) {
   private val accounts = Config.getAwsAccounts(config)
   private val startingCache = accounts.map(acc => (acc, Left(Failure.cacheServiceErrorPerAccount(acc.id, "cache").attempt))).toMap
-  private val publicBucketsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[PublicS3BucketDetail]]]] = Box(startingCache)
+  private val publicBucketsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[BucketDetail]]]] = Box(startingCache)
   private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(startingCache)
   private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(startingCache)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
   private val inspectorBox: Box[Map[AwsAccount, Either[FailedAttempt, List[InspectorAssessmentRun]]]] = Box(startingCache)
   private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("cache").attempt)))
 
-  def getAllPublicBuckets: Map[AwsAccount, Either[FailedAttempt, List[PublicS3BucketDetail]]] = publicBucketsBox.get()
+  def getAllPublicBuckets: Map[AwsAccount, Either[FailedAttempt, List[BucketDetail]]] = publicBucketsBox.get()
 
-  def getPublicBucketsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[PublicS3BucketDetail]] = {
+  def getPublicBucketsForAccount(awsAccount: AwsAccount): Either[FailedAttempt, List[BucketDetail]] = {
     publicBucketsBox.get().getOrElse(
       awsAccount,
       Left(Failure.cacheServiceErrorPerAccount(awsAccount.id, "public buckets").attempt)

--- a/hq/app/views/fragments/allKeyStatus.scala.html
+++ b/hq/app/views/fragments/allKeyStatus.scala.html
@@ -1,7 +1,7 @@
 @import model.KeyStatus
 @import model.AccessKeyDisabled
 @import model.AccessKeyEnabled
-@import logic.ReportDisplay
+@import logic.CredentialsReportDisplay
 @(key1Status: KeyStatus, key2Status: KeyStatus)
 
 
@@ -14,7 +14,7 @@
     }
 }
 
-@if(ReportDisplay.checkNoKeyExists(key1Status, key2Status)) {
+@if(CredentialsReportDisplay.checkNoKeyExists(key1Status, key2Status)) {
   <span>-</span>
 } else {
     @keyStatus(key1Status)

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -1,4 +1,4 @@
-@import logic.ReportDisplay._
+@import logic.CredentialsReportDisplay._
 @import model._
 @import utils.attempt.FailedAttempt
 @(reports: List[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])], exposedKeySummary: Map[AwsAccount, Boolean])(implicit assets: AssetsFinder)

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -1,6 +1,6 @@
 @import logic.DateUtils
 @import model._
-@import logic.ReportDisplay
+@import logic.CredentialsReportDisplay
 @(report: CredentialReportDisplay)
 
 <div class="row">
@@ -26,7 +26,7 @@
                         <i class="material-icons left tooltipped" data-tooltip="human user" data-position="bottom" data-delay="50">person</i>
                         @cred.stack match {
                             case Some(stack) => {
-                            <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stack)">
+                            <a target="_blank" rel="noopener noreferrer" href="@CredentialsReportDisplay.linkForAwsConsole(stack)">
                                 <i class="material-icons left tooltipped" data-tooltip="@stack.name stack" data-position="bottom" data-delay="50">cloud_done</i>
                             </a>
                             }
@@ -55,7 +55,7 @@
                         }
                     </td>
                     <td>
-                        <span>@ReportDisplay.toDayString(cred.lastActivityDay)</span>
+                        <span>@CredentialsReportDisplay.toDayString(cred.lastActivityDay)</span>
                     </td>
                     <td>@views.html.fragments.humanReportStatus(cred.reportStatus)</td>
                 </tr>
@@ -67,7 +67,7 @@
                         <i class="material-icons left tooltipped" data-tooltip="machine user" data-position="bottom" data-delay="50">computer</i>
                         @cred.stack match {
                             case Some(stack) => {
-                                <a target="_blank" rel="noopener noreferrer" href="@ReportDisplay.linkForAwsConsole(stack)">
+                                <a target="_blank" rel="noopener noreferrer" href="@CredentialsReportDisplay.linkForAwsConsole(stack)">
                                     <i class="material-icons left tooltipped" data-tooltip="@stack.name stack" data-position="bottom" data-delay="50">cloud_done</i>
                                 </a>
                             }
@@ -89,7 +89,7 @@
                     <td>@views.html.fragments.allKeyStatus(cred.key1Status, cred.key2Status)</td>
                     <td><span>-</span></td>
                     <td>
-                        <span>@ReportDisplay.toDayString(cred.lastActivityDay)</span>
+                        <span>@CredentialsReportDisplay.toDayString(cred.lastActivityDay)</span>
                     </td>
                     <td>@views.html.fragments.machineReportStatus(cred.reportStatus)</td>
                 </tr>

--- a/hq/app/views/s3/publicBuckets.scala.html
+++ b/hq/app/views/s3/publicBuckets.scala.html
@@ -1,7 +1,8 @@
 @import logic.PublicBucketsDisplay._
 @import model._
+@import utils.attempt.FailedAttempt
 
-@(reports: List[(AwsAccount, Either[utils.attempt.FailedAttempt, List[PublicS3BucketDetail]])])(implicit assets: AssetsFinder)
+@(reports: List[(AwsAccount, Either[FailedAttempt, (BucketReportSummary, List[PublicS3BucketDetail])])])(implicit assets: AssetsFinder)
 
 @floatingNav() = {
     <div class="fixed-action-btn js-floating-nav iam-floating-nav">
@@ -44,39 +45,37 @@
 
         <div class="row">
             <ul class="collapsible" data-collapsible="accordion">
-            @for((account, report) <- reports) {
+            @for((account, result) <- reports) {
                 <li>
                     <div class="collapsible-header" tabindex="22">
                         <i class="material-icons">keyboard_arrow_down</i>
                         <span class="iam-header__name">@account.name</span>
-                        @report match {
-                            case Right(re) => {
-                                @defining(reportSummary(re)) { statusCounts =>
-                                    @if(statusCounts.errors > 0) {
-                                        <span class="icon-count">@statusCounts.errors</span>
-                                        <i class="material-icons red-text">error</i>
-                                    }
-                                    @if(statusCounts.warnings > 0) {
-                                        <span class="icon-count">@statusCounts.warnings</span>
-                                        <i class="material-icons amber-text">warning</i>
-                                    }
-                                    @if(statusCounts.suppressed > 0) {
-                                        <span class="icon-count">@statusCounts.suppressed</span>
-                                        <i class="material-icons purple-text">watch_later</i>
-                                    }
-                                    @if(statusCounts.errors == 0 && statusCounts.warnings == 0) {
-                                        <i class="material-icons green-text">check</i>
-                                    }
+                        @result match {
+                            case Right((statusCounts, bucketDetails)) => {
+                                @if(statusCounts.errors > 0) {
+                                    <span class="icon-count">@statusCounts.errors</span>
+                                    <i class="material-icons red-text">error</i>
+                                }
+                                @if(statusCounts.warnings > 0) {
+                                    <span class="icon-count">@statusCounts.warnings</span>
+                                    <i class="material-icons amber-text">warning</i>
+                                }
+                                @if(statusCounts.suppressed > 0) {
+                                    <span class="icon-count">@statusCounts.suppressed</span>
+                                    <i class="material-icons purple-text">watch_later</i>
+                                }
+                                @if(statusCounts.errors == 0 && statusCounts.warnings == 0) {
+                                    <i class="material-icons green-text">check</i>
+                                }
                             }
-                        }
-                        case Left(_) => {
-                            <i class="material-icons">warning</i>
-                        }
+                            case Left(_) => {
+                                <i class="material-icons">warning</i>
+                            }
                     }
                     </div>
 
                     <div class="collapsible-body">
-                        @report match {
+                        @result match {
                             case Left(errs) => {
                                 <p class="p--warning">
                                 @for(err <- errs.failures) {
@@ -84,10 +83,10 @@
                                 }
                                 </p>
                             }
-                            case Right(Nil) => {
+                            case Right((statusCounts, Nil)) => {
                                 <p>No open S3 buckets</p>
                             }
-                            case Right(openBuckets) => {
+                            case Right((statusCounts, openBuckets)) => {
                                 @views.html.s3.publicBucketsBody(openBuckets, shadow=false)
                             }
                         }

--- a/hq/app/views/s3/publicBuckets.scala.html
+++ b/hq/app/views/s3/publicBuckets.scala.html
@@ -2,7 +2,7 @@
 @import model._
 @import utils.attempt.FailedAttempt
 
-@(reports: List[(AwsAccount, Either[FailedAttempt, (BucketReportSummary, List[PublicS3BucketDetail])])])(implicit assets: AssetsFinder)
+@(reports: List[(AwsAccount, Either[FailedAttempt, (BucketReportSummary, List[BucketDetail])])])(implicit assets: AssetsFinder)
 
 @floatingNav() = {
     <div class="fixed-action-btn js-floating-nav iam-floating-nav">

--- a/hq/app/views/s3/publicBucketsAccount.scala.html
+++ b/hq/app/views/s3/publicBucketsAccount.scala.html
@@ -2,7 +2,7 @@
 @import model._
 @import utils.attempt.FailedAttempt
 
-@(awsAccount: AwsAccount, report: Either[FailedAttempt, (BucketReportSummary, List[PublicS3BucketDetail])])(implicit assets: AssetsFinder)
+@(awsAccount: AwsAccount, report: Either[FailedAttempt, (BucketReportSummary, List[BucketDetail])])(implicit assets: AssetsFinder)
 
 @floatingNav() = {
     <div class="fixed-action-btn js-floating-nav iam-floating-nav">

--- a/hq/app/views/s3/publicBucketsAccount.scala.html
+++ b/hq/app/views/s3/publicBucketsAccount.scala.html
@@ -1,7 +1,8 @@
 @import logic.PublicBucketsDisplay._
 @import model._
+@import utils.attempt.FailedAttempt
 
-@(awsAccount: AwsAccount, report: Either[utils.attempt.FailedAttempt, List[PublicS3BucketDetail]])(implicit assets: AssetsFinder)
+@(awsAccount: AwsAccount, report: Either[FailedAttempt, (BucketReportSummary, List[PublicS3BucketDetail])])(implicit assets: AssetsFinder)
 
 @floatingNav() = {
     <div class="fixed-action-btn js-floating-nav iam-floating-nav">
@@ -43,13 +44,13 @@
         </div>
 
         @report match {
-            case Right(Nil) => {
+            case Right((_, Nil)) => {
                 <div class="card-panel valign-wrapper">
                     <i class="material-icons medium green-text left">verified_user</i>
                     <h5>No open S3 buckets found</h5>
                 </div>
             }
-            case Right(openBuckets) => {
+            case Right((_, openBuckets)) => {
                 @if(hasSuppressedReports(openBuckets)) {
                     <div class="row">
                         <div class="card-panel valign-wrapper">

--- a/hq/app/views/s3/publicBucketsBody.scala.html
+++ b/hq/app/views/s3/publicBucketsBody.scala.html
@@ -1,6 +1,6 @@
 @import logic.PublicBucketsDisplay._
-@import model.PublicS3BucketDetail
-@(buckets: List[PublicS3BucketDetail], shadow: Boolean)
+@import model.BucketDetail
+@(buckets: List[BucketDetail], shadow: Boolean)
 
 @helpIcon = {
     <a class="modal-trigger buckets-modal__trigger right" href="#buckets-help"><i class="material-icons black-text">help_outline</i></a>

--- a/hq/test/logic/CredentialsReportDisplayTest.scala
+++ b/hq/test/logic/CredentialsReportDisplayTest.scala
@@ -3,11 +3,11 @@ package logic
 import model._
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
-import ReportDisplay._
+import CredentialsReportDisplay._
 import utils.attempt.{FailedAttempt, Failure}
 
 
-class ReportDisplayTest extends FreeSpec with Matchers {
+class CredentialsReportDisplayTest extends FreeSpec with Matchers {
 
   "display logic" - {
     val now = DateTime.now()

--- a/hq/test/logic/PublicBucketsDisplayTest.scala
+++ b/hq/test/logic/PublicBucketsDisplayTest.scala
@@ -1,0 +1,31 @@
+package logic
+
+import org.scalatest.FreeSpec
+
+class PublicBucketsDisplayTest extends FreeSpec {
+  "bucketDetailsSort" - {
+    "puts a Red bucket before others" ignore {}
+
+    "puts an amber bucket before others" ignore {}
+
+    "puts a green bucket before blue" ignore {}
+  }
+
+  "accountsSort" - {
+    "puts an account with errors above one with lots of warnings" ignore {}
+
+    "breaks ties by name" ignore {}
+
+    "puts an account with a failed response after others" ignore {}
+  }
+
+  "accountsBucketData" - {
+    "sorts accounts" ignore {}
+  }
+
+  "accountBucketData" - {
+    "sorts buckets" ignore {}
+
+    "adds bucket details summary information" ignore {}
+  }
+}

--- a/hq/test/logic/PublicBucketsDisplayTest.scala
+++ b/hq/test/logic/PublicBucketsDisplayTest.scala
@@ -1,31 +1,157 @@
 package logic
 
-import org.scalatest.FreeSpec
+import org.scalatest.{FreeSpec, Matchers}
+import PublicBucketsDisplay._
+import model._
+import utils.attempt.{FailedAttempt, Failure}
 
-class PublicBucketsDisplayTest extends FreeSpec {
+class PublicBucketsDisplayTest extends FreeSpec with Matchers {
+
+  def createExampleBuckets(id: Int): List[BucketDetail] = {
+    List(
+      BucketDetail("eu-west-1", s"bucket-green-$id", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green)),
+      BucketDetail("eu-west-1", s"bucket-amber-$id", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Amber)),
+      BucketDetail("eu-west-1", s"bucket-red-$id", "Red", aclAllowsRead = false, aclAllowsWrite = true, policyAllowsAccess = false, isSuppressed = false, Some(Red))
+    )
+  }
+
+  "reportSummary" - {
+    "lis" in {
+      val examples: List[BucketDetail] = createExampleBuckets(1) ++ createExampleBuckets(2)
+
+      reportSummary(examples) shouldEqual BucketReportSummary(6, 2, 2, 0)
+    }
+  }
+
   "bucketDetailsSort" - {
-    "puts a Red bucket before others" ignore {}
 
-    "puts an amber bucket before others" ignore {}
+    "puts an amber bucket before green" in {
+      val buckets = List(
+        BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green)),
+        BucketDetail("eu-west-1", s"bucket-amber-1", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Amber))
+      )
 
-    "puts a green bucket before blue" ignore {}
+      buckets.sortBy(bucketDetailsSort) shouldEqual List(
+        BucketDetail("eu-west-1", s"bucket-amber-1", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Amber)),
+        BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green))
+      )
+    }
+
+    "puts a green bucket before blue" in {
+      val buckets = List(
+        BucketDetail("eu-west-1", s"bucket-blue-1", "Blue", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = true, isSuppressed = false, Some(Blue)),
+        BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green))
+      )
+
+      buckets.sortBy(bucketDetailsSort) shouldEqual List(
+        BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green)),
+        BucketDetail("eu-west-1", s"bucket-blue-1", "Blue", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = true, isSuppressed = false, Some(Blue))
+      )
+    }
+
+    "puts a Red bucket before all others" in {
+      val buckets = createExampleBuckets(1) ++ createExampleBuckets(2)
+      buckets.sortBy(bucketDetailsSort).map(_.bucketName) shouldEqual List(
+        "bucket-red-1",
+        "bucket-red-2",
+        "bucket-amber-1",
+        "bucket-amber-2",
+        "bucket-green-1",
+        "bucket-green-2",
+      )
+    }
   }
 
   "accountsSort" - {
-    "puts an account with errors above one with lots of warnings" ignore {}
+    val accountWithErrors = (AwsAccount("account-with-errors", "name", "ARN"),
+      Right(BucketReportSummary(3, 1, 2, 0),
+        List(
+      BucketDetail("eu-west-1", s"bucket-red-1", "Red", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = true, isSuppressed = false, Some(Red)),
+      BucketDetail("eu-west-1", s"bucket-red-2", "Red", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = true, isSuppressed = false, Some(Red)),
+      BucketDetail("eu-west-1", s"bucket-amber-1", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Amber))
+    )))
+    val accountWithWarnings = (AwsAccount("account-with-warnings", "name", "ARN"),
+      Right(BucketReportSummary(3, 2, 1, 0),
+        List(
+      BucketDetail("eu-west-1", s"bucket-amber-1", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Amber)),
+      BucketDetail("eu-west-1", s"bucket-amber-2", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Amber)),
+      BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green))
+    )))
+    val accountAllGreen = (AwsAccount("account-all-green", "name", "ARN"),
+      Right(BucketReportSummary(2, 0, 0, 0),
+        List(
+      BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green)),
+      BucketDetail("eu-west-1", s"bucket-green-2", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, Some(Green))
+    )))
+    "puts an account with errors above one with lots of warnings" in {
+      val accounts = List(accountWithWarnings, accountAllGreen, accountWithErrors).sortBy(accountsSort)
+      accounts shouldEqual List(accountWithErrors, accountWithWarnings, accountAllGreen)
+    }
 
-    "breaks ties by name" ignore {}
+    "breaks ties by name" in {
+      val accountA = accountWithWarnings.copy(_1 = AwsAccount("account-with-warnings", "first", "ARN"))
+      val accountB = accountWithWarnings.copy(_1 = AwsAccount("account-with-warnings", "second", "ARN"))
+      val accountC = accountWithWarnings.copy(_1 = AwsAccount("account-with-warnings", "will-be-last", "ARN"))
 
-    "puts an account with a failed response after others" ignore {}
+      List(accountB, accountA, accountC).sortBy(accountsSort) shouldEqual List(
+        accountA, accountB, accountC
+      )
+    }
+
+    "puts an account with a failed response after others" ignore {
+      val accountA = accountWithWarnings.copy(_1 = AwsAccount("account-with-warnings", "first", "ARN"))
+      val accountB = accountWithWarnings.copy(_1 = AwsAccount("account-with-warnings", "second", "ARN"))
+      val accountWithFailure = (
+        AwsAccount("account-with-failure", "will-be-last", "ARN"),
+        Left(Failure.cacheServiceErrorPerAccount("account id", "failure type").attempt)
+      )
+      List(accountB, accountWithFailure, accountA).sortBy(accountsSort) shouldEqual List(
+        accountA, accountB, accountWithFailure
+      )
+    }
   }
 
-  "accountsBucketData" - {
-    "sorts accounts" ignore {}
+  "allAccountsBucketData" - {
+    "sorts accounts" ignore {
+
+    }
   }
 
   "accountBucketData" - {
-    "sorts buckets" ignore {}
+    val accountWithErrors = (AwsAccount("account-with-errors", "name", "ARN"),
+      Right(List(
+        BucketDetail("eu-west-1", s"bucket-red-1", "Red", aclAllowsRead = false, aclAllowsWrite = true, policyAllowsAccess = false, isSuppressed = false, None),
+        BucketDetail("eu-west-1", s"bucket-red-2", "Red", aclAllowsRead = false, aclAllowsWrite = true, policyAllowsAccess = false, isSuppressed = false, None),
+        BucketDetail("eu-west-1", s"bucket-amber-1", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, None)
+      )))
+    val accountWithWarnings = (AwsAccount("account-with-warnings", "name", "ARN"),
+      Right(List(
+      BucketDetail("eu-west-1", s"bucket-amber-1", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, None),
+      BucketDetail("eu-west-1", s"bucket-amber-2", "Amber", aclAllowsRead = true, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, None),
+      BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, None)
+    )))
+    val accountAllGreen = (AwsAccount("account-all-green", "name", "ARN"),
+      Right(List(
+      BucketDetail("eu-west-1", s"bucket-green-1", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, None),
+      BucketDetail("eu-west-1", s"bucket-green-2", "Green", aclAllowsRead = false, aclAllowsWrite = false, policyAllowsAccess = false, isSuppressed = false, None)
+    )))
 
-    "adds bucket details summary information" ignore {}
+    "sorts buckets" ignore {
+      val accounts = List(accountWithWarnings, accountAllGreen, accountWithErrors)
+    }
+
+    "adds bucket details summary information" in {
+      val (greenSummary, _) = accountBucketData(accountAllGreen)._2.right.get
+      val (amberSummary, _) = accountBucketData(accountWithWarnings)._2.right.get
+      val (redSummary, _) = accountBucketData(accountWithErrors)._2.right.get
+
+      greenSummary shouldEqual BucketReportSummary(2, 0, 0, 0)
+      amberSummary shouldEqual BucketReportSummary(3, 2, 0, 0)
+      redSummary shouldEqual BucketReportSummary(3, 1, 2, 0)
+    }
+
+    "adds the Report details summary information" in {
+
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

#### 👉 The Public S3 buckets page now sorts accounts according to number and severity of issues:

<img width="1189" alt="Screenshot 2019-07-17 at 14 27 35" src="https://user-images.githubusercontent.com/8607683/61705128-21038580-ad3d-11e9-9a7b-e4365871de32.png">

- An account with errors will be above one with lots of warnings
- An account with a failed response from AWS will appear after others

#### 👉 The ordering of the buckets within each account is now based on the severity of the issue:

<img width="1188" alt="Screenshot 2019-07-17 at 14 28 14" src="https://user-images.githubusercontent.com/8607683/61705136-2791fd00-ad3d-11e9-92d9-c4cc7435b86d.png">


- A bucket with report status `Red` will be above one with report status `Amber`
- Buckets with equal report status severity will be sorted alphabetically

## What is the value of this?

- Add logic to sort bucket report information

- Counts the total reports along with warnings and errors

- Adds bucket details summary information to the account display

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

## Any additional notes?

The Trusted Advisor report actually includes all buckets, even if they are status green therefore this PR renames the class and some methods to better express what we are actually getting from Trusted Advisor. 

Next steps will be to filter suppressed buckets from the view and to add details and warnings around bucket encryption status, along with elevating the report status of unencrypted buckets. We can then remove the buckets from the view that have a green (OK) status.

However, this will all be done in a subsequent PR.