### PR TITLE
log shipping

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,9 @@ lazy val hq = (project in file("hq"))
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,
+      "net.logstash.logback" % "logstash-logback-encoder" % "6.4",
+      "com.gu" % "kinesis-logback-appender" % "1.4.4",
     ),
     pipelineStages in Assets := Seq(digest),
     // exclude docs

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,11 @@ lazy val hq = (project in file("hq"))
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,
-      "net.logstash.logback" % "logstash-logback-encoder" % "6.4",
+
+      // logstash-logback-encoder brings in version 2.11.0
+      // exclude transitive dependency to avoid a runtime exception:
+      // `com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0`
+      "net.logstash.logback" % "logstash-logback-encoder" % "6.4" exclude("com.fasterxml.jackson.core", "jackson-databind"),
       "com.gu" % "kinesis-logback-appender" % "1.4.4",
     ),
     pipelineStages in Assets := Seq(digest),

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -55,6 +55,9 @@ Parameters:
     - PROD
     - CODE
     - DEV
+  LoggingRoleToAssumeArn:
+    Type: String
+    Description: Name of IAM role in logging account e.g. arn:aws:iam::222222222222:role/LoggingRole
 
 Mappings:
   Constants:
@@ -64,6 +67,19 @@ Mappings:
       Value: security-hq
 
 Resources:
+  LoggingPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: LoggingPolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: !Ref "LoggingRoleToAssumeArn"
+      Roles:
+        - !Ref SecurityHQInstanceRole
+
   SecurityHQInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -38,9 +38,9 @@ class AppComponents(context: Context)
     csrfFilter,
     new HstsFilter()
   )
-  private val region = Regions.EU_WEST_1
+
   private val stack = configuration.get[String]("stack")
