### PR TITLE
Allow Sec HQ to post metrics to cloudwatch

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -179,6 +179,19 @@ Resources:
           - sts:AssumeRole
       Roles:
       - !Ref SecurityHQInstanceRole
+      
+  CloudWatchMetrics:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: cloudwatch-put-metric
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - cloudwatch:PutMetricData
+      Roles:
+      - !Ref SecurityHQInstanceRole
 
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
## What does this change?
Lets Sec HQ post metrics to cloudwatch

## What is the value of this?

Getting #202 to actually work!

## Will this require CloudFormation and/or updates to the AWS StackSet?

Indeed!