### PR TITLE
Set loglevel to info

### DIFF
--- a/hq/app/logging/LogConfig.scala
+++ b/hq/app/logging/LogConfig.scala
@@ -3,7 +3,6 @@ package logging
 import java.net.InetSocketAddress
 
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.{Logger => LogbackLogger}
 import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
@@ -99,7 +98,6 @@ object LogConfig {
             appender.setCredentialsProvider(buildCredentialsProvider(stsRole, config))
             appender.start()
             rootLogger.addAppender(appender)
-            rootLogger.setLevel(Level.INFO)
             rootLogger.info("Initialised remote log shipping")
           }
           case _ => rootLogger.info(s"Missing remote logging configuration streamName=${config.streamName} stsRole=${config.stsRole}")

--- a/hq/app/logging/LogConfig.scala
+++ b/hq/app/logging/LogConfig.scala
@@ -3,6 +3,7 @@ package logging
 import java.net.InetSocketAddress
 
 import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.{Logger => LogbackLogger}
 import com.amazonaws.auth.{InstanceProfileCredentialsProvider, STSAssumeRoleSessionCredentialsProvider}
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder
@@ -98,6 +99,7 @@ object LogConfig {
             appender.setCredentialsProvider(buildCredentialsProvider(stsRole, config))
             appender.start()
             rootLogger.addAppender(appender)
+            rootLogger.setLevel(Level.INFO)
             rootLogger.info("Initialised remote log shipping")
           }
           case _ => rootLogger.info(s"Missing remote logging configuration streamName=${config.streamName} stsRole=${config.stsRole}")

--- a/hq/conf/logback.xml
+++ b/hq/conf/logback.xml
@@ -33,7 +33,7 @@
   <logger name="com.avaje.ebeaninternal.server.lib.BackgroundThread" level="OFF" />
   <logger name="com.gargoylesoftware.htmlunit.javascript" level="OFF" />
 
-  <root level="WARN">
+  <root level="INFO">
     <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>


### PR DESCRIPTION
## What does this change?

This modifies both what gets printed to the console and gets sent to central elk.

## What is the value of this?

Currently, central elk is not getting much of anything sent to it, so the data isn't very useful!

When developing locally, it's useful to see more logs in the console than just errors

## Will this require CloudFormation and/or updates to the AWS StackSet?

No
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->
