### PR TITLE
Try to break words less often with overflow-wrap

### DIFF
--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -402,12 +402,11 @@ table.iam-report__table th {
 .gcp-report__table th {
   min-height: 21px;
   box-sizing: initial;
-  word-wrap: break-word;
 }
 
 .gcp-report__table {
   table-layout: fixed;
-  word-break: break-all;
+  overflow-wrap: break-word;
 }
 
 .gcp-table-row-severity {


### PR DESCRIPTION
## What does this change?

I noticed in the GCP Security Findings section (https://security-hq.gutools.co.uk/gcp) that the words in the 'Explanation' column were all splitting exactly at the right-hand edge - sometimes it's necessary to split words in layout because they're just too long to ever fit (eg `AUDIT_LOGGING_DISABLED` might never fit in the column space) but for shorter words it's unnecessary to split them in half, when you can just let the whole word flow onto the next line - although it's relatively new behaviour, CSS does support this, with the [`overflow-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) property (rather than `word-wrap` & `word-break`).

#### Before (see all the split words on the right-hand of the Explanation column)

![image](https://user-images.githubusercontent.com/52038/114893687-de81b680-9e05-11eb-8c10-a46127f1bc4d.png)

#### After (words are no longer split unless it's necessary, as is the case in the Category column)

![image](https://user-images.githubusercontent.com/52038/114893819-fc4f1b80-9e05-11eb-9b5e-d297e88ad5d3.png)

I've only tried this by experimenting in Chrome Dev Tools, not actually run Security HQ with these changes, so I may have made a mistake in this PR, but hopefully the changes are so simple I haven't managed to mess them up!

## What is the value of this?

The text is hopefully clearer and easier to read.

## Any additional notes?

There might be a few other places in Security HQ where `word-wrap` & `word-break` are used, so if this change is helpful you might want to try applying it in the other places too.

See also, for another example: https://github.com/guardian/ophan/pull/3161#discussion_r253934454