### PR TITLE
Add tooltips for menu items

### DIFF
--- a/hq/app/views/header.scala.html
+++ b/hq/app/views/header.scala.html
@@ -13,22 +13,22 @@
                     <a href="#" data-activates="mobile-nav" class="button-collapse"><i class="material-icons black-text">menu</i></a>
                     <ul class="main-nav hide-on-med-and-down">
                         <li class="main-nav--home">
-                            <a href="/"><i class="material-icons black-text">home</i></a>
+                            <a class="tooltipped" data-tooltip="Home" href="/"><i class="material-icons black-text">home</i></a>
                         </li>
                         <li class="main-nav">
-                            <a href="/security-groups"><i class="material-icons black-text">vpn_lock</i></a>
+                            <a class="tooltipped" data-tooltip="Security groups" href="/security-groups"><i class="material-icons black-text">vpn_lock</i></a>
                         </li>
                         <li class="main-nav">
-                            <a href="/iam"><i class="material-icons black-text">vpn_key</i></a>
+                            <a class="tooltipped" data-tooltip="IAM" href="/iam"><i class="material-icons black-text">vpn_key</i></a>
                         </li>
                         <li class="main-nav">
-                            <a href="/buckets"><i class="material-icons black-text">storage</i></a>
+                            <a class="tooltipped" data-tooltip="Buckets" href="/buckets"><i class="material-icons black-text">storage</i></a>
                         </li>
                         <li class="main-nav">
-                            <a href="/snyk"><i class="material-icons black-text">security</i></a>
+                            <a class="tooltipped" data-tooltip="Snyk" href="/snyk"><i class="material-icons black-text">security</i></a>
                         </li>
                         <li class="main-nav">
-                            <a href="/documentation"><i class="material-icons black-text">description</i></a>
+                            <a class="tooltipped" data-tooltip="Documentation" href="/documentation"><i class="material-icons black-text">description</i></a>
                         </li>
                     </ul>
 

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -101,4 +101,5 @@ $(document).ready(function() {
         'slow'
       );
   });
+  $('.tooltipped').tooltip({enterDelay: 0, inDuration: 100});
 });


### PR DESCRIPTION
## What does this change?
Adds some tooltips to the menu to identify what each icon does.

## What is the value of this?
Usability. A better option would arguably be labels but they probably wouldn't fit, and this is a super quick and easy option.


## Will this require CloudFormation and/or updates to the AWS StackSet?
No


<img width="379" alt="Screenshot 2021-02-03 at 15 47 15" src="https://user-images.githubusercontent.com/3606555/106771774-401fea80-6637-11eb-891e-1fd6e7afcad1.png">
