### PR TITLE
Manages missing GCP severity values and fixes styling

### DIFF
--- a/hq/app/logic/GcpDisplay.scala
+++ b/hq/app/logic/GcpDisplay.scala
@@ -21,7 +21,7 @@ object GcpDisplay {
         GcpFinding(
           getProjectNameFromUri(finding.getExternalUri).getOrElse("unknown"),
           finding.getCategory,
-          Option(finding.getSourcePropertiesOrDefault("SeverityLevel", Value.newBuilder.build).getStringValue),
+          getSeverity(finding.getSourcePropertiesOrDefault("SeverityLevel", Value.newBuilder.build).getStringValue),
           new DateTime(finding.getEventTime.getSeconds * 1000),
           Option(finding.getSourcePropertiesOrDefault("Explanation", Value.newBuilder.build).getStringValue),
           Option(finding.getSourcePropertiesOrDefault("Recommendation", Value.newBuilder.build).getStringValue)
@@ -38,9 +38,9 @@ object GcpDisplay {
       client.listFindings(request.build)
     }
 
-  val severities = List("High", "Medium", "Low")
+  val severities = List("High", "Medium", "Low", "Unknown")
   def sortFindings(findings: List[GcpFinding]): List[GcpFinding] = findings.sortBy{ finding =>
-    val severity = severities.indexOf(finding.severity.getOrElse("Low"))
+    val severity = severities.indexOf(finding.severity)
       val date = finding.eventTime.getMillis
     (severity, -date)
   }
@@ -49,4 +49,6 @@ object GcpDisplay {
       val regexPattern = new Regex("""(?<=project=).*""")
       regexPattern.findFirstIn(uri)
     }
+
+  def getSeverity(severityLevel: String): String = if (severityLevel == "") "Unknown" else severityLevel
 }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -202,7 +202,7 @@ case class GcpReport(reportDate: DateTime, finding: Map[String, Seq[GcpFinding]]
 case class GcpFinding(
   project: String,
   category: String,
-  severity: Option[String],
+  severity: String,
   eventTime: DateTime,
   explanation: Option[String],
   recommendation: Option[String]

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -36,5 +36,5 @@
         </table>
     </div>
 </div>
+    
 
-@*if(finding.severity.contains("")) {Unknown} else {@finding.severity} *@

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -338,8 +338,8 @@ table.iam-report__table th {
   box-sizing: initial;
 }
 
-gcp-report__table td,
-gcp-report__table th {
+table.gcp-report__table td,
+table.gcp-report__table th {
   min-height: 21px;
   box-sizing: initial;
   word-wrap: break-word;

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -351,7 +351,7 @@ table.gcp-report__table {
 }
 
 .gcp-table-row-severity {
-  width: 55px;
+  width: 65px;
 }
 
 .gcp-table-row-category {

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -345,7 +345,7 @@ gcp-report__table th {
   word-wrap: break-word;
 }
 
-gcp-report__table {
+table.gcp-report__table {
   table-layout: fixed;
   word-break: break-all;
 }


### PR DESCRIPTION
## What does this change?
I took a little too much of the CSS out of #198 post code review, which led to the table text overflowing out of the table. Adding the CSS back in here to fix it, so that the text remains within the table!

Also, this PR adds "Unknown" for missing severity values.