### PR TITLE
Remove floating icon

### DIFF
--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -45,7 +45,6 @@
         <div class="row flow-text">
             <h3>GCP Security Findings</h3>
             <p>Security Command Centre's findings display possible security risks for your GCP resources.</p>
-            <i class="material-icons red-text text-darken-4">error</i>
         </div>
 
         <div class="row">


### PR DESCRIPTION
This removes an erroneously placed icon from the top of the GCP dashboard