### PR TITLE
Shows severity value icon on /gcp if greater than zero

### DIFF
--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -68,14 +68,22 @@
                     <div class="collapsible-header" tabindex="22">
                     <i class="material-icons">keyboard_arrow_down</i>
                     <span class="iam-header__name">@projectName</span>
-                        <span class="icon-count">@findings.count(_.severity == "High")</span>
-                        <i class="material-icons red-text">error</i>
-                        <span class="icon-count">@findings.count(_.severity == "Medium")</span>
-                        <i class="material-icons orange-text">warning</i>
-                        <span class="icon-count">@findings.count(_.severity == "Low")</span>
-                        <i class="material-icons yellow-text">priority_high</i>
-                        <span class="icon-count">@findings.count(_.severity == "Unknown")</span>
-                        <i class="material-icons grey-text">not_listed_location</i>
+                        @if(findings.exists(_.severity == "High")) {
+                            <span class="icon-count">@findings.count(_.severity == "High")</span>
+                            <i class="material-icons red-text">error</i>
+                        }
+                        @if(findings.exists(_.severity == "Medium")) {
+                            <span class="icon-count">@findings.count(_.severity == "Medium")</span>
+                            <i class="material-icons orange-text">warning</i>
+                        }
+                        @if(findings.exists(_.severity == "Low")) {
+                            <span class="icon-count">@findings.count(_.severity == "Low")</span>
+                            <i class="material-icons yellow-text">priority_high</i>
+                        }
+                        @if(findings.exists(_.severity == "Unknown")) {
+                            <span class="icon-count">@findings.count(_.severity == "Unknown")</span>
+                            <i class="material-icons grey-text">not_listed_location</i>
+                        }
                     </div>
                     <div class="collapsible-body">
                     @views.html.gcp.gcpReportBody(GcpDisplay.sortFindings(findings.toList), report.reportDate)


### PR DESCRIPTION
## What does this change?
This PR changes the showing of the severity value summary icon on each row of the /gcp table. Now the icon is only shown when this value is great than zero. This is an improvement on PR https://github.com/guardian/security-hq/pull/217.

<img width="1031" alt="Screenshot 2021-04-06 at 06 39 33" src="https://user-images.githubusercontent.com/42121379/113664121-1ae54200-96a3-11eb-87c5-0c47f1b866b4.png">

## What is the value of this?
This is so much better than when we were showing each icon everytime, because there is less noise on the UI. It's easier to see where the red high severity findings are. Hopefully this should make it easier for developers to see at a glance where they should prioritise their gcp security efforts.

Also, this change follows the pattern already used in SHQ in the S3 buckets and IAM report tables.
