### PR TITLE
Add notifier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val hq = (project in file("hq"))
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
+      "org.quartz-scheduler" % "quartz" % "2.3.2",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "org.scalatest" %% "scalatest" % "3.0.5" % Test,
       "com.typesafe.play" %% "play-json" % playVersion,
-      "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0",
+      "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
       "ch.qos.logback" %  "logback-classic" % "1.2.3",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     )

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,6 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark" % "0.62.2",
       "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
-      "com.vladsch.flexmark" % "flexmark" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,8 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-efs" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark" % "0.62.2",
+      "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
+      "com.vladsch.flexmark" % "flexmark" % "0.28.20",
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
@@ -48,6 +50,7 @@ lazy val hq = (project in file("hq"))
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,
+      "com.gu" % "anghammarad-client_2.12" % "1.1.2",
 
       // logstash-logback-encoder brings in version 2.11.0
       // exclude transitive dependency to avoid a runtime exception:

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -209,3 +209,6 @@ case class GcpFinding(
 )
 
 case class GcpSccConfig(orgId: String, sourceId: String)
+
+case class CronSchedule(cron: String, description: String)
+

--- a/hq/app/schedule/CredentialsNotifier.scala
+++ b/hq/app/schedule/CredentialsNotifier.scala
@@ -1,0 +1,43 @@
+package schedule
+
+import com.amazonaws.services.sns.AmazonSNSAsync
+import com.gu.anghammarad.Anghammarad
+import com.gu.anghammarad.models.{Email, Notification, Preferred, Target}
+import model.CredentialReportDisplay
+import play.api.Logging
+
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext}
+import scala.util.control.NonFatal
+
+
+object CredentialsNotifier extends Logging {
+  val subject = "Action required - old AWS credentials and/or credentials missing MFA"
+  val channel = Preferred(Email)
+  val sourceSystem = "Security HQ Credentials Notifier"
+
+  //TODO write multi-line string
+  // https://github.com/guardian/frontend/blob/9468d4bc3e35dc9213f8f5c18d4b88c70b8667cc/common/app/services/Notification.scala#L71
+  //and write tests for this
+  def createMessage(outdatedKeys: CredentialReportDisplay, missingMfa: CredentialReportDisplay): String = ???
+
+  def createNotification(awsAccount: Target, message: String): Notification = {
+    Notification(subject, message, List.empty, List(awsAccount), channel, sourceSystem)
+  }
+
+  def send(
+    notification: Notification,
+    topicArn: String,
+    snsClient: AmazonSNSAsync)(implicit executionContext: ExecutionContext): Unit = {
+
+    val response = Anghammarad.notify(notification, topicArn, snsClient)
+
+    try {
+      val id = Await.result(response, 5.seconds)
+      logger.info(s"Sent notification to ${notification.target}: $id")
+    } catch {
+      case NonFatal(err) =>
+        logger.error("Failed to send notification", err)
+    }
+  }
+}

