### PR TITLE
Show stale data on credential report failure

### DIFF
--- a/hq/app/logic/DateUtils.scala
+++ b/hq/app/logic/DateUtils.scala
@@ -12,7 +12,9 @@ object DateUtils {
   }
   def toISOString(dateTime: DateTime) = ISODateTimeFormat.dateTime().print(dateTime)
 
-  def dayDiff(date: Option[DateTime]): Option[Long] =  date.map(new Duration(_, DateTime.now(DateTimeZone.UTC)).getStandardDays)
+  def dayDiff(date: Option[DateTime]): Option[Long] =  date.map(dayDiff)
+
+  def dayDiff(date: DateTime): Long =  new Duration(date, DateTime.now(DateTimeZone.UTC)).getStandardDays
 
   def printTime(date: DateTime): String = date.toString("HH:mm")
 }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -98,7 +98,8 @@ class CacheService(
       allCredentialReports <- IAMClient.getAllCredentialReports(accounts, cfnClients, iamClients, regions)
     } yield {
       logger.info("Sending the refreshed data to the Credentials Box")
-      credentialsBox.send(allCredentialReports.toMap)
+      if(! allCredentialReports.exists(_._2.isLeft))
+        credentialsBox.send(allCredentialReports.toMap)
     }
   }
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -108,7 +108,9 @@ class CacheService(
       allPublicBuckets <- TrustedAdvisorS3.getAllPublicBuckets(accounts, taClients, s3Clients)
     } yield {
       logger.info("Sending the refreshed data to the Public Buckets Box")
-      publicBucketsBox.send(allPublicBuckets.toMap)
+      if(allPublicBuckets.exists(_._2.isRight)) {
+        publicBucketsBox.send(allPublicBuckets.toMap)
+      }
     }
   }
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -95,11 +95,13 @@ class CacheService(
   def refreshCredentialsBox(): Unit = {
     logger.info("Started refresh of the Credentials data")
     for {
-      allCredentialReports <- IAMClient.getAllCredentialReports(accounts, cfnClients, iamClients, regions)
+      newCredentialReports <- IAMClient.getAllCredentialReports(accounts, cfnClients, iamClients, regions)
     } yield {
       logger.info("Sending the refreshed data to the Credentials Box")
-      if(! allCredentialReports.exists(_._2.isLeft))
-        credentialsBox.send(allCredentialReports.toMap)
+      val oldCredentialsReports = credentialsBox.get()
+      val mergedCredentialsReports = newCredentialReports.toMap.map(report => if (report._2.isLeft) (report._1, oldCredentialsReports(report._1)) else report)
+
+      credentialsBox.send(mergedCredentialsReports)
     }
   }
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -108,7 +108,7 @@ class CacheService(
       allPublicBuckets <- TrustedAdvisorS3.getAllPublicBuckets(accounts, taClients, s3Clients)
     } yield {
       logger.info("Sending the refreshed data to the Public Buckets Box")
-      if(allPublicBuckets.exists(_._2.isRight)) {
+      if(! allPublicBuckets.exists(_._2.isLeft)) {
         publicBucketsBox.send(allPublicBuckets.toMap)
       }
     }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -109,9 +109,7 @@ class CacheService(
       allPublicBuckets <- TrustedAdvisorS3.getAllPublicBuckets(accounts, taClients, s3Clients)
     } yield {
       logger.info("Sending the refreshed data to the Public Buckets Box")
-      if(! allPublicBuckets.exists(_._2.isLeft)) {
-        publicBucketsBox.send(allPublicBuckets.toMap)
-      }
+      publicBucketsBox.send(allPublicBuckets.toMap)
     }
   }
 

--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -2,10 +2,17 @@
 @import model._
 @import logic.CredentialsReportDisplay
 @(report: CredentialReportDisplay)
-
+@message = @{s"Report generated at ${DateUtils.printTime(report.reportDate)} (refreshed every four hours)"}
+@warning = @{". Warning: this data is over a day old."}
 <div class="row">
     <div class="card-panel">
-        <span>Report generated at @{DateUtils.printTime(report.reportDate)} (refreshed every four hours)</span>
+        <span>
+        @if(DateUtils.dayDiff(report.reportDate) > 0) {
+            @{message + warning}
+        } else {
+            @{message}
+        }
+        </span>
     </div>
 </div>
 <div class="row">


### PR DESCRIPTION
## What does this change?

This change essentially backfills missing credentials reports with existing ones.

It does so by looking at the result from the fetch and replacing tuples with "left"  with tuples with the data currently in memory.

## What is the value of this?

The idea here is that it's more valuable to display the last known good report rather than an error message like this

![Discussion___IAM_report___Security_HQ](https://user-images.githubusercontent.com/1672034/115267454-1869fa00-a131-11eb-9866-51dbdffa7a21.png)

The age of the report is displayed up top but it doesn't do anything clever to highlight that a report is older than it should be. Given that it's fetched every 90 minutes, I'd expect that the api rate limiting issue wont' leave us with very old reports.

![Baton___IAM_report___Security_HQ](https://user-images.githubusercontent.com/1672034/115387835-18bad180-a1d3-11eb-978e-dd78adfe1eda.png)


## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

## Any additional notes?

This is probably a little hacky, but we do intend to solve the root cause of the issue (which is the way we're fetching data causing us to be API rate limited) next week or the week after.
