### PR TITLE
adds dummy data for /gcp

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -208,4 +208,19 @@ case class GcpFinding(
   recommendation: Option[String]
 )
 
+//TODO delete after /gcp dev work complete
+object GcpFinding {
+  val longText: String = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+  val test: List[GcpFinding] = List(
+    GcpFinding("TEST PROJECT A", "TEST", "High", DateTime.now, Some(longText), Some("TEST")),
+    GcpFinding("TEST PROJECT A", "TEST", "Medium", DateTime.now, Some("TEST"), Some(longText)),
+    GcpFinding("TEST PROJECT A", "TEST", "Low", DateTime.now, Some("TEST"), Some("TEST")),
+    GcpFinding("TEST PROJECT A", "TEST", "Unknown", DateTime.now, Some("TEST"), Some("TEST")),
+    GcpFinding("TEST PROJECT B", "TEST", "High", DateTime.now, Some("TEST"), Some("TEST")),
+    GcpFinding("TEST PROJECT B", "TEST", "Medium", DateTime.now, Some("TEST"), Some("TEST")),
+    GcpFinding("TEST PROJECT B", "TEST", "Low", DateTime.now, Some("TEST"), Some(longText)),
+    GcpFinding("TEST PROJECT B", "TEST", "Unknown", DateTime.now, Some(longText), Some("TEST")),
+  )
+}
+
 case class GcpSccConfig(orgId: String, sourceId: String)

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -25,7 +25,6 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import logging.Cloudwatch
 
 
 class CacheService(
@@ -145,12 +144,17 @@ class CacheService(
 
   def refreshGcpBox(): Unit = {
     logger.info("Started refresh of GCP data")
-    val organisation = OrganizationName.of(Config.gcpSccAuthentication(config).orgId)
-    for {
-      gcpFindings <- GcpDisplay.getGcpFindings(organisation, gcpClient, config)
-    } yield {
-      logger.info("Sending the refreshed data to the GCP Box")
-      gcpBox.send(Attempt.Right(gcpFindings))
+    config.getOptional[String]("stage") match {
+      case Some("DEV") =>
+        gcpBox.send(Attempt.Right(GcpFinding.test))
+      case _ =>
+        val organisation = OrganizationName.of(Config.gcpSccAuthentication(config).orgId)
+        for {
+          gcpFindings <- GcpDisplay.getGcpFindings(organisation, gcpClient, config)
+        } yield {
+          logger.info("Sending the refreshed data to the GCP Box")
+          gcpBox.send(Attempt.Right(gcpFindings))
+        }
     }
   }
 


### PR DESCRIPTION
## What does this change?
This PR returns test data for /gcp when running SHQ locally. 

## What is the value of this?
It should make development work on /gcp easier whilst improving the styling of the page. Prior to this change, it was taking around 4 minutes to return the data from the GCP API.

## Any additional notes?
I attend to revert this commit once I've completed my styling work.