### PR TITLE
Improve documentation pages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-efs" % awsSdkVersion,
-      "com.vladsch.flexmark" % "flexmark" % "0.28.20",
+      "com.vladsch.flexmark" % "flexmark" % "0.62.2",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -5,7 +5,7 @@ import java.io.FileInputStream
 import com.amazonaws.regions.Regions
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
-import model.{AwsAccount, DEV, PROD, Stage}
+import model.{AwsAccount, DEV, Documentation, PROD, Stage}
 import play.api.Configuration
 import play.api.http.HttpConfiguration
 
@@ -16,6 +16,11 @@ import scala.util.Try
 object Config {
   // TODO fetch the region dynamically from the instance
   val region: Regions = Regions.EU_WEST_1
+  val documentationLinks = List (
+    Documentation("SSH", "Use SSM-Scala for SSH access.", "code", "ssh-access"),
+    Documentation("Software dependency checks", "Integrate Snyk for software vulnerability reports.", "security", "snyk"),
+    Documentation("Wazuh", "Guide to installing the Wazuh agent.", "scanner", "wazuh")
+  )
 
   def getStage(config: Configuration): Stage = {
     config.getAndValidate("stage", Set("DEV", "PROD")) match {

--- a/hq/app/logic/DocumentUtil.scala
+++ b/hq/app/logic/DocumentUtil.scala
@@ -2,8 +2,10 @@ package logic
 
 import com.vladsch.flexmark.html.HtmlRenderer
 import com.vladsch.flexmark.parser.Parser
-import com.vladsch.flexmark.util.options.MutableDataSet
 import java.io.InputStream
+
+import com.vladsch.flexmark.util.data.MutableDataSet
+
 import scala.io.Source
 import play.twirl.api.Html
 

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -192,3 +192,5 @@ case class SnykProjectIssues(project: Option[SnykProject], ok: Boolean, vulnerab
 }
 
 case class SnykError(error: String)
+
+case class Documentation(title: String, description: String, icon: String, slug: String)

--- a/hq/app/views/documentationHome.scala.html
+++ b/hq/app/views/documentationHome.scala.html
@@ -1,3 +1,4 @@
+@import config.Config
 @()(implicit assets: AssetsFinder)
 
 
@@ -15,28 +16,21 @@
 } { @* Main content *@
     <div class="container">
         <div class="row docs-reports">
-            <div class="card">
-                <div class="card-content">
-                    <a class="docs__link" href="/documentation/ssh-access">
-                        <i class="right material-icons">code</i>
-                        <span class="card-title">SSH</span>
-                        <p>
-                            Use SSM-Scala for SSH access.
-                        </p>
-                    </a>
+            @for(docLink <- Config.documentationLinks) {
+                <div class="card">
+                    <div class="card-content">
+                        <a class="docs__link" href="/documentation/@{
+                            docLink.slug
+                        }">
+                            <i class="right material-icons">@docLink.icon</i>
+                            <span class="card-title">@docLink.title</span>
+                            <p>
+                            @docLink.description
+                            </p>
+                        </a>
+                    </div>
                 </div>
-            </div>
-            <div class="card">
-                <div class="card-content">
-                    <a class="docs__link" href="/documentation/snyk">
-                        <i class="right material-icons">security</i>
-                        <span class="card-title">Software dependency checks</span>
-                        <p>
-                            Integrate Snyk for software vulnerability reports.
-                        </p>
-                    </a>
-                </div>
-            </div>
+            }
         </div>
     </div>
 }

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -360,20 +360,31 @@ table.iam-report__table th {
   color: rgba(0, 0, 0, 0.87);
 }
 
+.doc-content {
+  font-size: 1.2rem;
+}
+
+.doc-content ul, .doc-content ul li {
+  list-style-type: disc !important;
+  margin-left: 10px;
+}
+
+
+
 .doc-content h1 {
-  font-size: 3.5rem;
-}
-
-.doc-content h2 {
-  font-size: 3rem;
-}
-
-.doc-content h3 {
   font-size: 2.5rem;
 }
 
-.doc-content h4 {
+.doc-content h2 {
   font-size: 2rem;
+}
+
+.doc-content h3 {
+  font-size: 1.5rem;
+}
+
+.doc-content h4 {
+  font-size: 1rem;
 }
 
 /* Snyk */


### PR DESCRIPTION
## What does this change?
This PR:
 - Reduces font size of the docs so you don't have to zoom out
 - re-enables bullet point in unordered lists (disabled by materialize by default)
 - Pulls the data driving the [documentation index page](https://security-hq.gutools.co.uk/documentation) out of the template to reduce boilerplate
 - Adds Wazuh to the documentation index


## What is the value of this?
Docs are more readable and findable 🥳 


Before
<img width="1120" alt="Screenshot 2021-02-09 at 18 29 09" src="https://user-images.githubusercontent.com/3606555/107410094-c25f5180-6b04-11eb-898a-8dd8d0f50bc8.png">
After
<img width="1203" alt="Screenshot 2021-02-09 at 18 29 19" src="https://user-images.githubusercontent.com/3606555/107410101-c4291500-6b04-11eb-892d-f998f136709e.png">


![zoom out](https://64.media.tumblr.com/ddd191ba12b72c02ba0019b6b5d843a8/tumblr_nyjx5diq5h1ukrkg0o1_250.gif)
