### PR TITLE
Post metrics to cloudwatch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-efs" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark" % "0.62.2",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -33,7 +33,7 @@ object Cloudwatch extends logging {
     }
   }
 
-  def putMetric(account: AwsAccount, dataType: DataType.Value , value: Int): String = {
+  def putMetric(account: AwsAccount, dataType: DataType.Value , value: Int): Unit = {
     logger.info(s"METRIC:  Account=${account.name},DataType=${dataType},Value=${value}")
     val cw = AmazonCloudWatchClientBuilder.defaultClient
 
@@ -43,7 +43,6 @@ object Cloudwatch extends logging {
     )
     val datum = new MetricDatum().withMetricName("Vulnerabilities").withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)
     val request = new PutMetricDataRequest().withNamespace("SecurityHQ").withMetricData(datum)
-    val response: PutMetricDataResult = cw.putMetricData(request)
-    response.toString
+    cw.putMetricData(request)
   }
 }

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -1,0 +1,48 @@
+package logging
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, PutMetricDataResult, StandardUnit}
+import model.{AwsAccount, CredentialReportDisplay}
+
+import collection.JavaConverters._
+
+
+object Cloudwatch {
+
+  object DataType extends Enumeration {
+    val s3Total = Value("s3/total")
+    val iamCredentialsTotal = Value("iam/credentials/total")
+    val iamKeysTotal = Value("iam/keys/total")
+    val sgTotal = Value("securitygroup/total")
+  }
+
+  def logAsMetric[T](data: Seq[T], dataType: DataType.Value ) : Unit = {
+    for ((account: AwsAccount, result) <- data) {
+      result match {
+        case Right(details: CredentialReportDisplay) => {
+          putMetric(account, dataType, details.humanUsers.length + details.machineUsers.length)
+        }
+        case Right(details: List[Any]) => {
+          putMetric(account, dataType, details.length)
+        }
+        case Left(_) => {
+          println(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
+        }
+      }
+    }
+  }
+
+  def putMetric(account: AwsAccount, dataType: DataType.Value , value: Int): String = {
+    println(s"METRIC:  Account=${account.name},DataType=${dataType},Value=${value}")
+    val cw = AmazonCloudWatchClientBuilder.defaultClient
+
+    val dimension = List(
+      (new Dimension).withName("Account").withValue(account.name),
+      (new Dimension).withName("DataType").withValue(dataType.toString)
+    )
+    val datum = new MetricDatum().withMetricName("Vulnerabilities").withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)
+    val request = new PutMetricDataRequest().withNamespace("SecurityHQ").withMetricData(datum)
+    val response: PutMetricDataResult = cw.putMetricData(request)
+    response.toString
+  }
+}

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -26,7 +26,7 @@ object Cloudwatch extends Logging {
       case (account: AwsAccount, Right(details: List[Any])) =>
         putMetric(account, dataType, details.length)
       case (account: AwsAccount, Left(_)) =>
-        println(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
+        logger.error(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
     }
   }
 

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -4,13 +4,13 @@ import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, PutMetricDataResult, StandardUnit}
 import model.{AwsAccount, CredentialReportDisplay}
-import sun.util.logging.resources.logging
+import play.api.Logging
 
 import collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 
