### PR TITLE
Friendly error msg whilst GCP cache loading

### DIFF
--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -50,7 +50,7 @@ class CacheService(
   private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(startingCache)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
   private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("cache").attempt)))
-  private val gcpBox: Box[Attempt[List[GcpFinding]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("").attempt)))
+  private val gcpBox: Box[Attempt[List[GcpFinding]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorGcp("GCP").attempt)))
 
   def getAllPublicBuckets: Map[AwsAccount, Either[FailedAttempt, List[BucketDetail]]] = publicBucketsBox.get()
 

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -64,6 +64,12 @@ object Failure {
     Failure(details, friendlyMessage, 500)
   }
 
+  def cacheServiceErrorGcp(cacheContent: String): Failure = {
+    val details = s"Cache service error; unable to retrieve $cacheContent"
+    val friendlyMessage = s"Oops! We're still loading the $cacheContent data. Please refresh the page shortly."
+    Failure(details, friendlyMessage, 500)
+  }
+
   def contextString(clientContext: AwsClient[_]): String = {
     val acc = s"account: ${clientContext.account.name}"
     val reg = s"region: ${clientContext.region.name}"


### PR DESCRIPTION
## What does this change?
The current error message on /gcp is misleading as it says `error-missing data` and doesn't tell the user how they should remediate this problem. 

We've made the message friendlier and given the user an action to take.

<img width="1065" alt="Screenshot 2021-04-07 at 05 21 25" src="https://user-images.githubusercontent.com/42121379/113810230-b210cf00-9761-11eb-82ca-29a2569e9998.png">
