### PR TITLE
Adds Read more/less toggle button

### DIFF
--- a/hq/app/logic/GcpDisplay.scala
+++ b/hq/app/logic/GcpDisplay.scala
@@ -51,4 +51,8 @@ object GcpDisplay {
     }
 
   def getSeverity(severityLevel: String): String = if (severityLevel == "") "Unknown" else severityLevel
+
+  def preview(s: String, n: Int): String = {
+    if (s.length <= n) s else s.take(s.lastIndexWhere(_.isSpaceChar, n + 1)).trim
+  }
 }

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -28,28 +28,21 @@
                         <td class="gcp-table-row-severity"><span>@finding.severity</span></td>
                         <td class="gcp-table-row-category"><span>@finding.category</span></td>
                         <td class="gcp-table-row-date"><span>@finding.eventTime.toString(GcpDisplay.dateTimePattern)</span></td>
-                        <td><span>@finding.explanation</span></td>
                         <td>
-                        @*if the text is less than 40 chars, show it*@
-                        @if(finding.recommendation.getOrElse("").length < 30) {
-                            <span class="unaltered-short">@finding.recommendation</span>} else {
-                            @*if not, trim the text to show only 40 chars and add ... to the end*@
-                            <span class="truncated">@GcpDisplay.preview(finding.recommendation.getOrElse(""), 30)</span>
-                            <span class="full-text">@finding.recommendation</span>
-                            <span class="js-read-more btn usage-cta truncate">Read More</span>}
+                            @if(finding.explanation.getOrElse("").length < 30) {
+                                <span class="unaltered-short">@finding.explanation</span>} else {
+                                <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(finding.explanation.getOrElse(""), 30)</span>
+                                <span class="gcp-toggle gcp-full-text">@finding.explanation</span>
+                                <span class="js-read-more btn">Read More/Less</span>
+                            }
                         </td>
-                            @*in the td:
-                                span 0 = unaltered-short
-                                span 1 = truncated
-                                span 2 = full text (css: hidden by default)
-                                span 3 = read more button
-                            add *click handler* to read more button (when clicked, shown span 2, hide span 1)
-                            https://api.jquery.com/click/
-                                *find parent*
-                            https://api.jquery.com/parent/
-                            *find the children with certain class names*
-                            https://api.jquery.com/find/
-                            *@
+                        <td>
+                            @if(finding.recommendation.getOrElse("").length < 30) {
+                                <span class="unaltered-short">@finding.recommendation</span>} else {
+                                <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(finding.recommendation.getOrElse(""), 30)</span>
+                                <span class="gcp-toggle gcp-full-text">@finding.recommendation</span>
+                                <span class="js-read-more btn">Read More/Less</span>}
+                        </td>
                         }
                     </tr>
             </tbody>

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -33,7 +33,9 @@
                                 <span class="unaltered-short">@finding.explanation</span>} else {
                                 <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(finding.explanation.getOrElse(""), 30)</span>
                                 <span class="gcp-toggle gcp-full-text">@finding.explanation</span>
-                                <span class="js-read-more btn">Read More/Less</span>
+                                <button class="js-read-more mdc-button">
+                                    <span class="mdc-button__label">Read More/Less</span>
+                                </button>
                             }
                         </td>
                         <td>
@@ -41,7 +43,9 @@
                                 <span class="unaltered-short">@finding.recommendation</span>} else {
                                 <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(finding.recommendation.getOrElse(""), 30)</span>
                                 <span class="gcp-toggle gcp-full-text">@finding.recommendation</span>
-                                <span class="js-read-more btn">Read More/Less</span>}
+                                <button class="js-read-more mdc-button">
+                                    <span class="mdc-button__label">Read More/Less</span>}
+                                </button>
                         </td>
                         }
                     </tr>

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -29,23 +29,27 @@
                         <td class="gcp-table-row-category"><span>@finding.category</span></td>
                         <td class="gcp-table-row-date"><span>@finding.eventTime.toString(GcpDisplay.dateTimePattern)</span></td>
                         <td>
