### PR TITLE
Store tags of IAM users and use them to power anghammarad alerts

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -20,7 +20,7 @@ import play.api.routing.Router
 import play.api.{BuiltInComponentsFromContext, Logging}
 import play.filters.csrf.CSRFComponents
 import router.Routes
-import schedule.JobScheduler
+import schedule.{IamJob, JobScheduler}
 import services.{CacheService, MetricService}
 import utils.attempt.Attempt
 

--- a/hq/app/aws/ec2/EC2.scala
+++ b/hq/app/aws/ec2/EC2.scala
@@ -13,7 +13,7 @@ import com.amazonaws.services.ec2.model._
 import com.amazonaws.services.elasticfilesystem.AmazonElasticFileSystemAsync
 import com.amazonaws.services.support.AWSSupportAsync
 import com.amazonaws.services.support.model.RefreshTrustedAdvisorCheckResult
-import model._
+import model.{AwsAccount, ELB, Ec2Instance, SGInUse, SGOpenPortsDetail, TrustedAdvisorDetailsResult, UnknownUsage}
 import utils.attempt.{Attempt, FailedAttempt}
 
 import scala.collection.JavaConverters._

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -54,7 +54,7 @@ object IAMClient {
   )(implicit ec: ExecutionContext): Attempt[CredentialReportDisplay] = {
     val delay = 3.seconds
     val now = DateTime.now()
-    
+
     if(CredentialsReport.credentialsReportReadyForRefresh(currentData, now))
       for {
         client <- iamClients.get(account, SOLE_REGION)

--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -61,8 +61,8 @@ object IAMClient {
         _ <- Retry.until(generateCredentialsReport(client), CredentialsReport.isComplete, "Failed to generate credentials report", delay)
         report <- getCredentialsReport(client)
         stacks <- CloudFormation.getStacksFromAllRegions(account, cfnClients, regions)
-        reportWithTags <- getCredentialTags(report, client)
-        reportWithStacks = CredentialsReport.enrichReportWithStackDetails(reportWithTags, stacks)
+//        reportWithTags <- getCredentialTags(report, client) NOTE: disabled pending fixing the stack set
+        reportWithStacks = CredentialsReport.enrichReportWithStackDetails(report, stacks)
       } yield CredentialsReportDisplay.toCredentialReportDisplay(reportWithStacks)
     else
       Attempt.fromEither(currentData)

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -66,7 +66,8 @@ object CredentialsReportDisplay {
             accessKey2Details(cred),
             machineReportStatus(cred),
             dayDiff(lastActivityDate(cred)),
-            stack = cred.stack
+            stack = cred.stack,
+            tags = cred.tags
           ))
         } else None
 
@@ -79,7 +80,8 @@ object CredentialsReportDisplay {
             accessKey2Details(cred),
             humanReportStatus(cred),
             dayDiff(lastActivityDate(cred)),
-            stack = cred.stack
+            stack = cred.stack,
+            tags = cred.tags
           ))
         } else None
 

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -187,7 +187,15 @@ object Tag {
 }
 
 
