### PR TITLE
Add filtering on severity

### DIFF
--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -40,6 +40,26 @@
 
 } { @* Main content *@
     <div class="container">
+        <div class="row flow-text">
+            <h3>GCP Security Findings</h3>
+            <p>Security Command Centre's findings display possible security risks for your GCP resources.</p>
+        </div>
+
+        <div class="row">
+            <div class="card-panel valign-wrapper">
+                <form class="finding-filter" action="#">
+                    <input class="js-finding-filter" type="checkbox" id="show-high-findings" checked="checked" />
+                    <label class="black-text finding-filter__label" for="show-high-findings">High</label>
+                    <input class="js-finding-filter" type="checkbox" id="show-medium-findings" />
+                    <label class="black-text finding-filter__label" for="show-medium-findings">Medium</label>
+                    <input class="js-finding-filter" type="checkbox" id="show-low-findings" />
+                    <label class="black-text finding-filter__label" for="show-low-findings">Low</label>
+                    <input class="js-finding-filter" type="checkbox" id="show-unknown-findings" />
+                    <label class="black-text finding-filter__label" for="show-unknown-findings">Unknown</label>
+                </form>
+            </div>
+        </div>
+
         <div class="row">
             <ul class="collapsible" data-collapsible="accordion">
                 @for((projectName, findings) <- report.finding.toList.sortBy(_._1)) {

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -48,13 +48,13 @@
         <div class="row">
             <div class="card-panel valign-wrapper">
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter" type="checkbox" id="show-high-findings" checked="checked" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-high-findings" checked="checked" />
                     <label class="black-text finding-filter__label" for="show-high-findings">High</label>
-                    <input class="js-finding-filter" type="checkbox" id="show-medium-findings" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-medium-findings" checked="checked" />
                     <label class="black-text finding-filter__label" for="show-medium-findings">Medium</label>
-                    <input class="js-finding-filter" type="checkbox" id="show-low-findings" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-low-findings" />
                     <label class="black-text finding-filter__label" for="show-low-findings">Low</label>
-                    <input class="js-finding-filter" type="checkbox" id="show-unknown-findings" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-unknown-findings" />
                     <label class="black-text finding-filter__label" for="show-unknown-findings">Unknown</label>
                 </form>
             </div>

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -24,7 +24,7 @@
             </thead>
             <tbody>
                 @for(finding <- findings) {
-                    <tr>
+                    <tr class="finding-@finding.severity.toLowerCase">
                         <td class="gcp-table-row-severity"><span>@finding.severity</span></td>
                         <td class="gcp-table-row-category"><span>@finding.category</span></td>
                         <td class="gcp-table-row-date"><span>@finding.eventTime.toString(GcpDisplay.dateTimePattern)</span></td>

--- a/hq/app/views/s3/publicBuckets.scala.html
+++ b/hq/app/views/s3/publicBuckets.scala.html
@@ -60,7 +60,7 @@
                 <span class="finding-header__name">Some buckets may not have encryption enabled for data at rest</span>
 
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter" type="checkbox" id="show-unencrypted-findings" checked="checked" />
+                    <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" />
                     <label class="black-text finding-filter__label" for="show-unencrypted-findings">Show all unencrypted buckets</label>
                 </form>
             </div>

--- a/hq/app/views/s3/publicBucketsAccount.scala.html
+++ b/hq/app/views/s3/publicBucketsAccount.scala.html
@@ -73,7 +73,7 @@
                                 Some buckets may not have encryption enabled for data at rest</span>
 
                             <form class="finding-filter" action="#">
-                                <input class="js-finding-filter" type="checkbox" id="show-unencrypted-findings" checked="checked" />
+                                <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" />
                                 <label class="black-text finding-filter__label" for="show-unencrypted-findings">
                                     Show all unencrypted buckets</label>
                             </form>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -36,6 +36,7 @@ $(document).ready(function() {
     }
   );
 
+  // filtering table results
   $('.js-finding-filter').change(function() {
     $('#show-ignored-findings')[0].checked
       ? $('.finding-suppressed--true').show()
@@ -43,9 +44,25 @@ $(document).ready(function() {
     $('#show-flagged-findings')[0].checked
       ? $('.finding-suppressed--false').show()
       : $('.finding-suppressed--false').hide();
+  });
+  $('.js-finding-filter-for-s3').change(function() {
     $('#show-unencrypted-findings')[0].checked
       ? $('.finding-unencrypted').show()
       : $('.finding-unencrypted').hide();
+  });
+  $('.js-finding-filter-for-gcp').change(function() {
+    $('#show-high-findings')[0].checked
+        ? $('.finding-high').show()
+        : $('.finding-high').hide();
+    $('#show-medium-findings')[0].checked
+        ? $('.finding-medium').show()
+        : $('.finding-medium').hide();
+    $('#show-low-findings')[0].checked
+        ? $('.finding-low').show()
+        : $('.finding-low').hide();
+    $('#show-unknown-findings')[0].checked
+        ? $('.finding-unknown').show()
+        : $('.finding-unknown').hide();
   });
 
   $('.js-finding-details').click(function() {

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -338,30 +338,6 @@ table.iam-report__table th {
   box-sizing: initial;
 }
 
-table.gcp-report__table td,
-table.gcp-report__table th {
-  min-height: 21px;
-  box-sizing: initial;
-  word-wrap: break-word;
-}
-
-table.gcp-report__table {
-  table-layout: fixed;
-  word-break: break-all;
-}
-
-.gcp-table-row-severity {
-  width: 65px;
-}
-
-.gcp-table-row-category {
-  width: 130px;
-}
-
-.gcp-table-row-date {
-  width: 65px;
-}
-
 .iam-modal__trigger {
   height: 24px;
 }
@@ -393,8 +369,6 @@ table.gcp-report__table {
   margin-left: 10px;
 }
 
-
-
 .doc-content h1 {
   font-size: 2.5rem;
 }
@@ -423,3 +397,27 @@ table.gcp-report__table {
   height: 40px;
 }
 
+/* GCP */
+table.gcp-report__table td,
+table.gcp-report__table th {
+  min-height: 21px;
+  box-sizing: initial;
+  word-wrap: break-word;
+}
+
+table.gcp-report__table {
+  table-layout: fixed;
+  word-break: break-all;
+}
+
+.gcp-table-row-severity {
+  width: 65px;
+}
+
+.gcp-table-row-category {
+  width: 130px;
+}
+
+.gcp-table-row-date {
+  width: 65px;
+}

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -398,14 +398,14 @@ table.iam-report__table th {
 }
 
 /* GCP */
-table.gcp-report__table td,
-table.gcp-report__table th {
+.gcp-report__table td,
+.gcp-report__table th {
   min-height: 21px;
   box-sizing: initial;
   word-wrap: break-word;
 }
 
-table.gcp-report__table {
+.gcp-report__table {
   table-layout: fixed;
   word-break: break-all;
 }


### PR DESCRIPTION
## What does this change?
This PR adds checkboxes to filter GCP security findings by severity.

<img width="1080" alt="Screenshot 2021-03-19 at 18 05 00" src="https://user-images.githubusercontent.com/42121379/111824135-b2921480-88dd-11eb-8589-4380ec413457.png">