### PR TITLE
Remove SSH access, add egress for wazuh agents

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -129,6 +129,9 @@ Resources:
         - Effect: Allow
           Resource: "*"
           Action:
+          - autoscaling:DescribeAutoScalingInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - ec2:DescribeRegions
           - ec2:DescribeTags
       Roles:
       - !Ref SecurityHQInstanceRole

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -12,8 +12,6 @@ Metadata:
         default: Security
       Parameters:
       - AccessRestrictionCidr
-      - SSHAccessCidr
-      - KeyName
     - Label:
         default: Networking
       Parameters:
@@ -40,14 +38,6 @@ Parameters:
   AccessRestrictionCidr:
     Description: CIDR block from which access to Security HQ should be allowed
     Type: String
-  SSHAccessCidr:
-    Description: A CIDR from which SSH access to the OWASP SKF instance is allowed
-    Type: String
-    AllowedPattern: ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/[0-9]{1,2}$
-    ConstraintDescription: Parameter should be a CIDR block e.g. "1.2.3.4/32"
-  KeyName:
-    Description: An ssh keypair to put on the instance
-    Type: AWS::EC2::KeyPair::KeyName
   Stage:
     Description: Application stage (e.g. PROD, CODE)
     Type: String
@@ -259,12 +249,6 @@ Resources:
         ToPort: 9000
         SourceSecurityGroupId:
           Ref: LoadBalancerSecurityGroup
-        # allow SSH access from within the office
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp:
-          Ref: SSHAccessCidr
       SecurityGroupEgress:
         # allow instance to make http requests
       - IpProtocol: tcp
@@ -274,6 +258,11 @@ Resources:
       - IpProtocol: tcp
         FromPort: 443
         ToPort: 443
+        CidrIp: 0.0.0.0/0
+      - IpProtocol: tcp
+        Description: Wazuh agent communication
+        FromPort: 1514
+        ToPort: 1515
         CidrIp: 0.0.0.0/0
       Tags:
       - Key: Stage
@@ -289,8 +278,6 @@ Resources:
   LaunchConfig:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-      KeyName:
-        Ref: KeyName
       ImageId:
         Ref: AMI
       SecurityGroups:


### PR DESCRIPTION
## What does this change?

#### 👉 Remove SSH access to instances

For a long time at The Guardian it has been possible to SSH without opening up port 22, thanks to [SSM-Scala!](https://github.com/guardian/ssm-scala)

Along with removing the requirement to have port 22 open, SSM-Scala also provides visibility into which instances have been accessed and removes the requirement for bastions (thanks to ssm-tunnelling!) The latest version of SSM-Scala - 2.0.0 - sets SSM tunnelling as the default behaviour.

SSM-Scala should therefore be the default way we access instances.

#### 👉  Enable Wazuh agent communication 

This changes the security groups of several instances so that the Wazuh agents can register with the Wazuh manager and send events to the Wazuh cluster.

- Port 1514 is used for agent event logging
- Port 1515 is used for agent registration

#### 👉  Add permissions to describe region and ASG

Describing region, tags and ASG is required so that the instance can configure labels during Wazuh agent installation. The labels can provide additional information about the instance the agent is running on, such as  the stack, app and stage.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes, the Cloudformation template will be applied after these changes are approved

TODO:
- [ ] Apply Cloudformation changes

