### PR TITLE
Run Snyk as a GitHub Action

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,32 @@
+# This action runs every day at 6 AM and on every push
+# If the branch it's running on is main then it will run snyk monitor (reports vulnerabilities to snyk.io)
+# Otherwise it will run snyk test
+name: Snyk
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  push:
+  workflow_dispatch:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    env:
+      SNYK_COMMAND: test
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v2
+
+      - name: Set command to monitor
+        if: github.ref == 'refs/heads/main'
+        run: echo "SNYK_COMMAND=monitor" >> $GITHUB_ENV
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/scala@0.3.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --org=guardian-security --project-name=${{ github.repository }}
+          command: ${{ env.SNYK_COMMAND }}
+          


### PR DESCRIPTION
## What does this change?
Run Snyk as a GitHub Action.

Notes:
- I do not have access to the org in snyk.io but I believe `guardian-security` is the one this repo is under. If someone with access could confirm it before this is merged it would be great though.
- I do have access to this repo's settings to check if `SNYK_TOKEN` is available. I believe it is but if someone with access could double check I'd appreciate it.

## What is the value of this?
Implements the the preferred method of integrating Snyk introduced in PR #212.

## Clean up
After this is merged and confirmed working the original project entry in snyk.io and the Snyk hook configured in GitHub can be removed. If there are any build steps in TeamCity that run Snyk, those can be removed too.