### PR TITLE
chore: open HTTPS access on the load balancer to the AUS office

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -11,7 +11,7 @@ Metadata:
     - Label:
         default: Security
       Parameters:
-      - AccessRestrictionCidr
+      - GuardianIpBlock
     - Label:
         default: Networking
       Parameters:
@@ -35,9 +35,15 @@ Parameters:
   TLSCertArn:
     Description: ARN of a TLS certificate to install on the load balancer
     Type: String
-  AccessRestrictionCidr:
-    Description: CIDR block from which access to Security HQ should be allowed
+  GuardianIpBlock:
+    Description: CIDR block for Guardian IP addresses
     Type: String
+  GuardianAUIpBlock:
+    Type: String
+    Description: CIDR block for Guardian AU IP addresses
+  GuardianAUIpBlock2:
+    Type: String
+    Description: CIDR block for Guardian AU IP addresses
   Stage:
     Description: Application stage (e.g. PROD, CODE)
     Type: String
@@ -191,7 +197,17 @@ Resources:
         FromPort: 443
         ToPort: 443
         CidrIp:
-          Ref: AccessRestrictionCidr
+          Ref: GuardianIpBlock
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp:
+          Ref: GuardianAUIpBlock
+      - IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443
+        CidrIp:
+          Ref: GuardianAUIpBlock2
       Tags:
       - Key: Stack
         Value: !FindInMap [ Constants, Stack, Value ]


### PR DESCRIPTION
## What does this change?

Opens HTTPS (443) on the load balancer to the AUS office. Requested from Nick E via @mchv:

> Nick E in Aus seems unable to access security-hq from the Aus.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Colleagues can use the tool.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

n/a

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
