### PR TITLE
Add GCP security vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,6 @@ lazy val hq = (project in file("hq"))
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
-      "com.google.cloud" % "google-cloud-storage" % "1.113.9", // we need this for point to a service account file: https://cloud.google.com/docs/authentication/production#passing_code
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbt.Keys.libraryDependencies
 organization in ThisBuild := "com.gu"
 version in ThisBuild := "0.2.0"
 scalaVersion in ThisBuild := "2.12.10"
-scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")
+scalacOptions in ThisBuild ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8") //"-Xfatal-warnings"
 
 // resolvers += "guardian-bintray" at "https://dl.bintray.com/guardian/sbt-plugins/"
 resolvers += DefaultMavenRepository
@@ -42,6 +42,8 @@ lazy val hq = (project in file("hq"))
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+      "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
+      "com.google.cloud" % "google-cloud-storage" % "1.113.9", // we need this for point to a service account file: https://cloud.google.com/docs/authentication/production#passing_code
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -7,7 +7,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.GoogleCredentials
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
-import model.{AwsAccount, DEV, Documentation, PROD, Stage}
+import model._
 import play.api.Configuration
 import play.api.http.HttpConfiguration
 
@@ -47,12 +47,10 @@ object Config {
     )
   }
 
-  case class GcpSccAuth(orgId: String, sourceId: String)
-
-  def gcpSccAuthentication(implicit config: Configuration): GcpSccAuth = {
-    val gcpOrgId = requiredString(config, "gcpOrgId")
-    val gcpSccSourceId = requiredString(config, "gcpSccSourceId")
-    GcpSccAuth(gcpOrgId, gcpSccSourceId)
+  def gcpSccAuthentication(implicit config: Configuration): GcpSccConfig = {
+    val gcpOrgId = requiredString(config, "gcp.orgId")
+    val gcpSccSourceId = requiredString(config, "gcp.sccSourceId")
+    GcpSccConfig(gcpOrgId, gcpSccSourceId)
   }
 
   def gcpCredentialsProvider(implicit config: Configuration): FixedCredentialsProvider = {

--- a/hq/app/controllers/GcpController.scala
+++ b/hq/app/controllers/GcpController.scala
@@ -1,0 +1,28 @@
+package controllers
+
+import auth.SecurityHQAuthActions
+import com.gu.googleauth.GoogleAuthConfig
+import model.GcpReport
+import org.joda.time.DateTime
+import play.api.Configuration
+import play.api.libs.ws.WSClient
+import play.api.mvc.{AnyContent, BaseController, BodyParser, ControllerComponents}
+import services.CacheService
+import utils.attempt.PlayIntegration.attempt
+
+import scala.concurrent.ExecutionContext
+
+class GcpController(val config: Configuration, val authConfig: GoogleAuthConfig, val cacheService: CacheService)
+  (implicit val ec: ExecutionContext, val wsClient: WSClient, val controllerComponents: ControllerComponents, val bodyParser: BodyParser[AnyContent], val assetsFinder: AssetsFinder)
+  extends BaseController with SecurityHQAuthActions {
+
+  def all = authAction.async {
+    attempt {
+      for {
+        allGcpFindings <- cacheService.getGcpFindings
+        gcpProjectToFinding = allGcpFindings.groupBy(_.project)
+        report = GcpReport(DateTime.now, gcpProjectToFinding)
+      } yield Ok(views.html.gcp.gcp(report))
+    }
+  }
+}

--- a/hq/app/logic/GcpDisplay.scala
+++ b/hq/app/logic/GcpDisplay.scala
@@ -35,7 +35,7 @@ object GcpDisplay {
       val sourceName: SourceName = SourceName.of(org.getOrganization, source)
       val filter = """-sourceProperties.ResourcePath : "projects/sys-"""" //TODO remove org level findings
       val request: ListFindingsRequest.Builder = ListFindingsRequest.newBuilder.setParent(sourceName.toString).setFilter(filter)
-      client.listFindings(request.build) //Calling the API
+      client.listFindings(request.build)
     }
 
   val severities = List("High", "Medium", "Low")

--- a/hq/app/logic/GcpDisplay.scala
+++ b/hq/app/logic/GcpDisplay.scala
@@ -1,0 +1,52 @@
+package logic
+
+import com.google.cloud.securitycenter.v1.{ListFindingsRequest, OrganizationName, SecurityCenterClient, SourceName}
+import com.google.protobuf.Value
+import config.Config
+import model.GcpFinding
+import org.joda.time.DateTime
+import play.api.Configuration
+import utils.attempt.Attempt
+
+import scala.collection.JavaConverters.asScalaIteratorConverter
+import scala.util.matching.Regex
+
+object GcpDisplay {
+  val dateTimePattern = "dd/MM/yy"
+
+  def getGcpFindings(org: OrganizationName, client: SecurityCenterClient, config: Configuration): Attempt[List[GcpFinding]] = {
+    Attempt.Right {
+      callGcpApi(org, client, config).iterateAll.iterator.asScala.toList.map{  result =>
+        val finding = result.getFinding
+        GcpFinding(
+          getProjectNameFromUri(finding.getExternalUri).getOrElse("unknown"),
+          finding.getCategory,
+          Option(finding.getSourcePropertiesOrDefault("SeverityLevel", Value.newBuilder.build).getStringValue),
+          new DateTime(finding.getEventTime.getSeconds * 1000),
+          Option(finding.getSourcePropertiesOrDefault("Explanation", Value.newBuilder.build).getStringValue),
+          Option(finding.getSourcePropertiesOrDefault("Recommendation", Value.newBuilder.build).getStringValue)
+        )
+      }
+    }
+  }
+
+  def callGcpApi(org: OrganizationName, client: SecurityCenterClient, config: Configuration): SecurityCenterClient.ListFindingsPagedResponse = {
+      val source = Config.gcpSccAuthentication(config).sourceId
+      val sourceName: SourceName = SourceName.of(org.getOrganization, source)
+      val filter = """-sourceProperties.ResourcePath : "projects/sys-"""" //TODO remove org level findings
+      val request: ListFindingsRequest.Builder = ListFindingsRequest.newBuilder.setParent(sourceName.toString).setFilter(filter)
+      client.listFindings(request.build) //Calling the API
+    }
+
+  val severities = List("High", "Medium", "Low")
+  def sortFindings(findings: List[GcpFinding]): List[GcpFinding] = findings.sortBy{ finding =>
+    val severity = severities.indexOf(finding.severity.getOrElse("Low"))
+      val date = finding.eventTime.getMillis
+    (severity, -date)
+  }
+
+    def getProjectNameFromUri(uri: String): Option[String] = {
+      val regexPattern = new Regex("""(?<=project=).*""")
+      regexPattern.findFirstIn(uri)
+    }
+}

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -1,6 +1,8 @@
 package model
 
 import com.amazonaws.regions.Region
+import com.google.cloud.securitycenter.v1.Finding
+import com.google.protobuf.{Timestamp, Value}
 import org.joda.time.DateTime
 
 case class AwsAccount(
@@ -194,3 +196,14 @@ case class SnykProjectIssues(project: Option[SnykProject], ok: Boolean, vulnerab
 case class SnykError(error: String)
 
 case class Documentation(title: String, description: String, icon: String, slug: String)
+
+case class GcpReport(reportDate: DateTime, finding: Map[String, Seq[GcpFinding]] = Map.empty)
+
+case class GcpFinding(
+  project: String,
+  category: String,
+  severity: Option[String],
+  eventTime: DateTime,
+  explanation: Option[String],
+  recommendation: Option[String]
+)

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -207,3 +207,5 @@ case class GcpFinding(
   explanation: Option[String],
   recommendation: Option[String]
 )
+
+case class GcpSccConfig(orgId: String, sourceId: String)

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -178,7 +178,7 @@ class CacheService(
     }
 
     val gcpSubscription = Observable.interval(initialDelay + 6000.millis, 90.minutes).subscribe { _ =>
-      println("refreshing the GCP Box now")
+      logger.info("refreshing the GCP Box now")
       refreshGcpBox()
     }
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -1,10 +1,10 @@
 package services
 
 import api.Snyk
+import aws.AwsClients
 import aws.ec2.EC2
 import aws.iam.IAMClient
 import aws.support.{TrustedAdvisorExposedIAMKeys, TrustedAdvisorS3}
-import aws.AwsClients
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.ec2.AmazonEC2Async
@@ -12,12 +12,14 @@ import com.amazonaws.services.elasticfilesystem.AmazonElasticFileSystemAsync
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.support.AWSSupportAsync
+import com.google.cloud.securitycenter.v1.{OrganizationName, SecurityCenterClient}
 import com.gu.Box
 import config.Config
+import logic.GcpDisplay
 import model._
+import play.api._
 import play.api.inject.ApplicationLifecycle
 import play.api.libs.ws.WSClient
-import play.api._
 import rx.lang.scala.Observable
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -36,7 +38,8 @@ class CacheService(
     s3Clients: AwsClients[AmazonS3],
     iamClients: AwsClients[AmazonIdentityManagementAsync],
     efsClients: AwsClients[AmazonElasticFileSystemAsync],
-    regions: List[Regions]
+    regions: List[Regions],
+    gcpClient: SecurityCenterClient
   )(implicit ec: ExecutionContext) extends Logging {
   private val accounts = Config.getAwsAccounts(config)
   private val startingCache = accounts.map(acc => (acc, Left(Failure.cacheServiceErrorPerAccount(acc.id, "cache").attempt))).toMap
@@ -45,6 +48,7 @@ class CacheService(
   private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(startingCache)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
   private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("cache").attempt)))
+  private val gcpBox: Box[Attempt[List[GcpFinding]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("").attempt)))
 
   def getAllPublicBuckets: Map[AwsAccount, Either[FailedAttempt, List[BucketDetail]]] = publicBucketsBox.get()
 
@@ -83,6 +87,8 @@ class CacheService(
   }
 
   def getAllSnykResults: Attempt[List[SnykProjectIssues]] = snykBox.get()
+
+  def getGcpFindings: Attempt[List[GcpFinding]] = gcpBox.get()
 
   def refreshCredentialsBox(): Unit = {
     logger.info("Started refresh of the Credentials data")
@@ -135,6 +141,17 @@ class CacheService(
     }
   }
 
+  def refreshGcpBox(): Unit = {
+    logger.info("Started refresh of GCP data")
+    val organisation = OrganizationName.of(Config.gcpSccAuthentication(config).orgId)
+    for {
+      gcpFindings <- GcpDisplay.getGcpFindings(organisation, gcpClient, config)
+    } yield {
+      logger.info("Sending the refreshed data to the GCP Box")
+      gcpBox.send(Attempt.Right(gcpFindings))
+    }
+  }
+
   if (environment.mode != Mode.Test) {
     val initialDelay =
       if (environment.mode == Mode.Prod) 10.seconds
@@ -160,12 +177,18 @@ class CacheService(
       refreshSnykBox()
     }
 
+    val gcpSubscription = Observable.interval(initialDelay + 6000.millis, 90.minutes).subscribe { _ =>
+      println("refreshing the GCP Box now")
+      refreshGcpBox()
+    }
+
     lifecycle.addStopHook { () =>
       publicBucketsSubscription.unsubscribe()
       exposedKeysSubscription.unsubscribe()
       sgSubscription.unsubscribe()
       credentialsSubscription.unsubscribe()
       snykSubscription.unsubscribe()
+      gcpSubscription.unsubscribe()
       Future.successful(())
     }
   }

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -1,0 +1,64 @@
+@import model.CredentialReportDisplay
+@import org.joda.time.DateTime
+@import model.GcpReport
+@import controllers.AssetsFinder
+@import logic.GcpDisplay
+@(report: GcpReport)(implicit assets: AssetsFinder)
+
+@floatingNav() = {
+    <div class="fixed-action-btn js-floating-nav iam-floating-nav">
+        <a class="btn-floating btn-large">
+            <i class="large material-icons">menu</i>
+        </a>
+        <ul>
+            <li><a class="btn-floating red js-iam-collapse">
+                <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="collapse all">fullscreen_exit</i>
+            </a></li>
+            <li><a class="btn-floating yellow darken-1 js-iam-expand">
+                <i class="material-icons tooltipped" data-position="left" data-delay="50" data-tooltip="expand all">fullscreen</i>
+            </a></li>
+        </ul>
+    </div>
+}
+
+@main(List("Gcp")) { @* Header *@
+    <div class="hq-sub-header">
+        <div class="container hq-sub-header__row">
+            <div class="hq-sub-header__name">
+                <h4 class="header light grey-text text-lighten-5">All accounts</h4>
+            </div>
+            <div class="hq-sub-header__tabs">
+                <ul class="tabs tabs-transparent">
+                    <li class="tab col s3"><a target="_self" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
+                    <li class="tab col s3"><a target="_self" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
+                    <li class="tab col s3"><a target="_self" href="/buckets"><i class="material-icons left">storage</i>S3 Buckets</a></li>
+                    <li class="tab col s3"><a target="_self" class="active" href="/gcp"><i class="material-icons left">cloud_queue</i>GCP</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+} { @* Main content *@
+    <div class="container">
+        <div class="row">
+            <ul class="collapsible" data-collapsible="accordion">
+                @for((projectName, findings) <- report.finding.toList.sortBy(_._1)) {
+                    <li>
+                    <div class="collapsible-header" tabindex="22">
+                    <i class="material-icons">keyboard_arrow_down</i>
+
+                    <span class="iam-header__name">@projectName</span>
+                    <i class="material-icons green-text">check</i>
+                    </div>
+                    <div class="collapsible-body">
+                    @views.html.gcp.gcpReportBody(GcpDisplay.sortFindings(findings.toList), report.reportDate)
+                    </div>
+                    </li>
+                }
+            </ul>
+        </div>
+
+        @floatingNav()
+
+    </div>
+}

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -1,0 +1,40 @@
+@import logic.DateUtils
+@import model._
+@import logic.CredentialsReportDisplay
+@import org.joda.time.DateTime
+@import logic.GcpDisplay
+@(findings: List[GcpFinding], date: DateTime)
+
+<div class="row">
+    <div class="card-panel">
+        <span>Report generated at @{DateUtils.printTime(date)} (refreshed every four hours)</span>
+    </div>
+</div>
+<div class="row">
+    <div class="col s12">
+        <table class="striped responsive-table gcp-report__table">
+            <thead>
+                <tr>
+                    <th class="gcp-table-row-severity">Severity</th>
+                    <th class="gcp-table-row-category">Category</th>
+                    <th class="gcp-table-row-date">Date</th>
+                    <th>Explanation</th>
+                    <th>Recommendation</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(finding <- findings) {
+                    <tr>
+                        <td class="gcp-table-row-severity"><span>@finding.severity</span></td>
+                        <td class="gcp-table-row-category"><span>@finding.category</span></td>
+                        <td class="gcp-table-row-date"><span>@finding.eventTime.toString(GcpDisplay.dateTimePattern)</span></td>
+                        <td><span>@finding.explanation</span></td>
+                        <td><span>@finding.recommendation</span></td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+</div>
+
+@*if(finding.severity.contains("")) {Unknown} else {@finding.severity} *@

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -47,8 +47,10 @@ auth {
   }
 }
 
-gcpOrgId=${GCP_ORG_ID}
-gcpSccSourceId=${GCP_SCC_SOURCE_ID}
+gcp {
+   orgId=${GCP_ORG_ID}
+   sccSourceId=${GCP_SCC_SOURCE_ID}
+}
 
 snykSSOUrl = ${?SNYK_SSO_URL}
 

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -47,6 +47,9 @@ auth {
   }
 }
 
+gcpOrgId=${GCP_ORG_ID}
+gcpSccSourceId=${GCP_SCC_SOURCE_ID}
+
 snykSSOUrl = ${?SNYK_SSO_URL}
 
 ## Akka

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -28,5 +28,6 @@ GET        /documentation/:file                       controllers.HQController.d
 
 GET        /build                                     controllers.Assets.at(path = "/public", file = "build.json")
 
+GET        /gcp                                       controllers.GcpController.all
 # Map static resources from the /public folder to the /assets URL path
 GET        /assets/*file                              controllers.Assets.versioned(path="/public", file: Asset)

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -338,6 +338,30 @@ table.iam-report__table th {
   box-sizing: initial;
 }
 
+table.gcp-report__table td,
+table.gcp-report__table th {
+  min-height: 21px;
+  box-sizing: initial;
+  word-wrap: break-word;
+}
+
+table.gcp-report__table {
+  table-layout: fixed;
+  word-break: break-all;
+}
+
+.gcp-table-row-severity {
+  width: 55px;
+}
+
+.gcp-table-row-category {
+  width: 130px;
+}
+
+.gcp-table-row-date {
+  width: 65px;
+}
+
 .iam-modal__trigger {
   height: 24px;
 }
@@ -398,3 +422,4 @@ table.iam-report__table th {
 .hq-footer__links {
   height: 40px;
 }
+

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -338,19 +338,17 @@ table.iam-report__table th {
   box-sizing: initial;
 }
 
-table.gcp-report__table td,
-table.gcp-report__table th {
+gcp-report__table td,
+gcp-report__table th {
   min-height: 21px;
   box-sizing: initial;
   word-wrap: break-word;
 }
 
-/*
-table.gcp-report__table {
+gcp-report__table {
   table-layout: fixed;
   word-break: break-all;
 }
- */
 
 .gcp-table-row-severity {
   width: 55px;

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -345,10 +345,12 @@ table.gcp-report__table th {
   word-wrap: break-word;
 }
 
+/*
 table.gcp-report__table {
   table-layout: fixed;
   word-break: break-all;
 }
+ */
 
 .gcp-table-row-severity {
   width: 55px;

--- a/sbt
+++ b/sbt
@@ -5,7 +5,7 @@ DEBUG_PARAMS=""
 TC_PARAMS=""
 COLOUR_PARAMS=""
 
-CONF_PARAMS="-Dconfig.file=$HOME/.gu/security-hq.local.conf -Dgoogle.application.credentials=$HOME/.gu/security-hq-service-account-cert.json"
+CONF_PARAMS="-Dconfig.file=$HOME/.gu/security-hq.local.conf"
 for arg in "$@"
 do
     if [ "$arg" == "--debug" ]; then

--- a/sbt
+++ b/sbt
@@ -5,7 +5,7 @@ DEBUG_PARAMS=""
 TC_PARAMS=""
 COLOUR_PARAMS=""
 
-CONF_PARAMS="-Dconfig.file=$HOME/.gu/security-hq.local.conf"
+CONF_PARAMS="-Dconfig.file=$HOME/.gu/security-hq.local.conf -Dgoogle.application.credentials=$HOME/.gu/security-hq-service-account-cert.json"
 for arg in "$@"
 do
     if [ "$arg" == "--debug" ]; then


### PR DESCRIPTION
## What does this change?

This PR adds a new route, `/gcp`, to show Google Cloud Platform (GCP) security vulnerabilities for each project in the Guardian organisation.

![Screenshot 2021-03-09 at 15 01 26](https://user-images.githubusercontent.com/42121379/110490564-5e6e7f80-80e8-11eb-8d10-d4056c47a08c.png)

## What is the value of this?

We at the Guardian generally use AWS for our cloud infrastructure needs, but have recently increased our usage of GCP. Given this, it's vital that we include GCP assets in our security monitoring. 

This work is the Guardian's first major project to expose GCP security vulnerabilities so that engineering teams can easily see the remediation steps required for them to run their GCP infrastructure securely. 

## TODO

This PR should be seen as a minimum viable product, because there is still lots of work to do before this is ready to present to the department. Here are some of the major things on our TODO list after this PR is merged:

- add a /gcp link to the other routes, so that users can navigate to /gcp with ease!
- solve the missing severity values problem
- add a filter by severity
- colour code findings by severity
- change the green tick image next to the project names 
- add some logic to only show findings for one project when running in DEV mode (to make the developer experience nicer)
- more helpful error message when the GCP cache is not ready yet
