### PR TITLE
How to integrate Snyk using GitHub Actions

### DIFF
--- a/hq/markdown/snyk.md
+++ b/hq/markdown/snyk.md
@@ -25,14 +25,15 @@ section of the dashboard).
 
 ## Integrating Snyk with your project(s)
 
-By far the most effective way to integrate Snyk is through GitHub Actions. Here's how to do it:
+By far the most effective way to integrate Snyk is through GitHub Actions. You can also add projects via the Snyk UI, but that method has it's limitation and it's less accurate. Here's how to do it using GH Actions:
 
 1. Make sure your repo has the `SNYK_TOKEN` available under 'Organization secrets' (Go to Settings -> Secrets). If it does not, ask an engineering manager to enable it for your repo.
 1. Create a file called `snyk.yml` in the `/.github/workflows/` folder of your repo. Paste one the appropriate code snippets from below into your new file.
-1. Edit the `org` argument in the code snippet to your org's code. We have several organisations in our Snyk account. The code snippet bellow uses the Reader Revenue's code. To get your organisation's code go to the [Snyk dashboard](https://app.snyk.io/org/), select the org you want then obtain the code from the URL.
+1. Edit the `org` argument in the code snippet to your org's code. We have several organisations in our Snyk account. To get your organisation's code go to the [Snyk dashboard](https://app.snyk.io/org/), select the org you want then obtain the code from the URL.  
+![image](https://user-images.githubusercontent.com/48949546/112194614-f6985880-8c00-11eb-946f-a88fdae57662.jpg)
 1. If your package file does not live in the main folder you will need to add a `--file` argument, such as the one in the Node example below. 
 
-![image](https://user-images.githubusercontent.com/48949546/112194614-f6985880-8c00-11eb-946f-a88fdae57662.jpg)
+
 
 
 Setting up this Action will take care of updating your project's entry in snyk.io daily or whenever a new push to `main` takes place. It will also add feedback to commits and PRs, showing developers if their branch has any security vulnerabilities.
@@ -69,7 +70,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=the-guardian-cuu --project-name=${{ github.repository }} --file=./app/yarn.lock
+          args: --org=REPLACE_WITH_YOUR_ORG --project-name=${{ github.repository }} --file=./app/yarn.lock
           command: ${{ env.SNYK_COMMAND }}
 
 ```
@@ -106,7 +107,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --org=the-guardian-cuu --project-name=${{ github.repository }}
+          args: --org=REPLACE_WITH_YOUR_ORG --project-name=${{ github.repository }}
           command: ${{ env.SNYK_COMMAND }}
 ```
 

--- a/hq/markdown/snyk.md
+++ b/hq/markdown/snyk.md
@@ -25,11 +25,90 @@ section of the dashboard).
 
 ## Integrating Snyk with your project(s)
 
-By far the easiest way to use Snyk to test a project is to use their Github integration. 
+By far the most effective way to integrate Snyk is through GitHub Actions. Here's how to do it:
 
-In [the Snyk dashboard](https://snyk.io/) choose the organisation that the project should be part of,
-you can add a new project from there. You will need to be an administrator of the Github repository to integrate
-Snyk so that it can create a webhook to re-test the project for each Pull Requests.
+1. Make sure your repo has the `SNYK_TOKEN` available under 'Organization secrets' (Go to Settings -> Secrets). If it does not, ask an engineering manager to enable it for your repo.
+1. Create a file called `snyk.yml` in the `/.github/workflows/` folder of your repo. Paste one the appropriate code snippets from below into your new file.
+1. Edit the `org` argument in the code snippet to your org's code. We have several organisations in our Snyk account. The code snippet bellow uses the Reader Revenue's code. To get your organisation's code go to the [Snyk dashboard](https://app.snyk.io/org/), select the org you want then obtain the code from the URL.
+1. If your package file does not live in the main folder you will need to add a `--file` argument, such as the one in the Node example below. 
+
+![image](https://user-images.githubusercontent.com/48949546/112194614-f6985880-8c00-11eb-946f-a88fdae57662.jpg)
+
+
+Setting up this Action will take care of updating your project's entry in snyk.io daily or whenever a new push to `main` takes place. It will also add feedback to commits and PRs, showing developers if their branch has any security vulnerabilities.
+
+
+### Node
+```
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  push:
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      SNYK_COMMAND: test
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set command to monitor
+        if: github.ref == 'refs/heads/main'
+        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=${{ github.repository }} --file=./app/yarn.lock
+          command: ${{ env.SNYK_COMMAND }}
+
+```
+
+### Scala 
+
+```
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      SNYK_COMMAND: test
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set command to monitor
+        if: github.ref == 'refs/heads/main'
+        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=the-guardian-cuu --project-name=${{ github.repository }}
+          command: ${{ env.SNYK_COMMAND }}
+```
 
 ## Eliminating Vulnerabilities
 


### PR DESCRIPTION
## What does this change?
This PR changes the instructions on how to integrate Snyk to use GitHubs Actions instead of Snyk's GitHub integration.


## What is the value of this?
Snyk's GitHub integration can lead to number of issues, such as lack of immediate feedback or repo scans failing silently. This often leads developers to opt by using CLI integration alongside it. However, CLI integration also has its shortcomings and limitations.
Furthermore, using one or both of these integrations mean that the Snyk config is spread through different systems (Snyk website, GitHub hooks config, local scripts, TeamCity build steps, etc.), making it difficult for new developers to easily understand the Snyk workflow. 

Using GitHub Action to run Snyk solves these and other issues, making it the superior choice for integration.
It consistently updates snyk.io so the state of the repo can be tracked over time and vulnerabilities handled during the team's Snyk rota, it presents developers with clear and immediate information on whether vulnerabilities are present when they submit code, and keeps all of the Snyk related config alongside the code it's corresponds to.
