### PR TITLE
Add GCP link to all pages

### DIFF
--- a/hq/app/views/header.scala.html
+++ b/hq/app/views/header.scala.html
@@ -28,6 +28,9 @@
                             <a class="tooltipped" data-tooltip="Snyk" href="/snyk"><i class="material-icons black-text">security</i></a>
                         </li>
                         <li class="main-nav">
+                            <a class="tooltipped" data-tooltip="GCP" href="/gcp"><i class="material-icons black-text">cloud</i></a>
+                        </li>
+                        <li class="main-nav">
                             <a class="tooltipped" data-tooltip="Documentation" href="/documentation"><i class="material-icons black-text">description</i></a>
                         </li>
                     </ul>
@@ -47,6 +50,9 @@
                         </li>
                         <li class="main-nav">
                             <a href="/snyk"><i class="material-icons black-text">security</i>Snyk</a>
+                        </li>
+                        <li class="main-nav">
+                            <a href="/gcp"><i class="material-icons black-text">cloud</i>GCP</a>
                         </li>
                         <li class="main-nav">
                             <a href="/documentation"><i class="material-icons black-text">description</i>Documentation</a>

--- a/hq/app/views/iam/iam.scala.html
+++ b/hq/app/views/iam/iam.scala.html
@@ -30,6 +30,7 @@
                     <li class="tab col s3"><a target="_self" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                     <li class="tab col s3"><a target="_self" class="active" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
                     <li class="tab col s3"><a target="_self" href="/buckets"><i class="material-icons left">storage</i>S3 Buckets</a></li>
+                    <li class="tab col s3"><a target="_self" href="/gcp"><i class="material-icons left">cloud</i>GCP Findings</a></li>
                 </ul>
             </div>
         </div>

--- a/hq/app/views/index.scala.html
+++ b/hq/app/views/index.scala.html
@@ -7,7 +7,7 @@
     <div class="hq-sub-header">
         <div class="container hq-sub-header__row">
             <div class="hq-sub-header__name">
-                <h4 class="header light grey-text text-lighten-5">Centralised AWS Account security management</h4>
+                <h4 class="header light grey-text text-lighten-5">Centralised AWS & GCP Account security management</h4>
             </div>
         </div>
     </div>
@@ -55,6 +55,17 @@
                         <span class="card-title">Snyk audits</span>
                         <p>
                             Snyk vulnerability reports.
+                        </p>
+                    </a>
+                </div>
+            </div>
+            <div class="card">
+                <div class="card-content">
+                    <a class="hp__link" href="/gcp">
+                        <i class="right material-icons">cloud</i>
+                        <span class="card-title">GCP Security Findings</span>
+                        <p>
+                            GCP Security Command Center vulnerability findings.
                         </p>
                     </a>
                 </div>

--- a/hq/app/views/main.scala.html
+++ b/hq/app/views/main.scala.html
@@ -33,7 +33,7 @@
                     <div class="col l8 s12">
                         <h5 class="white-text">Security HQ</h5>
                         <p class="grey-text text-lighten-4">
-                            A tool for monitoring the security status of AWS accounts, developed by the Guardian's security team.
+                            A tool for monitoring the security status of AWS & GCP accounts, developed by the Guardian's security team.
                         </p>
                     </div>
                     <div class="col l3 offset-l1 s12">

--- a/hq/app/views/s3/publicBuckets.scala.html
+++ b/hq/app/views/s3/publicBuckets.scala.html
@@ -31,6 +31,7 @@
                     <li class="tab col s3"><a target="_self" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                     <li class="tab col s3"><a target="_self" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
                     <li class="tab col s3"><a target="_self" class="active" href="/buckets"><i class="material-icons left">storage</i>S3 Buckets</a></li>
+                    <li class="tab col s3"><a target="_self" href="/gcp"><i class="material-icons left">cloud</i>GCP Findings</a></li>
                 </ul>
             </div>
         </div>

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -35,6 +35,7 @@
                     <li class="tab col s3"><a target="_self" class="active" href="/security-groups"><i class="material-icons left">vpn_lock</i>Security Groups</a></li>
                     <li class="tab col s3"><a target="_self" href="/iam"><i class="material-icons left">vpn_key</i>IAM Report</a></li>
                     <li class="tab col s3"><a target="_self" href="/buckets"><i class="material-icons left">storage</i>S3 Buckets</a></li>
+                    <li class="tab col s3"><a target="_self" href="/gcp"><i class="material-icons left">cloud</i>GCP Findings</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## What does this change?
This PR adds the GCP logo and link to the homepage and to the headers of the other pages.
<img width="1080" alt="Screenshot 2021-03-16 at 10 02 08" src="https://user-images.githubusercontent.com/42121379/111291068-b2c0b480-863e-11eb-94bb-365ac5076779.png">

## What is the value of this?
Users can now navigate to /gcp from other pages without manually typing it into the browser!