-  implicit val awsClient: AWSSimpleSystemsManagement = AWSSimpleSystemsManagementFactory(region.getName, stack)
+  implicit val awsClient: AWSSimpleSystemsManagement = AWSSimpleSystemsManagementFactory(Config.region.getName, stack)
 
   val configraun: Configuration = {
 
@@ -69,13 +69,13 @@ class AppComponents(context: Context)
   //  - available regions can return regions that are not in the SDK and so Regions.findName will fail
   // to solve these we return the intersection of available regions and regions.values()
   private val availableRegions = {
-    val ec2Client = AwsClient(AmazonEC2AsyncClientBuilder.standard().withRegion(region).build(), AwsAccount(stack, stack, stack), region)
+    val ec2Client = AwsClient(AmazonEC2AsyncClientBuilder.standard().withRegion(Config.region).build(), AwsAccount(stack, stack, stack), Config.region)
     try {
       val availableRegionsAttempt: Attempt[List[Regions]] = for {
         regionList <- EC2.getAvailableRegions(ec2Client)
         regionStringSet = regionList.map(_.getRegionName).toSet
       } yield Regions.values.filter(r => regionStringSet.contains(r.getName)).toList
-      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.getOrElse(List(region, Regions.US_EAST_1))
+      Await.result(availableRegionsAttempt.asFuture, 30 seconds).right.getOrElse(List(Config.region, Regions.US_EAST_1))
     } finally {
       ec2Client.client.shutdown()
     }

--- a/hq/app/AppLoader.scala
+++ b/hq/app/AppLoader.scala
@@ -6,10 +6,14 @@ import play.api.{Application, ApplicationLoader}
 
 class AppLoader extends ApplicationLoader {
   override def load(context: Context): Application = {
-    val loggingConfig = LoggingConfig(context.initialConfiguration)
+    val loggingConfig = LoggingConfig(
+      context.initialConfiguration,
+      sys.env.getOrElse("LOCAL_LOG_SHIPPING", "false").toBoolean
+    )
 
     LogConfig.initPlayLogging(context)
     LogConfig.initRemoteLogShipping(loggingConfig)
+    LogConfig.initLocalLogShipping(loggingConfig)
 
     new AppComponents(context).application
   }

--- a/hq/app/AppLoader.scala
+++ b/hq/app/AppLoader.scala
@@ -1,12 +1,16 @@
+import config.LoggingConfig
+import logging.LogConfig
 import play.api.ApplicationLoader.Context
-import play.api.{Application, ApplicationLoader, LoggerConfigurator}
+import play.api.{Application, ApplicationLoader}
 
 
 class AppLoader extends ApplicationLoader {
   override def load(context: Context): Application = {
-    LoggerConfigurator(context.environment.classLoader).foreach {
-      _.configure(context.environment)
-    }
+    val loggingConfig = LoggingConfig(context.initialConfiguration)
+
+    LogConfig.initPlayLogging(context)
+    LogConfig.initRemoteLogShipping(loggingConfig)
+
     new AppComponents(context).application
   }
 }

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -2,6 +2,7 @@ package config
 
 import java.io.FileInputStream
 
+import com.amazonaws.regions.Regions
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
 import model.{AwsAccount, DEV, PROD, Stage}
@@ -13,6 +14,8 @@ import scala.util.Try
 
 
 object Config {
+  val region: Regions = Regions.EU_WEST_1
+
   def getStage(config: Configuration): Stage = {
     config.getAndValidate("stage", Set("DEV", "PROD")) match {
       case "DEV" => DEV

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -14,6 +14,7 @@ import scala.util.Try
 
 
 object Config {
+  // TODO fetch the region dynamically from the instance
   val region: Regions = Regions.EU_WEST_1
 
   def getStage(config: Configuration): Stage = {

--- a/hq/app/config/LoggingConfig.scala
+++ b/hq/app/config/LoggingConfig.scala
@@ -1,0 +1,38 @@
+package config
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.util.EC2MetadataUtils
+import model.{DEV, Stage}
+import play.api.Configuration
+
+case class LoggingConfig (
+  stack: String,
+  stage: Stage,
+  app: String,
+  instanceId: String,
+  region: Regions,
+  streamName: Option[String],
+  stsRole: Option[String]
+) {
+  val isDev: Boolean = stage == DEV
+}
+
+object LoggingConfig {
+  def apply(configuration: Configuration): LoggingConfig = {
+    val stack: String = configuration.get[String]("stack")
+    val app: String = configuration.getOptional[String]("app").getOrElse("security-hq")
+    val instanceId: String = Option(EC2MetadataUtils.getInstanceId).getOrElse("unknown")
+    val loggingStreamName: Option[String] = configuration.getOptional[String]("aws.kinesis.logging.streamName")
+    val loggingRole: Option[String] = configuration.getOptional[String]("aws.kinesis.logging.stsRoleToAssume")
+
+    LoggingConfig(
+      stack,
+      Config.getStage(configuration),
+      app,
+      instanceId,
+      Config.region,
+      loggingStreamName,
+      loggingRole
+    )
+  }
+}

--- a/hq/app/config/LoggingConfig.scala
+++ b/hq/app/config/LoggingConfig.scala
@@ -1,10 +1,8 @@
 package config
 
-import java.net.InetSocketAddress
-
 import com.amazonaws.regions.Regions
 import com.amazonaws.util.EC2MetadataUtils
-import model.{DEV, Stage}
+import model.Stage
 import play.api.Configuration
 
 case class LoggingConfig (
@@ -14,29 +12,19 @@ case class LoggingConfig (
   instanceId: String,
   region: Regions,
   streamName: Option[String],
-  stsRole: Option[String]
-) {
-  val isDev: Boolean = stage == DEV
-  val localLogShippingEnabled: Boolean = sys.env.getOrElse("LOCAL_LOG_SHIPPING", "false").toBoolean
-  lazy val localLogShippingDestination: InetSocketAddress = new InetSocketAddress("localhost", 5000)
-}
+  stsRole: Option[String],
+  localLogShippingEnabled: Boolean
+)
 
 object LoggingConfig {
-  def apply(configuration: Configuration): LoggingConfig = {
-    val stack: String = configuration.get[String]("stack")
-    val app: String = configuration.getOptional[String]("app").getOrElse("security-hq")
-    val instanceId: String = Option(EC2MetadataUtils.getInstanceId).getOrElse("unknown")
-    val loggingStreamName: Option[String] = configuration.getOptional[String]("aws.kinesis.logging.streamName")
-    val loggingRole: Option[String] = configuration.getOptional[String]("aws.kinesis.logging.stsRoleToAssume")
-
-    LoggingConfig(
-      stack,
-      Config.getStage(configuration),
-      app,
-      instanceId,
-      Config.region,
-      loggingStreamName,
-      loggingRole
-    )
-  }
+  def apply(configuration: Configuration, localLogShippingEnabled: Boolean): LoggingConfig = LoggingConfig(
+    configuration.get[String]("stack"),
+    Config.getStage(configuration),
+    configuration.getOptional[String]("app").getOrElse("security-hq"),
+    Option(EC2MetadataUtils.getInstanceId).getOrElse("unknown"),
+    Config.region,
+    configuration.getOptional[String]("aws.kinesis.logging.streamName"),
+    configuration.getOptional[String]("aws.kinesis.logging.stsRoleToAssume"),
+    localLogShippingEnabled
+  )
 }

--- a/hq/app/config/LoggingConfig.scala
+++ b/hq/app/config/LoggingConfig.scala
@@ -1,5 +1,7 @@
 package config
 
+import java.net.InetSocketAddress
+
 import com.amazonaws.regions.Regions
 import com.amazonaws.util.EC2MetadataUtils
 import model.{DEV, Stage}
@@ -15,6 +17,8 @@ case class LoggingConfig (
   stsRole: Option[String]
 ) {
   val isDev: Boolean = stage == DEV
+  val localLogShippingEnabled: Boolean = sys.env.getOrElse("LOCAL_LOG_SHIPPING", "false").toBoolean
+  lazy val localLogShippingDestination: InetSocketAddress = new InetSocketAddress("localhost", 5000)
 }
 
 object LoggingConfig {

--- a/hq/app/logging/LogConfig.scala
+++ b/hq/app/logging/LogConfig.scala
@@ -1,0 +1,84 @@
+package logging
+
+import java.security.SecureRandom
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Logger => LogbackLogger}
+import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
+import com.gu.logback.appender.kinesis.KinesisAppender
+import config.LoggingConfig
+import net.logstash.logback.layout.LogstashLayout
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
+import play.api.ApplicationLoader.Context
+import play.api.LoggerConfigurator
+import play.api.libs.json.Json
+
+import scala.util.Try
+
+object LogConfig {
+  private val BUFFER_SIZE = 1000
+  private val rootLogger: LogbackLogger = LoggerFactory.getLogger(SLFLogger.ROOT_LOGGER_NAME).asInstanceOf[LogbackLogger]
+
+  private def makeCustomFields(config: LoggingConfig): String = {
+    Json.toJson(Map(
+      "stack" -> config.stack,
+      "stage" -> config.stage.toString,
+      "app" -> config.app,
+      "instanceId" -> config.instanceId
+    )).toString()
+  }
+
+  private def buildCredentialsProvider(stsRole: String) = {
+    val random = new SecureRandom()
+    val sessionId = s"session${random.nextDouble()}"
+
+    val instanceProvider = InstanceProfileCredentialsProvider.getInstance
+    val stsClient = AWSSecurityTokenServiceClientBuilder.standard.withCredentials(instanceProvider).build
+    new STSAssumeRoleSessionCredentialsProvider.Builder(stsRole, sessionId).withStsClient(stsClient).build
+  }
+
+  def initRemoteLogShipping(config: LoggingConfig): Unit = {
+    if(config.isDev) {
+      rootLogger.info("Kinesis logging disabled in DEV")
+    } else {
+      Try {
+        rootLogger.info("Initialising remote log shipping via Kinesis")
+
+        (config.streamName, config.stsRole) match {
+          case (Some(streamName), Some(stsRole)) => {
+            val customFields = makeCustomFields(config)
+            val context = rootLogger.getLoggerContext
+
+            val layout = new LogstashLayout()
+            layout.setContext(context)
+            layout.setCustomFields(customFields)
+            layout.start()
+
+            val appender = new KinesisAppender[ILoggingEvent]()
+            appender.setBufferSize(BUFFER_SIZE)
+            appender.setRegion(config.region.getName)
+            appender.setStreamName(streamName)
+            appender.setContext(context)
+            appender.setLayout(layout)
+            appender.setRoleToAssumeArn(stsRole)
+            appender.setCredentialsProvider(buildCredentialsProvider(stsRole))
+
+            rootLogger.addAppender(appender)
+            rootLogger.info("Initialised remote log shipping")
+          }
+          case _ => rootLogger.info("Missing remote logging configuration")
+        }
+
+      } recover {
+        case e => rootLogger.error("Failed to initialise remote log shipping", e)
+      }
+    }
+  }
+
+  def initPlayLogging(context: Context): Unit = {
+    LoggerConfigurator(context.environment.classLoader).foreach {
+      _.configure(context.environment)
+    }
+  }
+}

--- a/hq/app/logging/LogConfig.scala
+++ b/hq/app/logging/LogConfig.scala
@@ -96,7 +96,7 @@ object LogConfig {
             appender.setLayout(layout)
             appender.setRoleToAssumeArn(stsRole)
             appender.setCredentialsProvider(buildCredentialsProvider(stsRole, config))
-
+            appender.start()
             rootLogger.addAppender(appender)
             rootLogger.info("Initialised remote log shipping")
           }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -127,12 +127,8 @@ case class UnknownUsage(
 ) extends SGInUse
 
 sealed trait Stage
-case object DEV extends Stage {
-  override def toString: String = "DEV"
-}
-case object PROD extends Stage {
-  override def toString: String = "PROD"
-}
+case object DEV extends Stage
+case object PROD extends Stage
 
 case class CredentialReportDisplay(
   reportDate: DateTime,

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -127,8 +127,12 @@ case class UnknownUsage(
 ) extends SGInUse
 
 sealed trait Stage
-case object DEV extends Stage
-case object PROD extends Stage
+case object DEV extends Stage {
+  override def toString: String = "DEV"
+}
+case object PROD extends Stage {
+  override def toString: String = "PROD"
+}
 
 case class CredentialReportDisplay(
   reportDate: DateTime,

--- a/sbt
+++ b/sbt
@@ -18,6 +18,10 @@ do
       CONF_PARAMS=""
       shift
     fi
+    if [ "$arg" == ""--ship-logs"" ]; then
+      export LOCAL_LOG_SHIPPING=true
+      shift
+    fi
 done
 
 if [ $TEAMCITY_BUILD_PROPERTIES_FILE ]; then


### PR DESCRIPTION
## What does this change?
Adds log shipping in two different flavours:
- Remote shipping to the central-ELK stack via Kinesis and the [`kinesis-logback-appender`](https://github.com/guardian/kinesis-logback-appender).
- Local log shipping to a [`local-elk`](https://github.com/guardian/local-elk) stack. This is just to provide a simpler interface for log interrogation compared to `grep` and others.

## What is the value of this?
Shipping logs to an ELK stack provides a simpler interface for interrogation.

Shipping logs to a remote ELK stack will mean one no longer needs to ssh onto an instance to observe logs generated by the application.

## Will this require CloudFormation and/or updates to the AWS StackSet?
No.

## Any additional notes?
This is heavily inspired by the Editorial Tools, for example [Workflow Frontend](https://github.com/guardian/workflow-frontend/blob/ca3789371031d52caaced42103740fbfd57c96b1/common-lib/src/main/scala/com/gu/workflow/lib/LogConfig.scala) and [Grid](https://github.com/guardian/grid/blob/a42d4d1acf1de7e4f06af003ddfe39dc25105371/common-lib/src/main/scala/com/gu/mediaservice/lib/logging/LogConfig.scala).

This uses the [latest 1.X.X `kinesis-logback-appender` available](https://mvnrepository.com/artifact/com.gu/kinesis-logback-appender). Version 2.X.X has a different API that I couldn't get to compile, maybe we bump a little later?

## Screenshots
**local logs**
![image](https://user-images.githubusercontent.com/836140/89456119-49e59580-d75b-11ea-8c76-e92f2af53e0e.png)

TODO:
- [x] test it!
- [x] create a start script with a flag to abstract away the env var, for example [this in Workflow Frontend](https://github.com/guardian/workflow-frontend/blob/ca3789371031d52caaced42103740fbfd57c96b1/scripts/start.sh)