### PR TITLE
Add bucket encryption status to Security HQ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,9 @@ scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-t
 // resolvers += "guardian-bintray" at "https://dl.bintray.com/guardian/sbt-plugins/"
 resolvers += DefaultMavenRepository
 
-val awsSdkVersion = "1.11.258"
+val awsSdkVersion = "1.11.596"
 val playVersion = "2.6.7"
-val jacksonVersion = "2.8.11.1"
+val jacksonVersion = "2.8.11.2"
 
 lazy val hq = (project in file("hq"))
   .enablePlugins(PlayScala, RiffRaffArtifact, UniversalPlugin, SbtWeb)

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val hq = (project in file("hq"))
       "org.typelevel" %% "cats-core" % "1.0.1",
       "com.github.tototoshi" %% "scala-csv" % "1.3.5",
       "com.gu" %% "configraun" % "0.3",
+      "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-support" % awsSdkVersion,

--- a/cloudformation/security-test-user.yaml
+++ b/cloudformation/security-test-user.yaml
@@ -21,7 +21,8 @@ Resources:
                 - ec2:DescribeRegions
                 - cloudformation:DescribeStacks
                 - cloudformation:DescribeStackResources
+                - s3:GetEncryptionConfiguration
                 - trustedadvisor:Describe*
-                - support:RefreshTrustedAdvisorCheck
-                - support:DescribeTrustedAdvisor*
+                - trustedadvisor:RefreshCheck
+                - support:*
 

--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -45,6 +45,7 @@ Resources:
           - Effect: Allow
             Resource: "*"
             Action:
+            - s3:GetEncryptionConfiguration
             # Analyse security groups
             - trustedadvisor:Describe*
             - trustedadvisor:Refresh*

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -75,7 +75,7 @@ class AppComponents(context: Context)
         regionList <- EC2.getAvailableRegions(ec2Client)
         regionStringSet = regionList.map(_.getRegionName).toSet
       } yield Regions.values.filter(r => regionStringSet.contains(r.getName)).toList
-      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.get
+      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.getOrElse(List(region, Regions.US_EAST_1))
     } finally {
       ec2Client.client.shutdown()
     }
@@ -93,7 +93,7 @@ class AppComponents(context: Context)
   private val ec2Clients = AWS.ec2Clients(configuration, availableRegions)
   private val cfnClients = AWS.cfnClients(configuration, availableRegions)
   private val taClients = AWS.taClients(configuration)
-  private val s3Clients = AWS.s3Clients(configuration, availableRegions)
+  private val s3Clients = AWS.s3Clients(configuration)
   private val iamClients = AWS.iamClients(configuration, availableRegions)
 
   private val cacheService = new CacheService(

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -93,6 +93,7 @@ class AppComponents(context: Context)
   private val ec2Clients = AWS.ec2Clients(configuration, availableRegions)
   private val cfnClients = AWS.cfnClients(configuration, availableRegions)
   private val taClients = AWS.taClients(configuration)
+  private val s3Clients = AWS.s3Clients(configuration, availableRegions)
   private val iamClients = AWS.iamClients(configuration, availableRegions)
 
   private val cacheService = new CacheService(
@@ -105,6 +106,7 @@ class AppComponents(context: Context)
     ec2Clients,
     cfnClients,
     taClients,
+    s3Clients,
     iamClients,
     availableRegions)
 

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -75,7 +75,7 @@ class AppComponents(context: Context)
         regionList <- EC2.getAvailableRegions(ec2Client)
         regionStringSet = regionList.map(_.getRegionName).toSet
       } yield Regions.values.filter(r => regionStringSet.contains(r.getName)).toList
-      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.getOrElse(List(Regions.EU_WEST_1))
+      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.get
     } finally {
       ec2Client.client.shutdown()
     }

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -63,8 +63,8 @@ object AWS {
   def taClients(configuration: Configuration, region: Regions = Regions.US_EAST_1): AwsClients[AWSSupportAsync] =
     clients(AWSSupportAsyncClientBuilder.standard(), configuration, region)
 
-  def s3Clients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonS3] =
-    clients(AmazonS3ClientBuilder.standard(), configuration, regions:_*)
+  def s3Clients(configuration: Configuration, region: Regions = Regions.US_EAST_1): AwsClients[AmazonS3] =
+    clients(AmazonS3ClientBuilder.standard(), configuration, region)
 
   def iamClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonIdentityManagementAsync] =
     clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, regions:_*)

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -9,6 +9,7 @@ import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonC
 import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
 import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
 import com.amazonaws.services.inspector.{AmazonInspectorAsync, AmazonInspectorAsyncClientBuilder}
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.support.{AWSSupportAsync, AWSSupportAsyncClientBuilder}
 import config.Config
 import model.AwsAccount