-trait IAMUser
+sealed trait IAMUser {
+  def username: String
+  def key1: AccessKey
+  def key2: AccessKey
+  def reportStatus: ReportStatus
+  def lastActivityDay: Option[Long]
+  def stack: Option[AwsStack]
+  def tags: List[Tag]
+}
 
 case class HumanUser(
   username: String,

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -55,7 +55,8 @@ case class IAMCredential(
   cert1Active: Boolean,
   cert1LastRotated: Option[DateTime],
   cert2Active: Boolean,
-  cert2LastRotated: Option[DateTime]
+  cert2LastRotated: Option[DateTime],
+  tags: List[Tag] = List()
                         ) {
   val rootUser = user == "<root_account>"
 }
@@ -156,6 +157,10 @@ object Green extends ReportStatus
 object Amber extends ReportStatus
 object Blue extends ReportStatus
 
+case class Tag(key: String, value: String)
+
+trait IAMUser
+
 case class HumanUser(
   username: String,
   hasMFA : Boolean,
@@ -163,16 +168,19 @@ case class HumanUser(
   key2: AccessKey,
   reportStatus: ReportStatus,
   lastActivityDay : Option[Long],
-  stack: Option[AwsStack]
-)
+  stack: Option[AwsStack],
+  tags: List[Tag]
+) extends IAMUser
+
 case class MachineUser(
   username: String,
   key1: AccessKey,
   key2: AccessKey,
   reportStatus: ReportStatus,
   lastActivityDay: Option[Long],
-  stack: Option[AwsStack]
-)
+  stack: Option[AwsStack],
+  tags: List[Tag]
+) extends IAMUser
 
 case class SnykToken(value: String) extends AnyVal
 

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -160,6 +160,8 @@ object Blue extends ReportStatus
 case class Tag(key: String, value: String)
 object Tag {
 
+  val EMPTY_SSAID = "no-ssa-tags"
+
   def findAnghammaradTarget(key: String, toTarget: String => Target, tags: List[Tag]): Option[Target] = {
     val value = tags.find(_.key.toLowerCase() == key.toLowerCase()).map(_.value)
     value.map(toTarget)
@@ -178,7 +180,7 @@ object Tag {
     if (ssaTags.nonEmpty) {
       ssaTags.sortBy(_.key).map(_.value).mkString("-")
     } else {
-      "no-ssa-tags"
+      EMPTY_SSAID
     }
   }
 }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -3,7 +3,7 @@ package model
 import com.amazonaws.regions.Region
 import com.google.cloud.securitycenter.v1.Finding.Severity
 import org.joda.time.DateTime
-import com.gu.anghammarad.models.{App, Stack, Stage, Target}
+import com.gu.anghammarad.models.{App, Stack, Stage => AnghammaradStage, Target}
 
 
 case class AwsAccount(
@@ -168,7 +168,7 @@ object Tag {
   def tagsToAnghammaradTargets(tags: List[Tag]): List[Target] = {
     List (
       findAnghammaradTarget("stack", Stack, tags),
-      findAnghammaradTarget("stage", Stage, tags),
+      findAnghammaradTarget("stage", AnghammaradStage, tags),
       findAnghammaradTarget("app", App, tags),
     ).flatten
   }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -175,7 +175,11 @@ object Tag {
 
   def tagsToSSAID(tags: List[Tag]): String = {
     val ssaTags = tags.filter(t => List("stack", "stage", "app").contains(t.key.toLowerCase))
-    ssaTags.sortBy(_.key).map(_.value).mkString("-")
+    if (ssaTags.nonEmpty) {
+      ssaTags.sortBy(_.key).map(_.value).mkString("-")
+    } else {
+      "no-ssa-tags"
+    }
   }
 }
 

--- a/hq/app/schedule/IamAudit.scala
+++ b/hq/app/schedule/IamAudit.scala
@@ -50,7 +50,7 @@ object IamAudit extends Logging {
           } else {
             logger.info(s"for ${awsAccount.name}, generating iam notification message for ${outdatedKeys.length} user(s) with outdated keys and ${missingMfa.length} user(s) with missing mfa")
             targetGroups.map { tg =>
-              val message = createMessage(tg.outdatedKeysUsers, tg.noMfaUsers)
+              val message = createMessage(tg.outdatedKeysUsers, tg.noMfaUsers, awsAccount)
               Some(createNotification(awsAccount, tg.targets :+ Account(awsAccount.accountNumber), message))
             }
           }
@@ -61,7 +61,7 @@ object IamAudit extends Logging {
           }
           None
       }
-    }
+    }.flatten
   }
 
   def findOldAccessKeys(credsReport: CredentialReportDisplay): CredentialReportDisplay = {

--- a/hq/app/schedule/IamAudit.scala
+++ b/hq/app/schedule/IamAudit.scala
@@ -1,6 +1,6 @@
 package schedule
 
-import com.gu.anghammarad.models.{Notification, Target, AwsAccount => Account}
+import com.gu.anghammarad.models.{Notification, AwsAccount => Account}
 import config.Config.{iamHumanUserRotationCadence, iamMachineUserRotationCadence}
 import logic.DateUtils
 import model._
@@ -12,7 +12,7 @@ object IamAudit {
   /**
     * Takes users with outdated keys/missing mfa and groups them based off the stack/stage/app tags of the users.
     * Produce a group containing the two groups of users (outdated keys/missing mfa) and a list of Anghammarad Targets
-    * for alerts about those userss to be sent to
+    * for alerts about those users to be sent to
     * @param outdatedKeys
     * @param missingMfa
     * @return
@@ -40,8 +40,9 @@ object IamAudit {
 
         val targetGroups = getNotificationTargetGroups(outdatedKeys, missingMfa)
         targetGroups.map { tg =>
-            val message = createMessage(tg.outdatedKeysUsers, tg.noMfaUsers)
-            createNotification(tg.targets :+ Account(awsAccount.id), message)
+          val message = createMessage(tg.outdatedKeysUsers, tg.noMfaUsers)
+          createNotification(tg.targets :+ Account(awsAccount.id), message)
+        }
       }
     }
   }

--- a/hq/app/schedule/IamJob.scala
+++ b/hq/app/schedule/IamJob.scala
@@ -8,7 +8,6 @@ import model._
 import play.api.{Configuration, Logging}
 import schedule.IamAudit.makeCredentialsNotification
 import schedule.IamNotifier.send
-import schedule.{CronSchedules, JobRunner}
 import services.CacheService
 import utils.attempt.FailedAttempt
 

--- a/hq/app/schedule/IamNotifier.scala
+++ b/hq/app/schedule/IamNotifier.scala
@@ -26,7 +26,7 @@ object IamNotifier extends Logging {
       case Some(arn) =>
         val response = Anghammarad.notify(notification, arn, snsClient)
         try {
-          val id = response.foreach(id => logger.info(s"Sent notification to ${notification.target}: $id"))
+          response.foreach(id => logger.info(s"Sent notification to ${notification.target}: $id"))
         } catch {
           case NonFatal(err) =>
             logger.error("Failed to send notification", err)

--- a/hq/app/schedule/IamNotifier.scala
+++ b/hq/app/schedule/IamNotifier.scala
@@ -14,8 +14,8 @@ import scala.util.control.NonFatal
 object IamNotifier extends Logging {
   val channel = Preferred(Email)
 
-  def createNotification(awsAccount: Target, message: String): Notification = {
-    Notification(subject, message, List.empty, List(awsAccount), channel, sourceSystem)
+  def createNotification(targets: List[Target], message: String): Notification = {
+    Notification(subject, message, List.empty, targets, channel, sourceSystem)
   }
 
   def send(

--- a/hq/app/schedule/IamNotifier.scala
+++ b/hq/app/schedule/IamNotifier.scala
@@ -6,8 +6,7 @@ import com.gu.anghammarad.models.{Email, Notification, Preferred, Target}
 import play.api.Logging
 import schedule.IamMessages.{sourceSystem, subject}
 
-import scala.concurrent.duration.DurationInt
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 

--- a/hq/test/aws/ec2/EC2Test.scala
+++ b/hq/test/aws/ec2/EC2Test.scala
@@ -4,7 +4,7 @@ import aws.AwsClient
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.ec2.AmazonEC2AsyncClientBuilder
 import com.amazonaws.services.ec2.model._
-import model._
+import model.{AwsAccount, ELB, Ec2Instance, SGInUse, SGOpenPortsDetail, UnknownUsage}
 import org.scalacheck.Gen
 import org.scalacheck.Prop._
 import org.scalacheck.ScalacheckShapeless._

--- a/hq/test/logic/CredentialsReportDisplayTest.scala
+++ b/hq/test/logic/CredentialsReportDisplayTest.scala
@@ -114,23 +114,23 @@ class CredentialsReportDisplayTest extends FreeSpec with Matchers {
     "check credential display report for human user" in {
       val humanCred = cred.copy(passwordEnabled = Some(true))
       val iAMCredentialsReport = IAMCredentialsReport(now, List(humanCred))
-      val humanUser = HumanUser(cred.user, cred.mfaActive, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Amber, Some(1), None)
+      val humanUser = HumanUser(cred.user, cred.mfaActive, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Amber, Some(1), None, List.empty)
       val displayReport = CredentialReportDisplay(now, humanUsers = Seq(humanUser) )
       toCredentialReportDisplay(iAMCredentialsReport) shouldBe displayReport
     }
 
     "check credential display report for machine user" in {
       val iAMCredentialsReport = IAMCredentialsReport(now, List(cred))
-      val machineUser = MachineUser(cred.user, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Green, Some(1), None)
+      val machineUser = MachineUser(cred.user, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Green, Some(1), None, List.empty)
       val displayReport = CredentialReportDisplay(now, machineUsers = Seq(machineUser) )
       toCredentialReportDisplay(iAMCredentialsReport) shouldBe displayReport
     }
 
     "check credential display report - machine user and human user" in {
       val humanCred = cred.copy(passwordEnabled = Some(true))
-      val humanUser = HumanUser(cred.user, cred.mfaActive, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Amber, Some(1), None)
+      val humanUser = HumanUser(cred.user, cred.mfaActive, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Amber, Some(1), None, List.empty)
       val iAMCredentialsReport = IAMCredentialsReport(now, List(humanCred, cred))
-      val machineUser = MachineUser(cred.user, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Green, Some(1), None)
+      val machineUser = MachineUser(cred.user, AccessKey(AccessKeyEnabled, Some(now.minusDays(4))), AccessKey(AccessKeyEnabled, Some(now.minusDays(6))), Green, Some(1), None, List.empty)
       val displayReport = CredentialReportDisplay(now, humanUsers = Seq(humanUser) , machineUsers = Seq(machineUser) )
       toCredentialReportDisplay(iAMCredentialsReport) shouldBe displayReport
     }
@@ -140,11 +140,11 @@ class CredentialsReportDisplayTest extends FreeSpec with Matchers {
   "sortAccountsByReportSummary" - {
     val now = DateTime.now()
 
-    val humanRed = HumanUser("humanRed", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red, Some(1), None)
-    val humanAmber = HumanUser("humanAmber", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None)
-    val humanGreen = HumanUser("humanGreen", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, Some(1), None)
-    val machineAmber = MachineUser("machineAmber", AccessKey(AccessKeyDisabled, None), AccessKey(NoKey, None), Amber, Some(1), None)
-    val machineGreen = MachineUser("machineGreen", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None)
+    val humanRed = HumanUser("humanRed", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red, Some(1), None, List.empty)
+    val humanAmber = HumanUser("humanAmber", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None, List.empty)
+    val humanGreen = HumanUser("humanGreen", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, Some(1), None, List.empty)
+    val machineAmber = MachineUser("machineAmber", AccessKey(AccessKeyDisabled, None), AccessKey(NoKey, None), Amber, Some(1), None, List.empty)
+    val machineGreen = MachineUser("machineGreen", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None, List.empty)
 
     val reportNoUsers = CredentialReportDisplay(now, humanUsers = Seq.empty, machineUsers = Seq.empty)
     val reportAllGreen = CredentialReportDisplay(now, humanUsers = Seq(humanGreen, humanGreen), machineUsers = Seq(machineGreen, machineGreen))
@@ -255,11 +255,11 @@ class CredentialsReportDisplayTest extends FreeSpec with Matchers {
     }
 
     "returns individual counts for each report status" in {
-      val humanRed = HumanUser("humanRed", hasMFA = false, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Red, Some(1), None)
-      val humanGreen = HumanUser("humanGreen", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None)
-      val machineAmber = MachineUser("machineAmber", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None)
-      val machineBlue = MachineUser("machineGreen", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Blue, Some(1), None)
-      val machineGreen = MachineUser("machineGreen", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None)
+      val humanRed = HumanUser("humanRed", hasMFA = false, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Red, Some(1), None, List.empty)
+      val humanGreen = HumanUser("humanGreen", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None, List.empty)
+      val machineAmber = MachineUser("machineAmber", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None, List.empty)
+      val machineBlue = MachineUser("machineGreen", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Blue, Some(1), None, List.empty)
+      val machineGreen = MachineUser("machineGreen", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None, List.empty)
       val report = CredentialReportDisplay(
         now, humanUsers = Seq(humanRed, humanGreen), machineUsers = Seq(machineAmber, machineBlue, machineGreen, machineAmber, machineBlue, machineBlue)
       )
@@ -272,17 +272,17 @@ class CredentialsReportDisplayTest extends FreeSpec with Matchers {
   "sortUsersByReportSummary" - {
     val now = DateTime.now()
 
-    val humanRedA = HumanUser("humanRedA", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red, Some(1), None)
-    val humanRedB = HumanUser("humanRedB", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red, Some(1), None)
-    val humanAmberA = HumanUser("humanAmberA", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None)
-    val humanAmberB = HumanUser("humanAmberB", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None)
-    val humanGreenA = HumanUser("humanGreenA", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, Some(1), None)
-    val humanGreenB = HumanUser("humanGreenB", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, Some(1), None)
+    val humanRedA = HumanUser("humanRedA", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red, Some(1), None, List.empty)
+    val humanRedB = HumanUser("humanRedB", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red, Some(1), None, List.empty)
+    val humanAmberA = HumanUser("humanAmberA", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None, List.empty)
+    val humanAmberB = HumanUser("humanAmberB", hasMFA = true, AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Amber, Some(1), None, List.empty)
+    val humanGreenA = HumanUser("humanGreenA", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, Some(1), None, List.empty)
+    val humanGreenB = HumanUser("humanGreenB", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, Some(1), None, List.empty)
 
-    val machineAmberA = MachineUser("machineAmberA", AccessKey(AccessKeyDisabled, None), AccessKey(NoKey, None), Amber, Some(1), None)
-    val machineAmberB = MachineUser("machineAmberB", AccessKey(AccessKeyDisabled, None), AccessKey(NoKey, None), Amber, Some(1), None)
-    val machineGreenA = MachineUser("machineGreenA", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None)
-    val machineGreenB = MachineUser("machineGreenB", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None)
+    val machineAmberA = MachineUser("machineAmberA", AccessKey(AccessKeyDisabled, None), AccessKey(NoKey, None), Amber, Some(1), None, List.empty)
+    val machineAmberB = MachineUser("machineAmberB", AccessKey(AccessKeyDisabled, None), AccessKey(NoKey, None), Amber, Some(1), None, List.empty)
+    val machineGreenA = MachineUser("machineGreenA", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None, List.empty)
+    val machineGreenB = MachineUser("machineGreenB", AccessKey(AccessKeyEnabled, None), AccessKey(AccessKeyEnabled, None), Green, Some(1), None, List.empty)
 
     "will sort according to username if the ReportStatuses are equal" in {
       val report = CredentialReportDisplay(now,

--- a/hq/test/model/TagTest.scala
+++ b/hq/test/model/TagTest.scala
@@ -1,0 +1,28 @@
+package model
+
+import com.gu.anghammarad.models.{App, Stack, Stage => AnghammaradStage}
+import org.scalatest.{FreeSpec, Matchers}
+
+class TagTest extends FreeSpec with Matchers {
+  val tagsListWithStack = List(Tag("stAck", "pawnee"), Tag("department", "parks and recreation"))
+  val tagsListWithStackStageApp = List(Tag("stack", "pawnee"), Tag("stage", "enquiry"), Tag("app", "the-pit"))
+
+
+  "findAnghammaradTarget should locate available target tag regardless of case" in {
+    Tag.findAnghammaradTarget("stack", Stack, tagsListWithStack) shouldEqual Some(Stack("pawnee"))
+    Tag.findAnghammaradTarget("STACK", Stack, tagsListWithStack) shouldEqual Some(Stack("pawnee"))
+    Tag.findAnghammaradTarget("blah", Stack, tagsListWithStack) shouldEqual None
+  }
+
+  "tagsToAnghammaradTargets should convert tags to targets" in {
+    Tag.tagsToAnghammaradTargets(tagsListWithStackStageApp) shouldEqual List(Stack("pawnee"), AnghammaradStage("enquiry"), App("the-pit"))
+    Tag.tagsToAnghammaradTargets(tagsListWithStack) shouldEqual List(Stack("pawnee"))
+  }
+
+  "tagsToSSAID should correctly convert tags to a string" in {
+    Tag.tagsToSSAID(tagsListWithStackStageApp) shouldEqual "the-pit-pawnee-enquiry"
+    Tag.tagsToSSAID(List(Tag("venue", "entertainment 720"))) shouldEqual Tag.EMPTY_SSAID
+    Tag.tagsToSSAID(tagsListWithStack) shouldEqual "pawnee"
+  }
+
+}

--- a/hq/test/schedule/IamAuditTest.scala
+++ b/hq/test/schedule/IamAuditTest.scala
@@ -20,26 +20,26 @@ class IamAuditTest extends FreeSpec with Matchers {
         CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
           Seq(
-            MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None),
-            MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None),
-            MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None),
+            MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None, List.empty),
+            MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None, List.empty),
+            MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None, List.empty),
           ),
           Seq(
-            HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None),
-            HumanUser("", true, oldHumanAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None),
-            HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None),
+            HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None, List.empty),
+            HumanUser("", true, oldHumanAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None, List.empty),
+            HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None, List.empty),
           )
         )
       val result: CredentialReportDisplay =
         CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
           Seq(
-            MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None),
-            MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None),
+            MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None, List.empty),
+            MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None, List.empty),
           ),
           Seq(
-            HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None),
-            HumanUser("", true, oldHumanAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None),
+            HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red, None, None, List.empty),
+            HumanUser("", true, oldHumanAccessKeyEnabled, AccessKey(NoKey, None), Red, None, None, List.empty),
           )
         )
       findOldAccessKeys(credsReport) shouldEqual result
@@ -48,10 +48,10 @@ class IamAuditTest extends FreeSpec with Matchers {
       val credsReport: CredentialReportDisplay = CredentialReportDisplay(
         new DateTime(2021, 1, 1, 1, 1),
         Seq(
-          MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(11))), AccessKey(NoKey, None), Red, None, None),
+          MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(11))), AccessKey(NoKey, None), Red, None, None, List.empty),
         ),
         Seq(
-          HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None),
+          HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None, List.empty),
         )
       )
       val result: CredentialReportDisplay = CredentialReportDisplay(
@@ -63,18 +63,18 @@ class IamAuditTest extends FreeSpec with Matchers {
       val credsReport: CredentialReportDisplay = CredentialReportDisplay(
         new DateTime(2021, 1, 1, 1, 1),
         Seq(
-          MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(10))), AccessKey(NoKey, None), Red, None, None),
+          MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(10))), AccessKey(NoKey, None), Red, None, None, List.empty),
         ),
         Seq(
-          HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None),
-          HumanUser("", false, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, None, None),
+          HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None, List.empty),
+          HumanUser("", false, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, None, None, List.empty),
         )
       )
       val result: CredentialReportDisplay = CredentialReportDisplay(
         new DateTime(2021, 1, 1, 1, 1),
         Seq.empty,
         Seq(
-          HumanUser("", false, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, None, None),
+          HumanUser("", false, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, None, None, List.empty),
         )
       )
       findMissingMfa(credsReport) shouldEqual result
@@ -83,11 +83,11 @@ class IamAuditTest extends FreeSpec with Matchers {
       val credsReport: CredentialReportDisplay = CredentialReportDisplay(
         new DateTime(2021, 1, 1, 1, 1),
         Seq(
-          MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(9))), AccessKey(NoKey, None), Red, None, None),
+          MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(9))), AccessKey(NoKey, None), Red, None, None, List.empty),
         ),
         Seq(
-          HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None),
-          HumanUser("", true, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, None, None),
+          HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None, List.empty),
+          HumanUser("", true, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, None, None, List.empty),
         )
       )
       val result: CredentialReportDisplay = CredentialReportDisplay(
@@ -103,13 +103,13 @@ class IamAuditTest extends FreeSpec with Matchers {
         AwsAccount("", "", "") -> Right(CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
           Seq(
-            MachineUser("machine user A", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None),
-            MachineUser("machine user B", AccessKey(AccessKeyEnabled, Some(new DateTime(2019, 12, 12, 1, 1))), AccessKey(NoKey, None), Red, Some(243), None),
-            MachineUser("machine user C", AccessKey(NoKey, None), AccessKey(AccessKeyEnabled, Some(new DateTime(2015, 6, 5, 12, 1))), Red, Some(243), None),
+            MachineUser("machine user A", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None, List.empty),
+            MachineUser("machine user B", AccessKey(AccessKeyEnabled, Some(new DateTime(2019, 12, 12, 1, 1))), AccessKey(NoKey, None), Red, Some(243), None, List.empty),
+            MachineUser("machine user C", AccessKey(NoKey, None), AccessKey(AccessKeyEnabled, Some(new DateTime(2015, 6, 5, 12, 1))), Red, Some(243), None, List.empty),
           ),
           Seq(
-            HumanUser("username A", false, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, Some(365), None),
-            HumanUser("username B", true, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, Some(150), None),
+            HumanUser("username A", false, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, Some(365), None, List.empty),
+            HumanUser("username B", true, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, Some(150), None, List.empty),
           )
         ))
       )
@@ -121,13 +121,13 @@ class IamAuditTest extends FreeSpec with Matchers {
           |Username: machine user B
           |Key 1 last rotation: 12/12/2019
           |Key 2 last rotation: Unknown
-          |Last active: 243 days ago
+          |Last active: 242 days ago
           |
           |
           |Username: machine user C
           |Key 1 last rotation: Unknown
           |Key 2 last rotation: 05/06/2015
-          |Last active: 243 days ago
+          |Last active: 242 days ago
           |
           |
           |Username: username B
@@ -151,7 +151,7 @@ class IamAuditTest extends FreeSpec with Matchers {
         List(AwsAccountTarget("")),
         Preferred(Email),
         "Security HQ Credentials Notifier")
-      val result: List[Either[FailedAttempt, Notification]] = List(Right(notification))
+      val result = List(Right(Seq(notification)))
       makeCredentialsNotification(allCreds) shouldEqual result
     }
     "makes a credentials notification with a message notifying about old access keys only" in {
@@ -160,13 +160,13 @@ class IamAuditTest extends FreeSpec with Matchers {
         AwsAccount("", "", "") -> Right(CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
           Seq(
-            MachineUser("machine user A", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None),
-            MachineUser("machine user B", AccessKey(AccessKeyEnabled, Some(new DateTime(2018, 12, 12, 1, 1))), AccessKey(NoKey, None), Red, Some(243), None),
-            MachineUser("machine user C", AccessKey(NoKey, None), AccessKey(AccessKeyEnabled, Some(new DateTime(2015, 6, 5, 12, 1))), Red, Some(243), None),
+            MachineUser("machine user A", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, None, None, List.empty),
+            MachineUser("machine user B", AccessKey(AccessKeyEnabled, Some(new DateTime(2018, 12, 12, 1, 1))), AccessKey(NoKey, None), Red, Some(243), None, List.empty),
+            MachineUser("machine user C", AccessKey(NoKey, None), AccessKey(AccessKeyEnabled, Some(new DateTime(2015, 6, 5, 12, 1))), Red, Some(243), None, List.empty),
           ),
           Seq(
-            HumanUser("username A", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, Some(365), None),
-            HumanUser("username B", true, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, Some(150), None),
+            HumanUser("username A", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, Some(365), None, List.empty),
+            HumanUser("username B", true, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red, Some(150), None, List.empty),
           )
         ))
       )
@@ -178,13 +178,13 @@ class IamAuditTest extends FreeSpec with Matchers {
           |Username: machine user B
           |Key 1 last rotation: 12/12/2018
           |Key 2 last rotation: Unknown
-          |Last active: 243 days ago
+          |Last active: 242 days ago
           |
           |
           |Username: machine user C
           |Key 1 last rotation: Unknown
           |Key 2 last rotation: 05/06/2015
-          |Last active: 243 days ago
+          |Last active: 242 days ago
           |
           |
           |Username: username B
@@ -203,7 +203,7 @@ class IamAuditTest extends FreeSpec with Matchers {
         List(AwsAccountTarget("")),
         Preferred(Email),
         "Security HQ Credentials Notifier")
-      val result: List[Either[FailedAttempt, Notification]] = List(Right(notification))
+      val result = List(Right(Seq(notification)))
       makeCredentialsNotification(allCreds) shouldEqual result
     }
     "makes a credentials notification with a message notifying about missing mfas only" in {
@@ -213,8 +213,8 @@ class IamAuditTest extends FreeSpec with Matchers {
           new DateTime(2021, 1, 1, 1, 1),
           Seq.empty,
           Seq(
-            HumanUser("username A", false, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, Some(365), None),
-            HumanUser("username B", false, AccessKey(NoKey, None), AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(2))), Red, Some(150), None),
+            HumanUser("username A", false, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Red, Some(365), None, List.empty),
+            HumanUser("username B", false, AccessKey(NoKey, None), AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(2))), Red, Some(150), None, List.empty),
           )
         ))
       )
@@ -241,7 +241,7 @@ class IamAuditTest extends FreeSpec with Matchers {
         List(AwsAccountTarget("")),
         Preferred(Email),
         "Security HQ Credentials Notifier")
-      val result: List[Either[FailedAttempt, Notification]] = List(Right(notification))
+      val result = List(Right(Seq(notification)))
       makeCredentialsNotification(allCreds) shouldEqual result
     }
     "returns a failure when there are no old access keys or missing mfas" in {

--- a/hq/test/schedule/IamAuditTest.scala
+++ b/hq/test/schedule/IamAuditTest.scala
@@ -1,14 +1,72 @@
 package schedule
 
-import com.gu.anghammarad.models.{Email, Notification, Preferred, AwsAccount => AwsAccountTarget}
+import com.gu.anghammarad.models.{Email, Notification, Preferred, Stack, Target, AwsAccount => AwsAccountTarget}
 import logic.DateUtils.dayDiff
-import model._
+import model.{UserWithOutdatedKeys, _}
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
 import schedule.IamAudit._
 import utils.attempt.FailedAttempt
 
 class IamAuditTest extends FreeSpec with Matchers {
+  val outdatedUser1: UserWithOutdatedKeys = UserWithOutdatedKeys("lesleyKnope", Some(DateTime.now.minusDays(400)), None, None, List())
+  val outdatedUser2: UserWithOutdatedKeys = UserWithOutdatedKeys("ronSwanson", Some(DateTime.now.minusDays(400)), None, None, List())
+  val outdatedUser3: UserWithOutdatedKeys = UserWithOutdatedKeys("tomHaverford", Some(DateTime.now.minusDays(400)), None, None, List())
+
+  val noMfaUser1: UserNoMfa = UserNoMfa("april", None, List())
+  val noMfaUser2: UserNoMfa = UserNoMfa("andy", None, List())
+  val noMfaUser3: UserNoMfa = UserNoMfa("diane", None, List())
+
+
+  "getNotificationTargetGroups" - {
+    "correctly builds target groups when users have no tags " in {
+      val targetGroups = getNotificationTargetGroups(Seq(outdatedUser1, outdatedUser2), Seq(noMfaUser1, noMfaUser2))
+      targetGroups.length shouldEqual 1
+      targetGroups.head.noMfaUsers.length shouldEqual 2
+      targetGroups.head.outdatedKeysUsers.length shouldEqual 2
+    }
+
+    "correctly builds target groups when users have tags" in {
+      val parks = Tag("Stack", "parks")
+      val recreation = Tag("Stack", "recreation")
+
+      val inputOutdatedUsers = Seq(
+        outdatedUser1,
+        outdatedUser2.copy(tags=List(parks)),
+        outdatedUser3.copy(tags=List(recreation))
+      )
+
+      val inputNoMfaUsers = Seq(
+        noMfaUser1,
+        noMfaUser2.copy(tags=List(Tag("Stack", "parks"))),
+        noMfaUser3.copy(tags=List(Tag("Stack", "recreation")))
+      )
+
+      val targetGroups = getNotificationTargetGroups(inputOutdatedUsers, inputNoMfaUsers)
+
+      targetGroups.length shouldEqual 3
+
+      val parkGroup = targetGroups.find(t => t.targets.exists{
+        case Stack(stack) => stack == "parks"
+        case _ => false
+      })
+      parkGroup shouldBe defined
+      val parkGroupNoMfaUsers = parkGroup.get.noMfaUsers
+      parkGroupNoMfaUsers.head.username shouldBe noMfaUser2.username
+
+      val noTagGroup = targetGroups.find(t => t.targets.isEmpty)
+      noTagGroup shouldBe defined
+      noTagGroup.get.noMfaUsers shouldEqual List(noMfaUser1)
+
+    }
+
+    "correctly builds target list when there are only mfa users" in {
+      val targetGroups = getNotificationTargetGroups(Seq(), Seq(noMfaUser1, noMfaUser2))
+      targetGroups.length shouldEqual 1
+      targetGroups.head.noMfaUsers.length shouldEqual 2
+      targetGroups.head.outdatedKeysUsers.length shouldEqual 0
+    }
+  }
   "findOldCredentialsAndMissingMfas" - {
     "returns CredentialReportDisplays with access keys greater than 90 days old" in {
       val oldHumanAccessKeyEnabled: AccessKey = AccessKey(AccessKeyEnabled, Some(new DateTime(2021, 1, 15, 1, 1)))

--- a/hq/test/schedule/IamAuditTest.scala
+++ b/hq/test/schedule/IamAuditTest.scala
@@ -180,13 +180,13 @@ class IamAuditTest extends FreeSpec with Matchers {
           |Username: machine user B
           |Key 1 last rotation: 12/12/2019
           |Key 2 last rotation: Unknown
-          |Last active: 242 days ago
+          |Last active: 243 days ago
           |
           |
           |Username: machine user C
           |Key 1 last rotation: Unknown
           |Key 2 last rotation: 05/06/2015
-          |Last active: 242 days ago
+          |Last active: 243 days ago
           |
           |
           |Username: username B
@@ -241,13 +241,13 @@ class IamAuditTest extends FreeSpec with Matchers {
           |Username: machine user B
           |Key 1 last rotation: 12/12/2018
           |Key 2 last rotation: Unknown
-          |Last active: 242 days ago
+          |Last active: 243 days ago
           |
           |
           |Username: machine user C
           |Key 1 last rotation: Unknown
           |Key 2 last rotation: 05/06/2015
-          |Last active: 242 days ago
+          |Last active: 243 days ago
           |
           |
           |Username: username B


### PR DESCRIPTION
## What does this change?
This PR does two things:

 - Sets security HQ up to enrich the data it gets from the IAM report with IAM User Tags. The current approach is to fail an entire report if the call to 'describe tags' for any of the users within the report fails. This isn't very resilient, and may need more work in future so that even if the tag fetch fails, the IAM report is still available. This work is all in this commit https://github.com/guardian/security-hq/commit/0d92708246498a7a9ab4b96c8aa0571c0a5cabdf **this feature is currently disabled**
 - Modifies `makeCredentialsNotification` so that it splits notifications into groups based off the  tags of the users with issues. Each group has a list of Targets, which are used by anghammarad to determine where to send the alert to. There's a fairly awkward operation here which happens in `getNotificationTargetGroups`

The motivation for opening this PR with the feature disabled is that  the reaper work @Nirvikalpa108 is doing builds on the same functions modified by this work. To avoid mega merge conflicts it's best to get this in place now before trying to deal with the problematic stack sets.

Tested on PROD - doesn't seem to cause any issues!

## What is the value of this?
For teams that share accounts we can send the right alerts to the right mailing list

## Will this require CloudFormation and/or updates to the AWS StackSet?
yes, see https://github.com/guardian/security-hq/pull/237  (merged)


