### PR TITLE
Create DNS validated certificate within the cloudformation template.

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -19,7 +19,7 @@ Metadata:
       Parameters:
       - VpcId
       - Subnets
-      - TLSCertArn
+      - TLSCertDomain
 
 Parameters:
   SecurityHQSourceBundleBucket:
@@ -34,8 +34,8 @@ Parameters:
   AMI:
     Description: Base AMI for Security HQ instances
     Type: AWS::EC2::Image::Id
-  TLSCertArn:
-    Description: ARN of a TLS certificate to install on the load balancer
+  TLSCertDomain:
+    Description: Domain name for a TLS certificate to install on the load balancer
     Type: String
   AccessRestrictionCidr:
     Description: CIDR block from which access to Security HQ should be allowed
@@ -331,7 +331,20 @@ Resources:
         Value:
           Fn::FindInMap: [ Constants, App, Value ]
         PropagateAtLaunch: true
-
+  TLSCertArn:
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      ValidationMethod: DNS
+      DomainName: !Ref TLSCertDomain
+      Tags:
+        - Key: Stage
+          Value: !Ref Stage
+        - Key: Stack
+          Value:
+            Fn::FindInMap: [ Constants, Stack, Value ]
+        - Key: App
+          Value:
+            Fn::FindInMap: [ Constants, App, Value ]
 Outputs:
   LoadBalancerUrl:
     Value:


### PR DESCRIPTION
## What does this change?
With https://github.com/guardian/dns-validation-lambda it is now possible to create DNS validated certificates that require no human interaction to be verified.

DNS validate certificates are preferred over email validated ones as they auto-renew; email validated certificates require a manual step of clicking a link in an email.

This changes the template to accept the domain name as a parameter, which is used to create the certificate.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
DNS validate certificates are preferred over email validated ones as they auto-renew; email validated certificates require a manual step of clicking a link in an email.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
CloudFormation changes. Note: creating certificates in CFN is a blocking request.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
Added the domain as a parameter to keep the template as generic as possible for external collaborators.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