@@ -61,6 +62,9 @@ object AWS {
   // Only needs Regions.US_EAST_1
   def taClients(configuration: Configuration, region: Regions = Regions.US_EAST_1): AwsClients[AWSSupportAsync] =
     clients(AWSSupportAsyncClientBuilder.standard(), configuration, region)
+
+  def s3Clients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonS3] =
+    clients(AmazonS3ClientBuilder.standard(), configuration, regions:_*)
 
   def iamClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonIdentityManagementAsync] =
     clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, regions:_*)

--- a/hq/app/aws/support/TrustedAdvisorS3.scala
+++ b/hq/app/aws/support/TrustedAdvisorS3.scala
@@ -2,6 +2,8 @@ package aws.support
 
 import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult}
 import aws.{AwsClient, AwsClients}
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.support.AWSSupportAsync
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
 import model._
@@ -13,10 +15,10 @@ import scala.concurrent.{ExecutionContext, Future}
 object TrustedAdvisorS3 {
   private val S3_Bucket_Permissions = "Pfx0RwqBli"
 
-  def getAllPublicBuckets(accounts: List[AwsAccount], taClients: AwsClients[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[BucketDetail]])]] = {
+  def getAllPublicBuckets(accounts: List[AwsAccount], taClients: AwsClients[AWSSupportAsync], s3Clients: AwsClients[AmazonS3])(implicit ec: ExecutionContext): Attempt[List[(AwsAccount, Either[FailedAttempt, List[BucketDetail]])]] = {
     Attempt.Async.Right {
       Future.traverse(accounts) { account =>
-        publicBucketsForAccount(account, taClients).asFuture.map(account -> _)
+        publicBucketsForAccount(account, taClients, s3Clients).asFuture.map(account -> _)
       }
     }
   }
@@ -26,12 +28,28 @@ object TrustedAdvisorS3 {
       .flatMap(parseTrustedAdvisorCheckResult(parseBucketDetail, ec))
   }
 
-  private def publicBucketsForAccount(account: AwsAccount, taClients: AwsClients[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[BucketDetail]] = {
+//  When you use server-side encryption, Amazon S3 encrypts an object before saving
+//  it to disk in its data centers and decrypts it when you download the object
+  private def addEncryptionStatus(bucket: BucketDetail, client: AwsClient[AmazonS3])(implicit ec: ExecutionContext): BucketDetail = {
+    // If there is no bucket encryption, AWS returns an error...
+    // Assume bucket is not encrypted if we cannot successfully getBucketEncryption
+    try {
+      client.client.getBucketEncryption(bucket.bucketName)
+      bucket.copy(isEncrypted = true)
+    } catch {
+        case e: AmazonS3Exception => {
+          bucket
+        }
+    }
+  }
+
+  private def publicBucketsForAccount(account: AwsAccount, taClients: AwsClients[AWSSupportAsync], s3Clients: AwsClients[AmazonS3])(implicit ec: ExecutionContext): Attempt[List[BucketDetail]] = {
     for {
       supportClient <- taClients.get(account)
+      s3Client <- s3Clients.get(account)
       bucketResult <- getBucketReport(supportClient)
-      publicBuckets = bucketResult.flaggedResources
-    } yield publicBuckets
+      enhancedBuckets = bucketResult.flaggedResources.map(addEncryptionStatus(_, s3Client))
+    } yield enhancedBuckets
   }
 
   private[support] def parseBucketDetail(detail: TrustedAdvisorResourceDetail): Attempt[BucketDetail] = {

--- a/hq/app/logic/PublicBucketsDisplay.scala
+++ b/hq/app/logic/PublicBucketsDisplay.scala
@@ -28,12 +28,7 @@ object PublicBucketsDisplay {
     s"https://console.aws.amazon.com/s3/home?bucket=${URLEncoder.encode(bucket.bucketName, "utf-8")}"
   }
 
-  def isOnlyMissingEncryption(bucket: BucketDetail): Boolean = {
-    if (bucket.reportStatus.getOrElse(None) == Blue) {
-      return !bucket.isEncrypted
-    }
-    false
-  }
+  def isOnlyMissingEncryption(bucket: BucketDetail): Boolean = bucket.reportStatus.getOrElse(None) == Blue && !bucket.isEncrypted
 
   private[logic] def bucketReportStatus(bucket: BucketDetail): ReportStatus = {
     // permission properties that grant global access

--- a/hq/app/logic/PublicBucketsDisplay.scala
+++ b/hq/app/logic/PublicBucketsDisplay.scala
@@ -28,6 +28,13 @@ object PublicBucketsDisplay {
     s"https://console.aws.amazon.com/s3/home?bucket=${URLEncoder.encode(bucket.bucketName, "utf-8")}"
   }
 
+  def isOnlyMissingEncryption(bucket: BucketDetail): Boolean = {
+    if (bucket.reportStatus.getOrElse(None) == Blue) {
+      return !bucket.isEncrypted
+    }
+    false
+  }
+
   private[logic] def bucketReportStatus(bucket: BucketDetail): ReportStatus = {
     // permission properties that grant global access
     // The bucket ACL allows Upload/Delete access to anyone

--- a/hq/app/logic/PublicBucketsDisplay.scala
+++ b/hq/app/logic/PublicBucketsDisplay.scala
@@ -7,18 +7,19 @@ import utils.attempt.FailedAttempt
 
 object PublicBucketsDisplay {
 
-  case class BucketReportSummary(total: Int, warnings: Int, errors: Int, suppressed: Int)
+  case class BucketReportSummary(total: Int, warnings: Int, errors: Int, other: Int, suppressed: Int)
 
   def reportSummary(buckets: List[BucketDetail]): BucketReportSummary = {
     val (suppressed, flagged) = buckets.partition( b => b.isSuppressed)
     val reportStatusSummary = flagged.map( bucket => bucketReportStatus(bucket))
 
-    val (warnings, errors) = reportStatusSummary.foldLeft(0,0) {
-      case ( (war, err), Amber ) => (war+1, err)
-      case ( (war, err), Red ) => (war, err+1)
-      case ( (war, err), _ ) => (war, err)
+    val (warnings, errors, other) = reportStatusSummary.foldLeft(0,0,0) {
+      case ( (war, err, oth), Amber ) => (war+1, err, oth)
+      case ( (war, err, oth), Red ) => (war, err+1, oth)
+      case ( (war, err, oth), Blue ) => (war, err, oth+1)
+      case ( (war, err, oth), _ ) => (war, err, oth)
     }
-    BucketReportSummary(buckets.length, warnings, errors, suppressed.length)
+    BucketReportSummary(buckets.length, warnings, errors, other, suppressed.length)
   }
 
   def hasSuppressedReports(buckets: List[BucketDetail]): Boolean = buckets.exists(_.isSuppressed)
@@ -35,6 +36,8 @@ object PublicBucketsDisplay {
     // The bucket ACL allows List access to anyone, or a bucket policy allows any kind of open access
     else if (bucket.aclAllowsRead || bucket.policyAllowsAccess)
       Amber
+    else if (!bucket.isEncrypted)
+      Blue
     else Green
   }
 
@@ -42,24 +45,24 @@ object PublicBucketsDisplay {
     val severity = bucketDetail.reportStatus.getOrElse(Blue) match {
       case Red => 0
       case Amber => 1
-      case Green => 2
-      case Blue => 3
+      case Blue => 2
+      case Green => 3
     }
     (severity, bucketDetail.bucketName)
   }
 
-  private[logic] def accountsSort(accountInfo: (AwsAccount, Either[FailedAttempt, (BucketReportSummary, List[BucketDetail])])): (Int, Int, Int, String) = {
+  private[logic] def accountsSort(accountInfo: (AwsAccount, Either[FailedAttempt, (BucketReportSummary, List[BucketDetail])])): (Int, Int, Int, Int, String) = {
     accountInfo match {
       case (account, Right((bucketReportSummary, _))) =>
-        (-bucketReportSummary.errors, -bucketReportSummary.warnings, -bucketReportSummary.suppressed, account.name)
+        (-bucketReportSummary.errors, -bucketReportSummary.warnings, -bucketReportSummary.other, -bucketReportSummary.suppressed, account.name)
       case (account, _) =>
-        (0, 0, 0, account.name)
+        (0, 0, 0, 0, account.name)
     }
   }
 
   // The TA report actually includes all buckets, even if they are status green
   private def removeGreenBuckets(buckets: List[BucketDetail]): List[BucketDetail] = {
-    buckets.filter( _.status != "green" )
+    buckets.filter( _.reportStatus.getOrElse(Blue) != Green )
   }
 
   def allAccountsBucketData(reports: List[(AwsAccount, Either[FailedAttempt, List[BucketDetail]])]):
@@ -74,7 +77,8 @@ object PublicBucketsDisplay {
         val bucketsWithReportStatus = bucketDetails.map(
           bucket => bucket.copy(reportStatus = Some(bucketReportStatus(bucket)))
         )
-        (account, Right(reportSummary(bucketDetails), bucketsWithReportStatus.sortBy(bucketDetailsSort)))
+        val sortedAndFilteredBuckets = removeGreenBuckets(bucketsWithReportStatus).sortBy(bucketDetailsSort)
+        (account, Right(reportSummary(bucketDetails), sortedAndFilteredBuckets))
       }
       case (account, Left(failure)) => (account, Left(failure))
     }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -114,7 +114,8 @@ case class BucketDetail(
   aclAllowsWrite: Boolean,
   policyAllowsAccess: Boolean,
   isSuppressed: Boolean,
-  reportStatus: Option[ReportStatus],
+  reportStatus: Option[ReportStatus] = None,
+  isEncrypted: Boolean = false
 ) extends TrustedAdvisorCheckDetails
 
 sealed trait SGInUse

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -11,6 +11,7 @@ import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.ec2.AmazonEC2Async
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.inspector.AmazonInspectorAsync
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.support.AWSSupportAsync
 import com.gu.Box
 import config.Config
@@ -34,6 +35,7 @@ class CacheService(
     ec2Clients: AwsClients[AmazonEC2Async],
     cfnClients: AwsClients[AmazonCloudFormationAsync],
     taClients: AwsClients[AWSSupportAsync],
+    s3Clients: AwsClients[AmazonS3],
     iamClients: AwsClients[AmazonIdentityManagementAsync],
     regions: List[Regions]
   )(implicit ec: ExecutionContext) {
@@ -106,7 +108,7 @@ class CacheService(
   private def refreshPublicBucketsBox(): Unit = {
     Logger.info("Started refresh of the public S3 buckets data")
     for {
-      allPublicBuckets <- TrustedAdvisorS3.getAllPublicBuckets(accounts, taClients)
+      allPublicBuckets <- TrustedAdvisorS3.getAllPublicBuckets(accounts, taClients, s3Clients)
     } yield {
       Logger.info("Sending the refreshed data to the Public Buckets Box")
       publicBucketsBox.send(allPublicBuckets.toMap)

--- a/hq/app/views/fragments/bucketsHelp.scala.html
+++ b/hq/app/views/fragments/bucketsHelp.scala.html
@@ -30,6 +30,12 @@
                 <p>A bucket is publicly accessible by either everyone in the world or by any authenticated AWS user, should this bucket be public?</p>
                 <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html" class="secondary-content">Read more in the AWS docs</a>
             </li>
+            <li class="collection-item avatar">
+                <i class="material-icons circle large-icon white purple-text">no_encryption</i>
+                <span class="title">No Encryption</span>
+                <p>Server-side encryption is about data encryption at rest. When you use server-side encryption, Amazon S3 encrypts an object before saving it to disk and decrypts it when you download the object.</p>
+                <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/security-best-practices.html#server-side" class="secondary-content">Read more in the AWS docs</a>
+            </li>
         </ul>
     </div>
 </div>

--- a/hq/app/views/s3/publicBuckets.scala.html
+++ b/hq/app/views/s3/publicBuckets.scala.html
@@ -43,6 +43,29 @@
             <h3>Public S3 Buckets</h3>
         </div>
 
+        <div class="row card-panel">
+            <div class="section valign-wrapper">
+                <i class="material-icons left">visibility_off</i>
+                <span class="finding-header__name">Some results may be ignored due to settings in AWS Trusted Advisor</span>
+
+                <form class="finding-filter" action="#">
+                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
+                    <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
+                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
+                    <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
+                </form>
+            </div>
+            <div class="section valign-wrapper">
+                <i class="material-icons left">no_encryption</i>
+                <span class="finding-header__name">Some buckets may not have encryption enabled for data at rest</span>
+
+                <form class="finding-filter" action="#">
+                    <input class="js-finding-filter" type="checkbox" id="show-unencrypted-findings" checked="checked" />
+                    <label class="black-text finding-filter__label" for="show-unencrypted-findings">Show all unencrypted buckets</label>
+                </form>
+            </div>
+        </div>
+
         <div class="row">
             <ul class="collapsible" data-collapsible="accordion">
             @for((account, result) <- reports) {
@@ -60,11 +83,15 @@
                                     <span class="icon-count">@statusCounts.warnings</span>
                                     <i class="material-icons amber-text">warning</i>
                                 }
+                                @if(statusCounts.other > 0) {
+                                    <span class="icon-count">@statusCounts.other</span>
+                                    <i class="material-icons purple-text">no_encryption</i>
+                                }
                                 @if(statusCounts.suppressed > 0) {
                                     <span class="icon-count">@statusCounts.suppressed</span>
                                     <i class="material-icons purple-text">watch_later</i>
                                 }
-                                @if(statusCounts.errors == 0 && statusCounts.warnings == 0) {
+                                @if(statusCounts.errors == 0 && statusCounts.warnings == 0 && statusCounts.other == 0) {
                                     <i class="material-icons green-text">check</i>
                                 }
                             }

--- a/hq/app/views/s3/publicBucketsAccount.scala.html
+++ b/hq/app/views/s3/publicBucketsAccount.scala.html
@@ -51,21 +51,35 @@
                 </div>
             }
             case Right((_, openBuckets)) => {
-                @if(hasSuppressedReports(openBuckets)) {
-                    <div class="row">
-                        <div class="card-panel valign-wrapper">
+                <div class="row card-panel">
+                    @if(hasSuppressedReports(openBuckets)) {
+                        <div class="section valign-wrapper">
                             <i class="material-icons left">visibility_off</i>
-                            <span class="finding-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
+                            <span class="finding-header__name">
+                                Some results may be ignored due to settings in AWS Trusted Advisor</span>
 
                             <form class="finding-filter" action="#">
                                 <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
-                                <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
+                                <label class="black-text finding-filter__label" for="show-flagged-findings">
+                                    Show flagged</label>
                                 <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
-                                <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
+                                <label class="black-text finding-filter__label" for="show-ignored-findings">
+                                    Show ignored</label>
                             </form>
                         </div>
-                    </div>
-                }
+                    }
+                        <div class="section valign-wrapper">
+                            <i class="material-icons left">no_encryption</i>
+                            <span class="finding-header__name">
+                                Some buckets may not have encryption enabled for data at rest</span>
+
+                            <form class="finding-filter" action="#">
+                                <input class="js-finding-filter" type="checkbox" id="show-unencrypted-findings" checked="checked" />
+                                <label class="black-text finding-filter__label" for="show-unencrypted-findings">
+                                    Show all unencrypted buckets</label>
+                            </form>
+                        </div>
+                </div>
 
                 @views.html.s3.publicBucketsBody(openBuckets, shadow=true)
 

--- a/hq/app/views/s3/publicBucketsBody.scala.html
+++ b/hq/app/views/s3/publicBucketsBody.scala.html
@@ -8,7 +8,7 @@
 
 <div class="finding-container">
     @for(bucket <- buckets) {
-        <div class="finding-container__card finding-suppressed--@bucket.isSuppressed">
+        <div class="finding-container__card finding-suppressed--@bucket.isSuppressed @if(isOnlyMissingEncryption(bucket)){finding-unencrypted}">
             <div class="card @if(!shadow){z-depth-0}">
                 <div class="card-content card-content--title">
                     <span class="card-title">
@@ -35,28 +35,34 @@
                                 @bucket.region
                                 </td>
                             </tr>
-                                <tr>
-                                    <th>ACL Allows Write</th>
-                                    <td>
-                                    @bucket.aclAllowsWrite
-                                    @if(bucket.aclAllowsWrite) { @helpIcon }
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <th>ACL allows Read</th>
-                                    <td>
-                                    @bucket.aclAllowsRead
-                                    @if(bucket.aclAllowsRead) { @helpIcon }
-                                    </td>
-                                </tr>
-
-                                <tr>
-                                    <th>Policy Allows Access</th>
-                                    <td>
-                                    @bucket.policyAllowsAccess
-                                    @if(bucket.policyAllowsAccess) { @helpIcon }
-                                    </td>
-                                </tr>
+                            <tr>
+                                <th>ACL Allows Write</th>
+                                <td>
+                                @bucket.aclAllowsWrite
+                                @if(bucket.aclAllowsWrite) { @helpIcon }
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>ACL allows Read</th>
+                                <td>
+                                @bucket.aclAllowsRead
+                                @if(bucket.aclAllowsRead) { @helpIcon }
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Default Encryption</th>
+                                <td>
+                                    @bucket.isEncrypted
+                                    @if(!bucket.isEncrypted) { @helpIcon }
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Policy Allows Access</th>
+                                <td>
+                                @bucket.policyAllowsAccess
+                                @if(bucket.policyAllowsAccess) { @helpIcon }
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -43,6 +43,9 @@ $(document).ready(function() {
     $('#show-flagged-findings')[0].checked
       ? $('.finding-suppressed--false').show()
       : $('.finding-suppressed--false').hide();
+    $('#show-unencrypted-findings')[0].checked
+        ? $('.finding-unencrypted').show()
+        : $('.finding-unencrypted').hide();
   });
 
   $('.js-finding-details').click(function() {

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -44,8 +44,8 @@ $(document).ready(function() {
       ? $('.finding-suppressed--false').show()
       : $('.finding-suppressed--false').hide();
     $('#show-unencrypted-findings')[0].checked
-        ? $('.finding-unencrypted').show()
-        : $('.finding-unencrypted').hide();
+      ? $('.finding-unencrypted').show()
+      : $('.finding-unencrypted').hide();
   });
 
   $('.js-finding-details').click(function() {


### PR DESCRIPTION
## What is the value of this?

Adds bucket encryption status to Security HQ so that there is a single place we can view all buckets that do not have encryption-at-rest enabled.

> Amazon S3 default encryption provides a way to set the default encryption behavior for an S3 bucket. You can set default encryption on a bucket so that all objects are encrypted when they are stored in the bucket.

https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html

## What does this change?

#### 👉 Add S3 clients and fetch S3 bucket default encryption status

Unfortunately, the encryption status for a bucket requires yet another set of AWS clients. This PR adds S3 clients so that we can call `s3:GetEncryptionConfiguration` on each bucket.

If there is no bucket encryption, AWS will return  an error. The current code assumes that the bucket is not encrypted if `getBucketEncryption` throws an `AmazonS3Exception` and this seems to be the only way to check if the bucket has default encryption.

#### 👉 Reflect encryption in bucket report status and update tests

The TA report actually includes all buckets, even if they are status `Green` in Trusted Advisor and do not have any public access. However, we only want to display buckets that may have configuration issues or overly permissive access policies. 

To ensure we can still display the buckets that do not have encryption-at-rest enabled, these buckets are being given a reportStatus of `Blue`

#### 👉 Add encryption status to the buckets view

Since it is likely many buckets will not have default encryption, and this may clutter the view, this adds a toggle to show and hide buckets where the only issue is the encryption status.

Buckets with no issues are now excluded from the page entirely. SHQ will only display buckets with configuration issues or overly permissive access policies.

<img width="1336" alt="Screenshot 2019-07-23 at 15 57 31" src="https://user-images.githubusercontent.com/8607683/61730046-76a55580-ad70-11e9-98a1-c1b552905670.png">

#### 👉 Add help information to the buckets modal

Clicking the help icon on the bucket card will bring up the help modal. 

<img width="1903" alt="Screenshot 2019-07-23 at 17 26 55" src="https://user-images.githubusercontent.com/8607683/61730030-6e4d1a80-ad70-11e9-9d53-f26239d9aedc.png">

The modal explains that: 

> Server-side encryption is about data encryption at rest. When you use server-side encryption, Amazon S3 encrypts an object before saving it to disk and decrypts it when you download the object.

https://docs.aws.amazon.com/AmazonS3/latest/dev/security-best-practices.html#server-side

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes, the watched-account role now needs `s3:GetEncryptionConfiguration`

- [x] update the StackSets

## Any additional notes?

When enabling default encryption, there is **no change** to the encryption of the objects that existed in the bucket **before** default encryption was enabled.

#### Useful CloudFormation snippets

Proactively block attempts to make a bucket public, or to specify a public ACL for objects:

```yaml
    Type: AWS::S3::Bucket
    Properties:
      PublicAccessBlockConfiguration:
        BlockPublicAcls: true
        BlockPublicPolicy: true
        IgnorePublicAcls: true
        RestrictPublicBuckets: true
```

Describe the default server-side encryption to apply to new objects in the bucket:

```yaml
    Type: AWS::S3::Bucket
    Properties:
      BucketEncryption:
      BucketEncryption:
        ServerSideEncryptionConfiguration:
        - ServerSideEncryptionByDefault:
            SSEAlgorithm: AES256 | aws:kms   # chose one
            KMSMasterKeyID:  <ARN for key>   # allowed if SSEAlgorithm is aws:kms
```
