### PR TITLE
Update security docs

### DIFF
--- a/hq/markdown/guardduty-sechub-common-problems.md
+++ b/hq/markdown/guardduty-sechub-common-problems.md
@@ -64,7 +64,7 @@ To determine whether a subnet is public or private you can check the route table
 (typically 0.0.0.0/0) is directed to an 'internet gateway' (typically igw-12345) then it is a *public subnet*. If there is
 no internet gateway entry then it is a private subnet.
 
-If you only have private subnets in your VPC then you won't be able to resolve this issue. You'll either need to add
+If you only have public subnets in your VPC then you won't be able to resolve this issue. You'll either need to add
 private subnets to your VPC if there's space or move to a new VPC with private subnets. Both tasks will likely require
 several weeks of work. Joe Smith did a great tech time on this issue. The slides are [here](https://docs.google.com/presentation/d/1_YfLuAfKULplBBP8Ugs9IYxrKwWLtL9JsBICBoVqn4c/edit#slide=id.g5c86dc83d4_0_81)
 , video [here](https://drive.google.com/file/d/1AP_fN2i9S0ssocETOBtJXl_oCZ2XY_zM/view).

--- a/hq/markdown/guardduty-sechub-common-problems.md
+++ b/hq/markdown/guardduty-sechub-common-problems.md
@@ -57,6 +57,18 @@ A quick test to see how painful this change will be is to search for usages of `
 If you are using AWS CDK you (may) need to wait before you can fix this feature - there's an issue tracking this 
 [here](https://github.com/aws/aws-cdk/issues/5137)
 
+## Instances should not have a public IPv4 address
+This will occur in cases where you have EC2 instances in the public section of your VPC. Often this is because when the VPC
+was set up, only public subnets were created. You can check the subnets of your VPC in the [AWS console](https://eu-west-1.console.aws.amazon.com/vpc/home?region=eu-west-1#subnets:).
+To determine whether a subnet is public or private you can check the route table. If there is an entry where all traffic 
+(typically 0.0.0.0/0) is directed to an 'internet gateway' (typically igw-12345) then it is a *public subnet*. If there is
+no internet gateway entry then it is a private subnet.
+
+If you only have private subnets in your VPC then you won't be able to resolve this issue. You'll either need to add
+private subnets to your VPC if there's space or move to a new VPC with private subnets. Both tasks will likely require
+several weeks of work. Joe Smith did a great tech time on this issue. The slides are [here](https://docs.google.com/presentation/d/1_YfLuAfKULplBBP8Ugs9IYxrKwWLtL9JsBICBoVqn4c/edit#slide=id.g5c86dc83d4_0_81)
+, video [here](https://drive.google.com/file/d/1AP_fN2i9S0ssocETOBtJXl_oCZ2XY_zM/view).
+
 # AWS GuardDuty Common Issues
 Right now, we don't have any of these to suggest remediation for. Please get in contact with DevX if you're unsure about
 something GuardDuty has flagged up

--- a/hq/markdown/snyk.md
+++ b/hq/markdown/snyk.md
@@ -179,3 +179,15 @@ When reviewing previously accepted risks, it would be prudent to examine how lon
 If a problem is not fairly new, and still looks unlikely to be resolved, then reconsider both the _risk_ of exploitation and
 the _cost_ of exploitation before deciding whether to continue extending an exemption.  It may now be
 appropriate to consider alternatives.
+
+## Common Vulnerabilities
+
+## Deserialization of Untrusted Data: Jackson Databind
+At the time of writing, this vulnerability makes up 74% of our 'high severity' vulnerabilities in Snyk. In the majority
+of cases this library is imported as a transitive dependency to our projects rather than being used directly - typically
+by the AWS SDK. This makes fixing it more challenging than you might expect, because it requires and AWS SDK upgrade 
+rather than simply moving to the latest minor version of the jackson databind library. In some cases it's not possible to fix
+this via an AWS SDK upgrade and you have to override the dependency. 
+
+For now, our recommendation is to *focus on other Snyk issues first*. For further info on this, there's a helpful thread
+on google chat [here](https://chat.google.com/room/AAAAFug03y8/3p2y42sYhMc). 

--- a/hq/markdown/snyk.md
+++ b/hq/markdown/snyk.md
@@ -190,4 +190,5 @@ rather than simply moving to the latest minor version of the jackson databind li
 this via an AWS SDK upgrade and you have to override the dependency. 
 
 For now, our recommendation is to *focus on other Snyk issues first*. For further info on this, there's a helpful thread
-on google chat [here](https://chat.google.com/room/AAAAFug03y8/3p2y42sYhMc). 
+on google chat [here](https://chat.google.com/room/AAAAFug03y8/3p2y42sYhMc) and an in depth blog post about the issue
+[here](https://cowtowncoder.medium.com/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062#da96).

--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -36,6 +36,11 @@ should ideally be locked down to the load balancer and nothing else. Port 22 acc
 With IAM credentials, note that any permanent credentials should be regularly rotated. Infosec recommend rotating credentials every 
 90 days. For credentials in a trusted 3rd  party such  as Fastly or Github, annual rotation is sufficient. 
 
+Security group and S3 bucket warnings in Security HQ are powered by AWS Trusted Advisor. If  there is a bucket you believe
+is correctly public or a security group that is correctly open you can exclude it from the trusted advisor report by going to
+the [dashboard](https://console.aws.amazon.com/trustedadvisor/home?region=eu-west-1#/category/security), waiting for everything to load
+then finding your bucket or group and clicking 'exclude'.
+
 ### 2. Operating system patches
 You should be regularly replacing your AMIs to get the latest security patches. At present, our advice here is to use 
 [AMIable](amiable.gutools.co.uk/) to check the status of the AMIs used in your account. Most of our apps should be automatically

--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -43,7 +43,17 @@ on a recent AMI thanks to using a combination of riffraff scheduled deploys and 
 deploy steps. If your app isn't deployed via riffraff then it might be more difficult to keep it up to date. Ideally there
 needs to be some kind of process, even if it's just a manual step when AMIable emails you about the out of date instances.
 
-### 3. AWS GuardDuty
+### 3. AWS Security Hub
+Security Hub has a LOT of information. Right now we're only interested in the [AWS Foundational Security Best Practices](https://eu-west-1.console.aws.amazon.com/securityhub/home?region=eu-west-1#/standards/aws-foundational-security-best-practices-1.0.0)
+section, with a focus on 'Critical' and 'High' severity vulnerabilities.
+
+We've documented a fair few of the common Security Hub issues [here](./guardduty-sechub-common-problems.md). 
+If something's missing please tell us: devx@theguardian.com
+
+:exclamation: Security Hub raises a large number of issues. For now focus only on 'High' and 'Critical' severity issues
+
+
+### 4. AWS GuardDuty
 ![guard gromit](./images/gromit.gif)
 
 If you're signed in to AWS already, you can click [here](https://eu-west-1.console.aws.amazon.com/guardduty/home?region=eu-west-1#/findings?macros=current)


### PR DESCRIPTION
## What does this change?
This change:
 - adds docs for excluding vulnerabilities
 - adds docs for jackson databind Snyk issues
 - adds docs for instances with a public ipv4 address
 - Swaps guard duty  and security hub around in the list of stuff to look at 