### PR TITLE
expand the ssm policy with permissions required for SSH over SSM

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -163,6 +163,10 @@ Resources:
           - ssm:ListInstanceAssociations
           - ssm:DescribeInstanceProperties
           - ssm:DescribeDocumentParameters
+          - ssmmessages:CreateControlChannel
+          - ssmmessages:CreateDataChannel
+          - ssmmessages:OpenControlChannel
+          - ssmmessages:OpenDataChannel
       Roles:
       - !Ref SecurityHQInstanceRole
 


### PR DESCRIPTION
## What does this change?
This policy has been copied from the [ssm-scala docs](https://github.com/guardian/ssm-scala#how-to-use-ssm-scala-with-your-own-project).

Currently `ssm ssh` is yielding:

```console
An error occurred (TargetNotConnected) when calling the StartSession operation: i-000000000000 is not connected.
kex_exchange_identification: Connection closed by remote host
```

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Enabling us to connect to an instance.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
CFN changes, yes.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
n/a

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
