### PR TITLE
GCP Dashboard Improvements

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -2,6 +2,7 @@ package model
 
 import com.amazonaws.regions.Region
 import com.google.cloud.securitycenter.v1.Finding
+import com.google.cloud.securitycenter.v1.Finding.Severity
 import com.google.protobuf.{Timestamp, Value}
 import org.joda.time.DateTime
 
@@ -202,7 +203,7 @@ case class GcpReport(reportDate: DateTime, finding: Map[String, Seq[GcpFinding]]
 case class GcpFinding(
   project: String,
   category: String,
-  severity: String,
+  severity: Severity,
   eventTime: DateTime,
   explanation: Option[String],
   recommendation: Option[String]

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -4,6 +4,7 @@
 @import controllers.AssetsFinder
 @import logic.GcpDisplay
 @import model.GcpFinding
+@import com.google.cloud.securitycenter.v1.Finding.Severity
 @(report: GcpReport)(implicit assets: AssetsFinder)
 
 @floatingNav() = {
@@ -68,20 +69,24 @@
                     <div class="collapsible-header" tabindex="22">
                     <i class="material-icons">keyboard_arrow_down</i>
                     <span class="iam-header__name">@projectName</span>
-                        @if(findings.exists(_.severity == "High")) {
-                            <span class="icon-count">@findings.count(_.severity == "High")</span>
+                        @if(findings.exists(_.severity == Severity.CRITICAL)) {
+                            <span class="icon-count">@findings.count(_.severity == Severity.CRITICAL)</span>
+                            <i class="material-icons red-text">error</i><i class="material-icons red-text">error</i>
+                        }
+                        @if(findings.exists(_.severity == Severity.HIGH)) {
+                            <span class="icon-count">@findings.count(_.severity == Severity.HIGH)</span>
                             <i class="material-icons red-text">error</i>
                         }
-                        @if(findings.exists(_.severity == "Medium")) {
-                            <span class="icon-count">@findings.count(_.severity == "Medium")</span>
+                        @if(findings.exists(_.severity == Severity.MEDIUM)) {
+                            <span class="icon-count">@findings.count(_.severity == Severity.MEDIUM)</span>
                             <i class="material-icons orange-text">warning</i>
                         }
-                        @if(findings.exists(_.severity == "Low")) {
-                            <span class="icon-count">@findings.count(_.severity == "Low")</span>
+                        @if(findings.exists(_.severity == Severity.LOW)) {
+                            <span class="icon-count">@findings.count(_.severity == Severity.LOW)</span>
                             <i class="material-icons yellow-text">priority_high</i>
                         }
-                        @if(findings.exists(_.severity == "Unknown")) {
-                            <span class="icon-count">@findings.count(_.severity == "Unknown")</span>
+                        @if(findings.exists(_.severity == Severity.SEVERITY_UNSPECIFIED)) {
+                            <span class="icon-count">@findings.count(_.severity == Severity.SEVERITY_UNSPECIFIED)</span>
                             <i class="material-icons grey-text">not_listed_location</i>
                         }
                     </div>

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -45,11 +45,14 @@
         <div class="row flow-text">
             <h3>GCP Security Findings</h3>
             <p>Security Command Centre's findings display possible security risks for your GCP resources.</p>
+            <i class="material-icons red-text text-darken-4">error</i>
         </div>
 
         <div class="row">
             <div class="card-panel valign-wrapper">
                 <form class="finding-filter" action="#">
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-critical-findings" checked="checked" />
+                    <label class="black-text finding-filter__label" for="show-critical-findings">Critical</label>
                     <input class="js-finding-filter-for-gcp" type="checkbox" id="show-high-findings" checked="checked" />
                     <label class="black-text finding-filter__label" for="show-high-findings">High</label>
                     <input class="js-finding-filter-for-gcp" type="checkbox" id="show-medium-findings" checked="checked" />
@@ -71,7 +74,7 @@
                     <span class="iam-header__name">@projectName</span>
                         @if(findings.exists(_.severity == Severity.CRITICAL)) {
                             <span class="icon-count">@findings.count(_.severity == Severity.CRITICAL)</span>
-                            <i class="material-icons red-text">error</i><i class="material-icons red-text">error</i>
+                            <i class="material-icons red-text text-darken-4">error</i>
                         }
                         @if(findings.exists(_.severity == Severity.HIGH)) {
                             <span class="icon-count">@findings.count(_.severity == Severity.HIGH)</span>

--- a/hq/app/views/gcp/gcpReportBody.scala.html
+++ b/hq/app/views/gcp/gcpReportBody.scala.html
@@ -24,8 +24,8 @@
             </thead>
             <tbody>
                 @for(finding <- findings) {
-                    <tr class="finding-@finding.severity.toLowerCase">
-                        <td class="gcp-table-row-severity"><span>@finding.severity</span></td>
+                    <tr class="finding-@finding.severity.getValueDescriptor.getName.toLowerCase()">
+                        <td class="gcp-table-row-severity"><span>@finding.severity.getValueDescriptor.getName</span></td>
                         <td class="gcp-table-row-category"><span>@finding.category</span></td>
                         <td class="gcp-table-row-date"><span>@finding.eventTime.toString(GcpDisplay.dateTimePattern)</span></td>
                         <td>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -51,6 +51,9 @@ $(document).ready(function() {
       : $('.finding-unencrypted').hide();
   });
   $('.js-finding-filter-for-gcp').change(function() {
+    $('#show-critical-findings')[0].checked
+        ? $('.finding-critical').show()
+        : $('.finding-critical').hide();
     $('#show-high-findings')[0].checked
         ? $('.finding-high').show()
         : $('.finding-high').hide();


### PR DESCRIPTION
## What does this change?
This change:
 - Increases page size of GCP queries to 1000 (the default is 10)
 - Adds an extra filter to only show 'active' findings - GCP Security centre keeps a record of all security events that have happened, but we only care about current ones
 - Switches the 'severity' value being used to the one at the top level of the finddings object.

## What is the value of this?
- The GCP query now loads more quickly as it involves fewer requests thanks to the larger page size. 
- We aren't showing non-active findings to users
 - We have fewer 'unknown severity' findings as the top level severity property seems to be more frequently set.

## Will this require CloudFormation and/or updates to the AWS StackSet?
No
