### PR TITLE
Allocate 4GB of memory to SBT on startup

### DIFF
--- a/sbt
+++ b/sbt
@@ -36,7 +36,7 @@ if [ $TEAMCITY_BUILD_PROPERTIES_FILE ]; then
 fi
 
 java $DEBUG_PARAMS \
-    -Xms1024M -Xmx2048M \
+    -Xms1024M -Xmx4096M \
     -Xss1M \
     -XX:+CMSClassUnloadingEnabled \
     $CONF_PARAMS \


### PR DESCRIPTION
## What does this change?
Modifies the SBT script for security HQ  so that more memory gets allocated on startup. The Xmx property specifiies "the maximum size, in bytes, of the memory allocation pool. "
## What is the value of this?
With this one simple trick...run security HQ locally for > 5 mins without crashing. 