-                            @if(finding.explanation.getOrElse("").length < 30) {
-                                <span class="unaltered-short">@finding.explanation</span>} else {
-                                <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(finding.explanation.getOrElse(""), 30)</span>
-                                <span class="gcp-toggle gcp-full-text">@finding.explanation</span>
-                                <button class="js-read-more mdc-button">
-                                    <span class="mdc-button__label">Read More/Less</span>
-                                </button>
+                            @finding.explanation.map{ explanation =>
+                                @if(explanation.length < 30) {
+                                    <span class="unaltered-short">@finding.explanation</span>} else {
+                                    <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(explanation, 30)</span>
+                                    <span class="gcp-toggle gcp-full-text">@explanation</span>
+                                    <button class="js-read-more mdc-button">
+                                        <span class="mdc-button__label">Read More/Less</span>
+                                    </button>
+                                }
                             }
                         </td>
                         <td>
-                            @if(finding.recommendation.getOrElse("").length < 30) {
-                                <span class="unaltered-short">@finding.recommendation</span>} else {
-                                <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(finding.recommendation.getOrElse(""), 30)</span>
-                                <span class="gcp-toggle gcp-full-text">@finding.recommendation</span>
+                            @finding.recommendation.map{ recommendation =>
+                            @if(recommendation.length < 30) {
+                                <span class="unaltered-short">recommendation</span>} else {
+                                <span class="gcp-toggle gcp-truncated">@GcpDisplay.preview(recommendation, 30)</span>
+                                <span class="gcp-toggle gcp-full-text">@recommendation</span>
                                 <button class="js-read-more mdc-button">
                                     <span class="mdc-button__label">Read More/Less</span>}
                                 </button>
+                            }
                         </td>
                         }
                     </tr>

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -36,7 +36,7 @@
                             @*if not, trim the text to show only 40 chars and add ... to the end*@
                             <span class="truncated">@GcpDisplay.preview(finding.recommendation.getOrElse(""), 30)</span>
                             <span class="full-text">@finding.recommendation</span>
-                            <span class="js-read-more">...Read More</span>}
+                            <span class="js-read-more btn usage-cta truncate">Read More</span>}
                         </td>
                             @*in the td:
                                 span 0 = unaltered-short

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -29,9 +29,29 @@
                         <td class="gcp-table-row-category"><span>@finding.category</span></td>
                         <td class="gcp-table-row-date"><span>@finding.eventTime.toString(GcpDisplay.dateTimePattern)</span></td>
                         <td><span>@finding.explanation</span></td>
-                        <td><span>@finding.recommendation</span></td>
+                        <td>
+                        @*if the text is less than 40 chars, show it*@
+                        @if(finding.recommendation.getOrElse("").length < 30) {
+                            <span class="unaltered-short">@finding.recommendation</span>} else {
+                            @*if not, trim the text to show only 40 chars and add ... to the end*@
+                            <span class="truncated">@GcpDisplay.preview(finding.recommendation.getOrElse(""), 30)</span>
+                            <span class="full-text">@finding.recommendation</span>
+                            <span class="js-read-more">...Read More</span>}
+                        </td>
+                            @*in the td:
+                                span 0 = unaltered-short
+                                span 1 = truncated
+                                span 2 = full text (css: hidden by default)
+                                span 3 = read more button
+                            add *click handler* to read more button (when clicked, shown span 2, hide span 1)
+                            https://api.jquery.com/click/
+                                *find parent*
+                            https://api.jquery.com/parent/
+                            *find the children with certain class names*
+                            https://api.jquery.com/find/
+                            *@
+                        }
                     </tr>
-                }
             </tbody>
         </table>
     </div>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -119,4 +119,9 @@ $(document).ready(function() {
       );
   });
   $('.tooltipped').tooltip({enterDelay: 0, inDuration: 100});
+
+  // Functionality for the GCP table
+  $('.js-read-more').click(function() {
+    $(this).parent().find('.gcp-toggle').toggle();
+  });
 });

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -421,3 +421,7 @@ table.iam-report__table th {
 .gcp-table-row-date {
   width: 65px;
 }
+
+.gcp-full-text {
+  display: none
+}


### PR DESCRIPTION
## What does this change?
This PR adds a read more/less toggle button to text inside the GCP table.

<img width="1020" alt="Screenshot 2021-04-07 at 13 50 10" src="https://user-images.githubusercontent.com/42121379/113869049-3423e680-97a8-11eb-9fac-2e90d14e9a50.png">

## What is the value of this?
Quite a lot of text is returned in some of the cells, so this toggle button should make it easier for users to select the text they want to see and skim over what they don't need to read.

