### PR TITLE
Move cloudwatch code to its own MetricService

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -19,7 +19,7 @@ import play.api.routing.Router
 import play.api.{BuiltInComponentsFromContext, Logging}
 import play.filters.csrf.CSRFComponents
 import router.Routes
-import services.CacheService
+import services.{CacheService, MetricService}
 import utils.attempt.Attempt
 
 import scala.concurrent.Await
@@ -115,6 +115,13 @@ class AppComponents(context: Context)
     efsClients,
     availableRegions,
     securityCenterClient
+  )
+
+  new MetricService(
+    configuration,
+    applicationLifecycle,
+    environment,
+    cacheService
   )
 
   override def router: Router = new Routes(

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -26,8 +26,8 @@ object Cloudwatch extends Logging {
     val sgTotal = Value("securitygroup/total")
   }
 
-  def logMetricsForCredentialsReport(data: Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])] ) : Unit = {
-    data.foreach {
+  def logMetricsForCredentialsReport(data: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] ) : Unit = {
+    data.toSeq.foreach {
       case (account: AwsAccount, Right(details: CredentialReportDisplay)) =>
         val reportSummary: CredentialsReportDisplay.ReportSummary = reportStatusSummary(details)
         putMetric(account, DataType.iamCredentialsCritical, reportSummary.errors)
@@ -38,9 +38,9 @@ object Cloudwatch extends Logging {
     }
   }
 
-  def logAsMetric[T](data: Seq[T], dataType: DataType.Value ) : Unit = {
-    data.foreach {
-      case (account: AwsAccount, Right(details: List[Any])) =>
+  def logAsMetric[T](data: Map[AwsAccount, Either[FailedAttempt, List[T]]], dataType: DataType.Value ) : Unit = {
+    data.toSeq.foreach {
+      case (account: AwsAccount, Right(details: List[T])) =>
         putMetric(account, dataType, details.length)
       case (account: AwsAccount, Left(_)) =>
         logger.error(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -99,7 +99,6 @@ class CacheService(
     } yield {
       logger.info("Sending the refreshed data to the Credentials Box")
       credentialsBox.send(allCredentialReports.toMap)
-      Cloudwatch.logMetricsForCredentialsReport(allCredentialReports)
     }
   }
 
@@ -110,7 +109,6 @@ class CacheService(
     } yield {
       logger.info("Sending the refreshed data to the Public Buckets Box")
       publicBucketsBox.send(allPublicBuckets.toMap)
-      Cloudwatch.logAsMetric(allPublicBuckets, Cloudwatch.DataType.s3Total)
     }
   }
 
@@ -121,7 +119,6 @@ class CacheService(
     } yield {
       logger.info("Sending the refreshed data to the Exposed Keys Box")
       exposedKeysBox.send(allExposedKeys.toMap)
-      Cloudwatch.logAsMetric(allExposedKeys, Cloudwatch.DataType.iamKeysTotal)
     }
   }
 
@@ -133,7 +130,6 @@ class CacheService(
     } yield {
       logger.info("Sending the refreshed data to the Security Groups Box")
       sgsBox.send(allFlaggedSgs.toMap)
-      Cloudwatch.logAsMetric(allFlaggedSgs, Cloudwatch.DataType.sgTotal)
     }
   }
 

--- a/hq/app/services/MetricService.scala
+++ b/hq/app/services/MetricService.scala
@@ -1,0 +1,59 @@
+package services
+
+import logging.Cloudwatch
+import model._
+import play.api._
+import play.api.inject.ApplicationLifecycle
+import rx.lang.scala.Observable
+import utils.attempt.FailedAttempt
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class MetricService(
+    config: Configuration,
+    lifecycle: ApplicationLifecycle,
+    environment: Environment,
+    cacheService: CacheService
+  )(implicit ec: ExecutionContext) extends Logging {
+
+  def dataMissingFrom[T](list: List[Map[AwsAccount, Either[FailedAttempt, T]]]): Boolean = {
+    list.exists { dataMap =>
+      dataMap.toSeq.exists(_._2.isLeft)
+    }
+  }
+
+  def postCachedContentsAsMetrics(): Unit = {
+    val allSgs = cacheService.getAllSgs
+    val allExposedKeys = cacheService.getAllExposedKeys
+    val allPublicBuckets = cacheService.getAllPublicBuckets
+    val allCredentials = cacheService.getAllCredentials
+
+    if(dataMissingFrom(List(allSgs, allExposedKeys, allPublicBuckets, allCredentials))) {
+      logger.info("At least part of the data is missing - skipping cloudwatch update!")
+      return
+    }
+
+    Cloudwatch.logAsMetric(allSgs, Cloudwatch.DataType.sgTotal)
+    Cloudwatch.logAsMetric(allExposedKeys, Cloudwatch.DataType.iamKeysTotal)
+    Cloudwatch.logAsMetric(allPublicBuckets, Cloudwatch.DataType.s3Total)
+    Cloudwatch.logMetricsForCredentialsReport(allCredentials)
+  }
+
+  if (environment.mode != Mode.Test) {
+    val initialDelay =
+      if (environment.mode == Mode.Prod) 5.minutes
+      else Duration.Zero
+
+    val cloudwatchSubscription = Observable.interval(initialDelay, 6.hours).subscribe { _ =>
+      logger.info("Posting new metrics to cloudwatch")
+      postCachedContentsAsMetrics()
+    }
+
+    lifecycle.addStopHook { () =>
+      cloudwatchSubscription.unsubscribe()
+      Future.successful(())
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?

This PR changes the data collection approach quite a bit. Instead of piggy backing off the existing CacheService, which has a refresh cadence of 5 minute updates for security groups and S3 and 90 minutes for iam, this PR creates an independent MetricService which runs once every 6 hours and fetches the latest data produced my CacheService.

## What is the value of this?

The value is twofold.

First, posting new metrics every 5 minutes is unnecessary for this data's usecase. It's too much resolution for a dataset where we care about daily and weekly trends. We also hit cloudwatch limits when trying to retrieve weeks of data if there's too many datapoints.

Secondly, this PR avoids posting to cloudwatch if the dataset is incomplete. This is slightly counter intuitive, at first glance that's not good because it means we're going to miss a datapoint. Even though that's true, by guaranteeing that every time we post we post everything we make it meaningful to sum different timeseries streams.

Consider this example. We're interested in tracking the total vulnerabilities that the dotcom team still have to fix

| Time | Account  | Security groups | Exposed keys | Total Vulnerabilities |
| -------------| ------------- | ------------- | ------------- | ------------- | 
| 1pm | Frontend  | 5  | 2  | 7  |
| 2pm | Frontend  | 5  | MISSING  | 5  |
| 3pm | Frontend  | 5  | 1  | 6  |

The fact that exposed keys is missing makes the Total Vulnerabilities number unstable. At 2pm it looks like 2 vulnerabilities were fixed and then 1 new was introduced at 3pm.


But if we reject the datapoint

| Time | Account  | Security groups | Exposed keys | Total Vulnerabilities |
| -------------| ------------- | ------------- | ------------- | ------------- | 
| 1pm | Frontend  | 5  | 2  | 7  |
| 3pm | Frontend  | 5  | 1  | 6  |

We get a stable trend that shows an issue was fixed at 3pm.

I'd propose the solution to get the 2pm datapoint is not to post partial datasets, but to re engineer Security HQ to provide stale data when the data refresh process fails.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