--- a/hq/app/schedule/CredentialsNotifier.scala
+++ b/hq/app/schedule/CredentialsNotifier.scala
@@ -29,9 +29,7 @@ object CredentialsNotifier extends Logging {
     notification: Notification,
     topicArn: String,
     snsClient: AmazonSNSAsync)(implicit executionContext: ExecutionContext): Unit = {
-
     val response = Anghammarad.notify(notification, topicArn, snsClient)
-
     try {
       val id = Await.result(response, 5.seconds)
       logger.info(s"Sent notification to ${notification.target}: $id")

--- a/hq/app/schedule/CredentialsReportJob.scala
+++ b/hq/app/schedule/CredentialsReportJob.scala
@@ -1,0 +1,29 @@
+
+import model.CronSchedule
+import play.api.{Logger, Logging}
+import schedule.{CronSchedules, JobRunner}
+
+class CredentialsReportJob(enabled: Boolean) extends JobRunner with Logging {
+  override val id = "credentials report job"
+  override val description = "Automated emails for old permanent credentials"
+
+  override val cronSchedule: CronSchedule = CronSchedules.onceADayAt1am
+
+  def run(): Unit = {
+    if (!enabled) {
+      logger.info(s"Skipping scheduled $id job as it is not enabled")
+    } else {
+      logger.info(s"Running scheduled job: $description")
+
+      // retrieve/generate creds report
+         // get from cacheservice : CredentialReportDisplay (for comp - for each account in our Map)
+         // We can use case classes: HumanUser / MachineUser and their AccessKey
+      // 1) get old perm creds (1 or more access keys)
+      // 2) find accounts where IAM users have password enabled, but not MFA
+      // create an email to the aws accounts with either of these 2 cases
+      // send an email
+
+      logger.info(s"Completed scheduled job: $description")
+    }
+  }
+}

--- a/hq/app/schedule/CredentialsReportJob.scala
+++ b/hq/app/schedule/CredentialsReportJob.scala
@@ -1,10 +1,14 @@
 
+import com.amazonaws.services.sns.AmazonSNSClientBuilder
+import com.amazonaws.services.sns.model.PublishRequest
 import logic.DateUtils
 import model.{AccessKey, AwsAccount, CredentialReportDisplay, CronSchedule}
 import play.api.Logging
+import schedule.CredentialsNotifier.{createMessage, createNotification}
 import schedule.{CronSchedules, JobRunner}
 import services.CacheService
 import utils.attempt.FailedAttempt
+import com.gu.anghammarad.models.{AwsAccount => Account}
 
 class CredentialsReportJob(enabled: Boolean, cacheService: CacheService) extends JobRunner with Logging {
   override val id = "credentials report job"
@@ -21,11 +25,12 @@ class CredentialsReportJob(enabled: Boolean, cacheService: CacheService) extends
         credsReport <- result
         outdatedKeys = findOldAccessKeys(credsReport)
         missingMfa = findMissingMfa(credsReport)
-        //TODO create this function or a set of functions
-        // (could we create a function that has the same name, but takes diff args so that we can use this for diff use cases?)
-        email = createEmail(awsAccount, outdatedKeys, missingMfa)
-        // TODO: create function that returns Either(failedAttempt, AWS was successful)
-        sendEmailResponse <- emailService.sendEmail(email)
+        // could we create a function that has the same name, but takes diff args so that we can use this for diff use cases?
+        message = createMessage(outdatedKeys, missingMfa)
+        email = createNotification(Account(awsAccount.id), message)
+        // create function that returns Either(failedAttempt, AWS was successful)
+        // send email to anghammarad notfy method with aws account id
+        sendEmailResponse <- send()
         // what does SNS respond with when we send it an email request? Is it an Either?
       } yield {
         logger.info(s"Completed scheduled job: $description")

--- a/hq/app/schedule/CredentialsReportJob.scala
+++ b/hq/app/schedule/CredentialsReportJob.scala
@@ -1,58 +1,48 @@
-
-import com.amazonaws.services.sns.AmazonSNSClientBuilder
-import com.amazonaws.services.sns.model.PublishRequest
+import com.gu.anghammarad.models.{AwsAccount => Account}
 import logic.DateUtils
 import model.{AccessKey, AwsAccount, CredentialReportDisplay, CronSchedule}
 import play.api.Logging
-import schedule.CredentialsNotifier.{createMessage, createNotification}
+import schedule.CredentialsNotifier.{createMessage, createNotification, send}
 import schedule.{CronSchedules, JobRunner}
 import services.CacheService
 import utils.attempt.FailedAttempt
-import com.gu.anghammarad.models.{AwsAccount => Account}
 
-class CredentialsReportJob(enabled: Boolean, cacheService: CacheService) extends JobRunner with Logging {
+import scala.concurrent.ExecutionContext
+
+class CredentialsReportJob(enabled: Boolean, cacheService: CacheService)(executionContext: ExecutionContext) extends JobRunner with Logging {
   override val id = "credentials report job"
   override val description = "Automated emails for old permanent credentials"
   override val cronSchedule: CronSchedule = CronSchedules.onceADayAt1am
+  val topicArn: String = ???
 
   def run(): Unit = {
     if (!enabled) {
       logger.info(s"Skipping scheduled $id job as it is not enabled")
     } else {
       logger.info(s"Running scheduled job: $description")
-      for {
-        (awsAccount, result) <- getCredentialsReport()
-        credsReport <- result
-        outdatedKeys = findOldAccessKeys(credsReport)
-        missingMfa = findMissingMfa(credsReport)
-        // could we create a function that has the same name, but takes diff args so that we can use this for diff use cases?
-        message = createMessage(outdatedKeys, missingMfa)
-        email = createNotification(Account(awsAccount.id), message)
-        // create function that returns Either(failedAttempt, AWS was successful)
-        // send email to anghammarad notfy method with aws account id
-        sendEmailResponse <- send()
-        // what does SNS respond with when we send it an email request? Is it an Either?
-      } yield {
-        logger.info(s"Completed scheduled job: $description")
-        // TODO: could we log the failures and successes?
+
+      getCredentialsReport().foreach{ case (awsAccount, result) =>
+        result.foreach{ credsReport =>
+          val outdatedKeys = findOldAccessKeys(credsReport)
+          val missingMfa = findMissingMfa(credsReport)
+          val message = createMessage(outdatedKeys, missingMfa)
+          val email = createNotification(Account(awsAccount.id), message)
+          send(email, topicArn, ???)(executionContext)
+          logger.info(s"Completed scheduled job: $description")
+        }
       }
     }
   }
+
   def getCredentialsReport(): Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = cacheService.getAllCredentials
+
   def findOldAccessKeys(credsReport: CredentialReportDisplay): CredentialReportDisplay = {
-    def hasOutdatedKey(keys: List[AccessKey]): Boolean = {
-      keys.exists{ key =>
-        DateUtils.dayDiff(key.lastRotated).getOrElse(1) > 90
-      }
-    }
-    val filteredMachines = credsReport.machineUsers.filter{ user =>
-      hasOutdatedKey(List(user.key1, user.key2))
-    }
-    val filteredHumans = credsReport.humanUsers.filter{ user =>
-      hasOutdatedKey(List(user.key1, user.key2))
-    }
+    def hasOutdatedKey(keys: List[AccessKey]): Boolean = keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > 90L) //TODO fix Long issue
+    val filteredMachines = credsReport.machineUsers.filter(user => hasOutdatedKey(List(user.key1, user.key2)))
+    val filteredHumans = credsReport.humanUsers.filter(user => hasOutdatedKey(List(user.key1, user.key2)))
     credsReport.copy(machineUsers = filteredMachines, humanUsers = filteredHumans)
   }
+
   def findMissingMfa(credsReport: CredentialReportDisplay): CredentialReportDisplay = {
     credsReport.copy(humanUsers = credsReport.humanUsers.filterNot(_.hasMFA))
   }

--- a/hq/app/schedule/CronSchedules.scala
+++ b/hq/app/schedule/CronSchedules.scala
@@ -1,0 +1,15 @@
+package schedule
+
+import model.CronSchedule
+
+object CronSchedules {
+  val onceADayAt1am = CronSchedule("0 0 1 * * ?", "Run once a day at 1am")
+  val onceADayAt2am = CronSchedule("0 0 2 * * ?", "Run once a day at 2am")
+  val onceADayAt3am = CronSchedule("0 0 3 * * ?", "Run once a day at 3am")
+  val onceADayAt4am = CronSchedule("0 0 4 * * ?", "Run once a day at 4am")
+  val onceADayAt5am = CronSchedule("0 0 5 * * ?", "Run once a day at 6am")
+  val onceADayAt6am = CronSchedule("0 0 6 * * ?", "Run once a day at 6am")
+  val onceADayAt7am = CronSchedule("0 0 7 * * ?", "Run once a day at 7am")
+  val onceADayAt8am = CronSchedule("0 0 8 * * ?", "Run once a day at 8am")
+  val onceADayAt9am = CronSchedule("0 0 9 * * ?", "Run once a day at 9am")
+}

--- a/hq/app/schedule/CronSchedules.scala
+++ b/hq/app/schedule/CronSchedules.scala
@@ -2,6 +2,7 @@ package schedule
 
 import model.CronSchedule
 
+//TODO consider if we need all of these
 object CronSchedules {
   val onceADayAt1am = CronSchedule("0 0 1 * * ?", "Run once a day at 1am")
   val onceADayAt2am = CronSchedule("0 0 2 * * ?", "Run once a day at 2am")

--- a/hq/app/schedule/JobRunner.scala
+++ b/hq/app/schedule/JobRunner.scala
@@ -1,0 +1,17 @@
+package schedule
+
+import model.CronSchedule
+import org.quartz.{JobKey, TriggerKey}
+
+abstract class JobRunner {
+  val id: String
+  val description: String
+  val cronSchedule: CronSchedule
+
+  val name: String = getClass.getName
+
+  val jobKey = new JobKey(name)
+  val triggerKey = new TriggerKey(name)
+
+  def run(): Unit
+}

--- a/hq/app/schedule/JobScheduler.scala
+++ b/hq/app/schedule/JobScheduler.scala
@@ -1,0 +1,44 @@
+package schedule
+
+import org.quartz.CronScheduleBuilder.cronSchedule
+import org.quartz.JobBuilder.newJob
+import org.quartz.{JobDataMap, Scheduler}
+import org.quartz.TriggerBuilder.newTrigger
+
+class JobScheduler(scheduler: Scheduler, adminJobs: List[JobRunner]) {
+
+  def initialise(): Unit = {
+    adminJobs.foreach(job => scheduleJob(job))
+  }
+
+  private def scheduleJob(job: JobRunner): Unit = {
+    val jobDetail = newJob(classOf[JobWrapper])
+      .withIdentity(job.id)
+      .usingJobData(buildJobDataMap(job))
+      .build()
+    val trigger = newTrigger()
+      .withIdentity(job.triggerKey)
+      .withSchedule(cronSchedule(job.cronSchedule.cron))
+      .build()
+    scheduler.scheduleJob(jobDetail, trigger)
+  }
+
+  private def buildJobDataMap(job: JobRunner): JobDataMap = {
+    val jobDataMap = new JobDataMap()
+    jobDataMap.put(AdminJobScheduler.JobDataKeys.JobId, job.id)
+    jobDataMap.put(AdminJobScheduler.JobDataKeys.Runner, job)
+    jobDataMap
+  }
+
+  def start(): Unit = scheduler.start()
+
+  def shutdown(): Unit = scheduler.shutdown()
+}
+
+object AdminJobScheduler {
+
+  object JobDataKeys {
+    val JobId = "JobId"
+    val Runner = "runner"
+  }
+}

--- a/hq/app/schedule/JobWrapper.scala
+++ b/hq/app/schedule/JobWrapper.scala
@@ -1,0 +1,15 @@
+package schedule
+
+import org.quartz.{Job, JobExecutionContext}
+
+class JobWrapper extends Job {
+
+  def execute(context: JobExecutionContext): Unit = {
+    import AdminJobScheduler.JobDataKeys
+    val jobData = context.getJobDetail.getJobDataMap
+    val job = jobData.get(JobDataKeys.Runner).asInstanceOf[JobRunner]
+
+    //TODO: Log.info(s"Running jobId=${job.id} - ${job.description} ...")
+    job.run()
+  }
+}


### PR DESCRIPTION
## What does this change?
This PR starts the work of adding a scheduler and notification service to security hq. 

## What is the value of this?
The aim is to send automated notifications about insecure credentials.

Ideally, every week (or another time period!) SHQ will check the ages of all permanent credentials. If the age is > 90 days an email will be sent to the email address associated with the AWS account contained in anghammarad. (A follow up piece of work is, if the age goes over 120 days (or another time period!) delete the credentials!)

The scheduling service is reusable, so if in the future we would like SHQ to send notifications for other reasons, this is possible.

## What is next?

1. Complete createMessage function
2. Address TODOs
3. Write tests