### PR TITLE
Allow security hq to listusertags

### DIFF
--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -62,6 +62,7 @@ Resources:
             - iam:GenerateCredentialReport
             - iam:GetCredentialReport
             - cloudformation:DescribeStacks
+            - iam:ListUserTags
             # get AWS inspector results
             - inspector:List*
             - inspector:Describe*

--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -88,8 +88,6 @@ Resources:
   LambdaS3AccountMappingPolicy:
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: read_s3_to_get_account_mapping_file
-    Properties:
       PolicyName: security-hq-install-bucket-policy
       PolicyDocument:
         Statement:


### PR DESCRIPTION
## What does this change?
Adds an extra permission to allow security HQ to fetch IAM tags. These will be used to determine which teams to alert about problematic IAM users, and maybe in the UI to make it clearer who owns what

## Will this require CloudFormation and/or updates to the AWS StackSet?
Yes - I haven't done this yet though pending this PR https://github.com/guardian/janus/pull/2643


