### PR TITLE
Adds Elastic File System (EFS)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-inspector" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-efs" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -95,6 +95,7 @@ class AppComponents(context: Context)
   private val taClients = AWS.taClients(configuration)
   private val s3Clients = AWS.s3Clients(configuration)
   private val iamClients = AWS.iamClients(configuration, availableRegions)
+  private val efsClients = AWS.efsClients(configuration, availableRegions)
 
   private val cacheService = new CacheService(
     configuration,
@@ -108,6 +109,7 @@ class AppComponents(context: Context)
     taClients,
     s3Clients,
     iamClients,
+    efsClients,
     availableRegions)
 
   override def router: Router = new Routes(

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -7,6 +7,7 @@ import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.{AmazonCloudFormationAsync, AmazonCloudFormationAsyncClientBuilder}
 import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
+import com.amazonaws.services.elasticfilesystem.{AmazonElasticFileSystemAsync, AmazonElasticFileSystemAsyncClient, AmazonElasticFileSystemAsyncClientBuilder}
 import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
 import com.amazonaws.services.inspector.{AmazonInspectorAsync, AmazonInspectorAsyncClientBuilder}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
@@ -68,5 +69,8 @@ object AWS {
 
   def iamClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonIdentityManagementAsync] =
     clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, regions:_*)
+
+  def efsClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonElasticFileSystemAsync] =
+    clients(AmazonElasticFileSystemAsyncClientBuilder.standard(), configuration, regions:_*)
 
 }

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -1,7 +1,7 @@
 package aws.ec2
 
 import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import aws.ec2.EFS.removeAllEfsUnknownUsages
+import aws.ec2.EFS.filterOutEfsUnknownUsages
 import aws.support.TrustedAdvisorSGOpenPorts
 import aws.{AwsClient, AwsClients}
 import cats.instances.map._
@@ -72,12 +72,10 @@ object EC2 {
         .fold(Map.empty)(_ |+| _)
     }
 
