### PR TITLE
Security HQ>>>ARM64 💪🏻 🚀 

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -48,6 +48,9 @@ Parameters:
   LoggingRoleToAssumeArn:
     Type: String
     Description: Name of IAM role in logging account e.g. arn:aws:iam::222222222222:role/LoggingRole
+  InstanceType:
+    Type: String
+    Description: AWS instance type (e.g. t4g.large)
 
 Mappings:
   Constants:
@@ -285,7 +288,7 @@ Resources:
         Ref: AMI
       SecurityGroups:
       - Ref: InstanceSecurityGroup
-      InstanceType: t3.large
+      InstanceType: !Ref InstanceType
       IamInstanceProfile:
         Ref: SecurityHQInstanceProfile
       AssociatePublicIpAddress: true

--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -19,6 +19,6 @@ deployments:
       templatePath: cfn.yaml
       amiEncrypted: true
       amiTags:
-        Recipe: security-java-lts
+        Recipe: security-java-lts-arm64
         BuiltBy: amigo
         AmigoStage: PROD


### PR DESCRIPTION
## What does this change?
This updates the referenced recipe for security HQ to a [new arm64 recipe](https://amigo.gutools.co.uk/recipes/security-java-lts-arm64) and parameterises the instance type within the security HQ cloudformation to make switching to a t4g easier. 

## How to test
This change is currently live on PROD and doesn't seem to be causing any issues


## What is the value of this?
$$$ savings and maybe performance increase?!

