### PR TITLE
Add old AMIs to critical vulnerabilities list

### DIFF
--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -17,6 +17,7 @@ which should always be addressed first. These are:
  - IAM users with a password but no multi factor authentication (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#1-security-hq))
  - IAM users with permanent credentials - these should be regularly rotated or deleted (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#1-security-hq))
  - Critical vulnerabilities identified by [AWS Security Hub](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#4-aws-security-hub)
+ - Out of date AMIs (audit via [amiable](https://amiable.gutools.co.uk)) - some details [below](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#2-operating-system-patches)
 
 
 ### 1. Security HQ


### PR DESCRIPTION
## What does this change?
Following a meeting with Infosec, this change adds out of date AMIs to the 'critical vulnerabilities' list. 