-object Cloudwatch extends logging {
+object Cloudwatch extends Logging {
 
   object DataType extends Enumeration {
     val s3Total = Value("s3/total")

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -3,11 +3,12 @@ package logging
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, PutMetricDataResult, StandardUnit}
 import model.{AwsAccount, CredentialReportDisplay}
+import sun.util.logging.resources.logging
 
 import collection.JavaConverters._
 
 
-object Cloudwatch {
+object Cloudwatch extends logging {
 
   object DataType extends Enumeration {
     val s3Total = Value("s3/total")
@@ -26,14 +27,14 @@ object Cloudwatch {
           putMetric(account, dataType, details.length)
         }
         case Left(_) => {
-          println(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
+          logger.error(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
         }
       }
     }
   }
 
   def putMetric(account: AwsAccount, dataType: DataType.Value , value: Int): String = {
-    println(s"METRIC:  Account=${account.name},DataType=${dataType},Value=${value}")
+    logger.info(s"METRIC:  Account=${account.name},DataType=${dataType},Value=${value}")
     val cw = AmazonCloudWatchClientBuilder.defaultClient
 
     val dimension = List(

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -42,11 +42,14 @@ object Cloudwatch extends Logging {
       (new Dimension).withName("Account").withValue(account.name),
       (new Dimension).withName("DataType").withValue(dataType.toString)
     )
+
     val datum = new MetricDatum().withMetricName("Vulnerabilities").withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)
     val request = new PutMetricDataRequest().withNamespace("SecurityHQ").withMetricData(datum)
+
     Try(cw.putMetricData(request)) match {
       case Success(response) => logger.info(s"METRIC:  Account=${account.name},DataType=${dataType},Value=${value}")
       case Failure(e: AmazonServiceException) => logger.error(s"Put metric of type ${dataType} failed for account ${account.name}", e)
+      case Failure(e) => logger.error(s"Put metric of type ${dataType} failed for account ${account.name} with an unknown exception", e)
     }
   }
 }

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -20,18 +20,13 @@ object Cloudwatch extends Logging {
   }
 
   def logAsMetric[T](data: Seq[T], dataType: DataType.Value ) : Unit = {
-    for ((account: AwsAccount, result) <- data) {
-      result match {
-        case Right(details: CredentialReportDisplay) => {
-          putMetric(account, dataType, details.humanUsers.length + details.machineUsers.length)
-        }
-        case Right(details: List[Any]) => {
-          putMetric(account, dataType, details.length)
-        }
-        case Left(_) => {
-          logger.error(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
-        }
-      }
+    data.foreach {
+      case (account: AwsAccount, Right(details: CredentialReportDisplay)) =>
+        putMetric(account, dataType, details.humanUsers.length + details.machineUsers.length)
+      case (account: AwsAccount, Right(details: List[Any])) =>
+        putMetric(account, dataType, details.length)
+      case (account: AwsAccount, Left(_)) =>
+        println(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
     }
   }
 

--- a/hq/app/logic/PublicBucketsDisplay.scala
+++ b/hq/app/logic/PublicBucketsDisplay.scala
@@ -74,7 +74,6 @@ object PublicBucketsDisplay {
 
   def accountBucketData(accountInfo: (AwsAccount, Either[FailedAttempt, List[BucketDetail]])):
       (AwsAccount, Either[FailedAttempt, (BucketReportSummary, List[BucketDetail])]) = {
-    println("Aadvanced programming skillz")
     accountInfo match {
       case (account, Right(bucketDetails)) => {
         val bucketsWithReportStatus = bucketDetails.map(

--- a/hq/app/logic/PublicBucketsDisplay.scala
+++ b/hq/app/logic/PublicBucketsDisplay.scala
@@ -74,6 +74,7 @@ object PublicBucketsDisplay {
 
   def accountBucketData(accountInfo: (AwsAccount, Either[FailedAttempt, List[BucketDetail]])):
       (AwsAccount, Either[FailedAttempt, (BucketReportSummary, List[BucketDetail])]) = {
+    println("Aadvanced programming skillz")
     accountInfo match {
       case (account, Right(bucketDetails)) => {
         val bucketsWithReportStatus = bucketDetails.map(

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -153,7 +153,7 @@ class CacheService(
           logMetric(account, dataType, details.length)
         }
         case Left(_) => {
-          println("left")
+          logger.error(s"Attempt to log cloudwatch metric failed. Data is missing for account ${account.name}.")
         }
       }
     }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -99,7 +99,7 @@ class CacheService(
     } yield {
       logger.info("Sending the refreshed data to the Credentials Box")
       credentialsBox.send(allCredentialReports.toMap)
-      Cloudwatch.logAsMetric(allCredentialReports, Cloudwatch.DataType.iamCredentialsTotal)
+      Cloudwatch.logMetricsForCredentialsReport(allCredentialReports)
     }
   }
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -26,8 +26,6 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import logging.Cloudwatch
-import logging.Cloudwatch.putMetric
-
 
 
 class CacheService(


### PR DESCRIPTION
## What does this change?

This makes Security HQ post the results of its data collection to cloudwatch as a metric. It's powering this [grafana dashboard](https://metrics.gutools.co.uk/d/RHAvkh8Gz/securityhq?orgId=1&from=now-2d&to=now). The data collected is based [on this original proposal](https://docs.google.com/document/d/1PIZC67-RymEYrtpOWLy18vAV8hRqjh67yBy4UezQoTQ/edit), but the key difference is in this PR I've only implemented 4 data types to reflect "totals". Namely

* Total number of S3 buckets `s3/total`
* Total number of IAM credentials marked red `iam/credentials/critical`
* Total number of IAM credentials marked amber `iam/credentials/warning`
* Total number of IAM credentials red or amber `iam/credentials/total`
* Total number of exposed keys `iam/keys/total`
* Total number of public security groups `securitygroup/total`

I'd be very keen on feedback for this, both on my dodgy scala code and the metrics themselves.

## What is the value of this?

To be able to answer questions like:

- Is the number of vulnerabilities trending up or down?
- Which teams have started fixing their issues?
- Is the number of public S3 buckets trending up or down?

## Will this require CloudFormation and/or updates to the AWS StackSet?

I completely forgot about this, but yes. It probably requires a CFN change to allow the server to post metrics to cloudwatch. No change on the StackSet.

## Any additional notes?

- Still need to think about increasing retention
- The total vulnerabilities per account chart is kind of busted. Need to understand if this is an issue with cloudwatch metrics or just a general challenge of adding timeseries data, which might require that total to be calculate at the source.


@katebee @philmcmahon 