-    val ec2AndEfsSecGrps = for {
+    for {
       efsSg <- efsSgs
       ec2Sg <- ec2Sgs
-    } yield List(ec2Sg, efsSg).fold(Map.empty)(_ |+| _)
-
-    removeAllEfsUnknownUsages(ec2AndEfsSecGrps)
+    } yield filterOutEfsUnknownUsages(List(ec2Sg, efsSg).fold(Map.empty)(_ |+| _))
   }
 
   def flaggedSgsForAccount(account: AwsAccount, ec2Clients: AwsClients[AmazonEC2Async], efsClients: AwsClients[AmazonElasticFileSystemAsync], taClients: AwsClients[AWSSupportAsync])(implicit ec: ExecutionContext): Attempt[List[(SGOpenPortsDetail, Set[SGInUse])]] = {

--- a/hq/app/aws/ec2/EFS.scala
+++ b/hq/app/aws/ec2/EFS.scala
@@ -53,12 +53,11 @@ object EFS {
   }
 
   // these functions remove the UnknownUsage EFS values, because we already have the correct EfsVolume value
-  def removeAllEfsUnknownUsages(allSecGrps: Attempt[Map[String, Set[SGInUse]]])(implicit ec: ExecutionContext): Attempt[Map[String, Set[SGInUse]]] = allSecGrps.map(filterUnknownEfsSecGrps)
-  def filterUnknownEfsSecGrps(secGrpToResources: Map[String, Set[SGInUse]]): Map[String, Set[SGInUse]] = secGrpToResources.mapValues(filterResources)
-  def filterResources(resources: Set[SGInUse]): Set[SGInUse] = resources.filter(filterResource)
-  def filterResource(resource: SGInUse): Boolean = resource match {
-    case resource:UnknownUsage => if (resource.description.contains("EFS mount target")) false else true
-    case _ => true
+  def filterOutEfsUnknownUsages(secGrpToResources: Map[String, Set[SGInUse]]): Map[String, Set[SGInUse]] = secGrpToResources.mapValues(filterOutEfsUnknownUsagesFromSet)
+  def filterOutEfsUnknownUsagesFromSet(resources: Set[SGInUse]): Set[SGInUse] = resources.filterNot(efsUnknownUsages)
+  def efsUnknownUsages(resource: SGInUse): Boolean = resource match {
+    case resource:UnknownUsage => resource.description.contains("EFS mount target")
+    case _ => false
   }
 }
 

--- a/hq/app/aws/ec2/EFS.scala
+++ b/hq/app/aws/ec2/EFS.scala
@@ -1,0 +1,64 @@
+package aws.ec2
+
+import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
+import aws.AwsClient
+import com.amazonaws.services.elasticfilesystem.AmazonElasticFileSystemAsync
+import com.amazonaws.services.elasticfilesystem.model._
+import model.{SGInUse, UnknownUsage}
+import utils.attempt.Attempt
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+/**
+  * Given an Elastic File System (EFS), finds the security groups of its Mount Targets
+  * and filters for those that are flagged by Trusted Advisor.
+  */
+object EFS {
+  def getFileSystems(client: AwsClient[AmazonElasticFileSystemAsync])(implicit ec: ExecutionContext): Attempt[DescribeFileSystemsResult] = {
+    handleAWSErrs(client)(awsToScala(client)(_.describeFileSystemsAsync)(new DescribeFileSystemsRequest()))
+  }
+
+  def getMountTargets(efsInstances: DescribeFileSystemsResult, client: AwsClient[AmazonElasticFileSystemAsync])(implicit ec: ExecutionContext): Attempt[List[DescribeMountTargetsResult]] = {
+     Attempt.traverse(efsInstances.getFileSystems.asScala.toList){ fileSystem =>
+      val request = new DescribeMountTargetsRequest().withFileSystemId(fileSystem.getFileSystemId)
+      handleAWSErrs(client)(awsToScala(client)(_.describeMountTargetsAsync)(request))
+    }
+  }
+
+  def getMountTargetSecGrps(mountTargets: List[DescribeMountTargetsResult], client: AwsClient[AmazonElasticFileSystemAsync])(implicit ec: ExecutionContext): Attempt[List[(String, DescribeMountTargetSecurityGroupsResult)]] = {
+    val mts = mountTargets.flatMap(_.getMountTargets.asScala.toList)
+    Attempt.traverse(mts){ mt =>
+      val mtId = mt.getMountTargetId
+      val fileSystemId = mt.getFileSystemId
+      val request = new DescribeMountTargetSecurityGroupsRequest().withMountTargetId(mtId)
+      val secGrps = handleAWSErrs(client)(awsToScala(client)(_.describeMountTargetSecurityGroupsAsync)(request))
+      secGrps.map(fileSystemId -> _)
+    }
+  }
+
+  def secGrpToKey(fileSystemIdToSecGrp: List[(String, DescribeMountTargetSecurityGroupsResult)]): List[(String, SGInUse)] = {
+    val secGrpToFileSystemId = fileSystemIdToSecGrp.flatMap { case (efs, secGrps) =>
+        secGrps.getSecurityGroups.asScala.toList.map { scGrp =>
+          scGrp -> model.EfsVolume(efs)
+        }
+    }
+    secGrpToFileSystemId
+  }
+
+  def getFlaggedSecGrps(sgIds: List[String], efsSecGrps: List[(String, SGInUse)]):List[(String, SGInUse)] = {
+    efsSecGrps.filter{ case (scGrp, _) =>
+      sgIds.contains(scGrp)
+    }
+  }
+
+  // these functions remove the UnknownUsage EFS values, because we already have the correct EfsVolume value
+  def removeAllEfsUnknownUsages(allSecGrps: Attempt[Map[String, Set[SGInUse]]])(implicit ec: ExecutionContext): Attempt[Map[String, Set[SGInUse]]] = allSecGrps.map(filterUnknownEfsSecGrps)
+  def filterUnknownEfsSecGrps(secGrpToResources: Map[String, Set[SGInUse]]): Map[String, Set[SGInUse]] = secGrpToResources.mapValues(filterResources)
+  def filterResources(resources: Set[SGInUse]): Set[SGInUse] = resources.filter(filterResource)
+  def filterResource(resource: SGInUse): Boolean = resource match {
+    case resource:UnknownUsage => if (resource.description.contains("EFS mount target")) false else true
+    case _ => true
+  }
+}
+

--- a/hq/app/logic/SecurityGroupDisplay.scala
+++ b/hq/app/logic/SecurityGroupDisplay.scala
@@ -1,11 +1,11 @@
 package logic
 
-import model.{ELB, Ec2Instance, SGInUse, SGOpenPortsDetail}
+import model.{EfsVolume, ELB, Ec2Instance, SGInUse, SGOpenPortsDetail}
 
 
 object SecurityGroupDisplay {
 
-  case class ResourceIcons(instances: Int, elbs: Int, unknown: Int)
+  case class ResourceIcons(instances: Int, elbs: Int, unknown: Int, efss: Int)
   case class SGReportSummary(total: Int, suppressed: Int, flagged: Int, active: Int)
 
   case class SGReportDisplay(
@@ -15,12 +15,13 @@ object SecurityGroupDisplay {
 
   def resourceIcons(usages: List[SGInUse]): ResourceIcons = {
 
-    val (instances, elbs, unknown) = usages.foldLeft(0,0,0) {
-      case ( (ins, elb, unk), Ec2Instance(_) ) => (ins+1, elb, unk)
-      case ( (ins, elb, unk), ELB(_) ) => (ins, elb+1, unk)
-      case ( (ins, elb, unk), _ ) => (ins, elb, unk+1)
+    val (instances, elbs, unknown, efss) = usages.foldLeft(0,0,0,0) {
+      case ( (ins, elb, unk, efs), Ec2Instance(_) ) => (ins+1, elb, unk, efs)
+      case ( (ins, elb, unk, efs), ELB(_) ) => (ins, elb+1, unk, efs)
+      case ( (ins, elb, unk, efs), EfsVolume(_) ) => (ins, elb, unk, efs+1)
+      case ( (ins, elb, unk, efs), _ ) => (ins, elb, unk+1, efs)
     }
-    ResourceIcons(instances, elbs, unknown)
+    ResourceIcons(instances, elbs, unknown, efss)
   }
 
   def reportSummary(sgs: List[(SGOpenPortsDetail, Set[SGInUse])]): SGReportSummary = {

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -121,6 +121,7 @@ case class BucketDetail(
 sealed trait SGInUse
 case class Ec2Instance(instanceId: String) extends SGInUse
 case class ELB(description: String) extends SGInUse
+case class EfsVolume(description: String) extends SGInUse
 case class UnknownUsage(
   description: String,
   networkInterfaceId: String

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -9,6 +9,7 @@ import aws.AwsClients
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.ec2.AmazonEC2Async
+import com.amazonaws.services.elasticfilesystem.AmazonElasticFileSystemAsync
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.inspector.AmazonInspectorAsync
 import com.amazonaws.services.s3.AmazonS3
@@ -37,6 +38,7 @@ class CacheService(
     taClients: AwsClients[AWSSupportAsync],
     s3Clients: AwsClients[AmazonS3],
     iamClients: AwsClients[AmazonIdentityManagementAsync],
+    efsClients: AwsClients[AmazonElasticFileSystemAsync],
     regions: List[Regions]
   )(implicit ec: ExecutionContext) extends Logging {
   private val accounts = Config.getAwsAccounts(config)
@@ -129,7 +131,7 @@ class CacheService(
     logger.info("Started refresh of the Security Groups data")
     for {
       _ <- EC2.refreshSGSReports(accounts, taClients)
-      allFlaggedSgs <- EC2.allFlaggedSgs(accounts, ec2Clients, taClients)
+      allFlaggedSgs <- EC2.allFlaggedSgs(accounts, ec2Clients, efsClients, taClients)
     } yield {
       logger.info("Sending the refreshed data to the Security Groups Box")
       sgsBox.send(allFlaggedSgs.toMap)

--- a/hq/app/views/fragments/openSecurityGroups.scala.html
+++ b/hq/app/views/fragments/openSecurityGroups.scala.html
@@ -1,4 +1,4 @@
-@import model.{SGOpenPortsDetail, SGInUse, Ec2Instance, ELB, UnknownUsage}
+@import model.{SGOpenPortsDetail, SGInUse, Ec2Instance, ELB, UnknownUsage, EfsVolume}
 @import logic.SecurityGroupDisplay._
 
 @(flaggedSgs: List[(SGOpenPortsDetail, Set[SGInUse])], shadow: Boolean)
@@ -25,6 +25,13 @@
               <a class="btn usage-cta truncate">
                 <i class="material-icons right">report_problem</i>
                 Unknown usage: @description @networkInterfaceId
+            </a>
+        }
+        case EfsVolume(description) => {
+            <a target="_blank" rel="noopener noreferrer" class="btn usage-cta truncate" href="https://@{flaggedSg.region}.console.aws.amazon.com/efs/home?region=@{flaggedSg.region}#file-systems/@description">
+                <i class="material-icons right tooltipped" data-position="bottom" data-delay="50" data-tooltip="Elastic File System">device_hub</i>
+                <i class="material-icons link_new_tab" >open_in_new</i>
+                @description
             </a>
         }
     }

--- a/hq/test/aws/ec2/EC2Test.scala
+++ b/hq/test/aws/ec2/EC2Test.scala
@@ -1,6 +1,5 @@
 package aws.ec2
 
-import akka.actor.FSM.->
 import aws.AwsClient
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.ec2.AmazonEC2AsyncClientBuilder

--- a/hq/test/aws/ec2/EFSTest.scala
+++ b/hq/test/aws/ec2/EFSTest.scala
@@ -1,0 +1,35 @@
+package aws.ec2
+
+import com.amazonaws.services.elasticfilesystem.model.DescribeMountTargetSecurityGroupsResult
+import model.{EfsVolume, SGInUse, UnknownUsage}
+import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.prop.{Checkers, PropertyChecks}
+import utils.attempt.AttemptValues
+
+class EFSTest extends FreeSpec with Matchers with Checkers with PropertyChecks with AttemptValues {
+  "getsEfsSecurityGroups" - {
+    "getEfsSecurityGroupResult" in {
+      val describeSecGrpResultOne = new DescribeMountTargetSecurityGroupsResult().withSecurityGroups("sg-12345")
+      val describeSecGrpResultTwo = new DescribeMountTargetSecurityGroupsResult().withSecurityGroups("sg-23456")
+      val efsSecGrps = List(("EFS 12345", describeSecGrpResultOne), ("EFS 23456", describeSecGrpResultTwo))
+      EFS.secGrpToKey(efsSecGrps) shouldEqual List(("sg-12345", model.EfsVolume("EFS 12345")), ("sg-23456", model.EfsVolume("EFS 23456")))
+    }
+
+    "getEfsFlaggedSecurityGroups" in {
+      val flaggedSecGrps = List("sg-12345")
+      val allEfsSecGrps = List(("sg-12345", model.EfsVolume("EFS 12345")), ("sg-23456", model.EfsVolume("EFS 12345")))
+      EFS.getFlaggedSecGrps(flaggedSecGrps, allEfsSecGrps) shouldEqual List(("sg-12345", model.EfsVolume("EFS 12345")))
+    }
+    "removeUnwantedUnknownUsageEfsValues" in {
+      val secGrpToResources: Map[String, Set[SGInUse]] = Map(
+        "sg-123456789" -> Set(
+        UnknownUsage("EFS mount target for fs-1234 (fsmt-1234)","eni-1234"),
+        UnknownUsage("EFS mount target for fs-1234 (fsmt-2345)","eni-2345"),
+        UnknownUsage("EFS mount target for fs-1234 (fsmt-3456)","eni-3456"),
+        EfsVolume("fs-1234"),
+        UnknownUsage("test","test")))
+      val result: Map[String, Set[SGInUse]] = Map("sg-123456789" -> Set(EfsVolume("fs-1234"), UnknownUsage("test","test")))
+      EFS.filterUnknownEfsSecGrps(secGrpToResources) shouldEqual result
+    }
+  }
+}

--- a/hq/test/aws/ec2/EFSTest.scala
+++ b/hq/test/aws/ec2/EFSTest.scala
@@ -29,7 +29,7 @@ class EFSTest extends FreeSpec with Matchers with Checkers with PropertyChecks w
         EfsVolume("fs-1234"),
         UnknownUsage("test","test")))
       val result: Map[String, Set[SGInUse]] = Map("sg-123456789" -> Set(EfsVolume("fs-1234"), UnknownUsage("test","test")))
-      EFS.filterUnknownEfsSecGrps(secGrpToResources) shouldEqual result
+      EFS.filterOutEfsUnknownUsages(secGrpToResources) shouldEqual result
     }
   }
 }

--- a/hq/test/logic/SecurityGroupDisplayTest.scala
+++ b/hq/test/logic/SecurityGroupDisplayTest.scala
@@ -15,10 +15,11 @@ class SecurityGroupDisplayTest extends FreeSpec with Matchers {
     }
 
     "returns individual counts for the different resource types" in {
-      val usages = List[SGInUse](Ec2Instance("instance"), ELB("elb-1"), ELB("elb-2"), UnknownUsage("unknown", ""))
+      val usages = List[SGInUse](Ec2Instance("instance"), ELB("elb-1"), ELB("elb-2"), UnknownUsage("unknown", ""), EfsVolume("fs-12345"))
       resourceIcons(usages).instances shouldEqual 1
       resourceIcons(usages).elbs shouldEqual 2
       resourceIcons(usages).unknown shouldEqual 1
+      resourceIcons(usages).efss shouldEqual 1
     }
   }
 


### PR DESCRIPTION
## What is the problem?

Security HQ does not recognise AWS Elastic File Systems. This means that when an EFS security group is flagged by Trusted Advisor (because for example it has ports open to the world and is therefore a security risk), the `/security-groups` endpoint does not give us the file system id and corresponding link to it in the AWS console. 

## What does this change?

We've now added the capability for Security HQ to recognise EFSs.

| Before      | After* |
| ----------- | ----------- |
| <img width="273" alt="Screenshot 2021-02-05 at 13 24 00" src="https://user-images.githubusercontent.com/42121379/107039172-6ec3cf80-67b5-11eb-9882-af4bfc360a15.png"> | <img width="273" alt="Screenshot 2021-02-05 at 13 23 52" src="https://user-images.githubusercontent.com/42121379/107039195-78e5ce00-67b5-11eb-96a4-d51f35b9880c.png"> |
_*This test File System is now deleted_

## What is the value of this?

This change means that when a Guardian account has an EFS with security groups flagged by Trusted Advisor, we will see the file system id at https://security-hq.gutools.co.uk/security-groups and, if we have credentials, can click through to it in the AWS console. 

This is helpful, because it means we can more easily remediate EFS security problems with relevant teams☺️.


