### PR TITLE
fix: Do not flag port 443 as open to the world

### DIFF
--- a/lambda/security-groups/src/test/scala/com/gu/hq/SecurityGroupsTest.scala
+++ b/lambda/security-groups/src/test/scala/com/gu/hq/SecurityGroupsTest.scala
@@ -73,6 +73,26 @@ class SecurityGroupsTest extends FreeSpec with Matchers {
     }
   }
 
+  "isExactlyHttps" - {
+    "returns true for a SecurityGroup with an HTTPS (443) port range exactly" in {
+      val openPermissions = List(
+        IpPermission("tcp", Some(443), Some(443), Nil, Nil, Nil)
+      )
+      val sg = SGConfiguration("owner", "security-group", "sg-01234", "Test SecurityGroup", openPermissions, Nil, "vpc-id", Nil)
+
+      SecurityGroups.isExactlyHttps(sg) shouldEqual true
+    }
+
+    "returns false for a SecurityGroup with a port range that includes HTTPS (443)" in {
+      val openPermissions = List(
+        IpPermission("tcp", Some(22), Some(443), Nil, Nil, Nil)
+      )
+      val sg = SGConfiguration("owner", "security-group", "sg-01234", "Test SecurityGroup", openPermissions, Nil, "vpc-id", Nil)
+
+      SecurityGroups.isExactlyHttps(sg) shouldEqual false
+    }
+  }
+
   private def elbWithSg(sgIds: String *): LoadBalancerDescription = {
     val elb = new LoadBalancerDescription()
     elb.withSecurityGroups(sgIds:_*)


### PR DESCRIPTION
## What does this change?

Do not flag a security group with port specifications as from 443 to 443 as open to the world.

This configuration is used to give HTTPS access to the world, which is totally legit.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

The alerts sent via Anghammarad include less false positives.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?

n/a

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
