### PR TITLE
refactor: Use `FormData` to react to filter changes

### DIFF
--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -50,15 +50,15 @@
         <div class="row">
             <div class="card-panel valign-wrapper">
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-critical-findings" checked="checked" name="showCriticalFindings" />
+                    <input type="checkbox" id="show-critical-findings" checked="checked" name="showCriticalFindings" />
                     <label class="black-text finding-filter__label" for="show-critical-findings">Critical</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-high-findings" checked="checked" name="showHighFindings" />
+                    <input type="checkbox" id="show-high-findings" checked="checked" name="showHighFindings" />
                     <label class="black-text finding-filter__label" for="show-high-findings">High</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-medium-findings" checked="checked" name="showMediumFindings" />
+                    <input type="checkbox" id="show-medium-findings" checked="checked" name="showMediumFindings" />
                     <label class="black-text finding-filter__label" for="show-medium-findings">Medium</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-low-findings" name="showLowFindings" />
+                    <input type="checkbox" id="show-low-findings" name="showLowFindings" />
                     <label class="black-text finding-filter__label" for="show-low-findings">Low</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-unknown-findings" name="showUnknownFindings" />
+                    <input type="checkbox" id="show-unknown-findings" name="showUnknownFindings" />
                     <label class="black-text finding-filter__label" for="show-unknown-findings">Unknown</label>
                 </form>
             </div>

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -50,15 +50,15 @@
         <div class="row">
             <div class="card-panel valign-wrapper">
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-critical-findings" checked="checked" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-critical-findings" checked="checked" name="showCriticalFindings" />
                     <label class="black-text finding-filter__label" for="show-critical-findings">Critical</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-high-findings" checked="checked" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-high-findings" checked="checked" name="showHighFindings" />
                     <label class="black-text finding-filter__label" for="show-high-findings">High</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-medium-findings" checked="checked" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-medium-findings" checked="checked" name="showMediumFindings" />
                     <label class="black-text finding-filter__label" for="show-medium-findings">Medium</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-low-findings" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-low-findings" name="showLowFindings" />
                     <label class="black-text finding-filter__label" for="show-low-findings">Low</label>
-                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-unknown-findings" />
+                    <input class="js-finding-filter-for-gcp" type="checkbox" id="show-unknown-findings" name="showUnknownFindings" />
                     <label class="black-text finding-filter__label" for="show-unknown-findings">Unknown</label>
                 </form>
             </div>

--- a/hq/app/views/s3/publicBuckets.scala.html
+++ b/hq/app/views/s3/publicBuckets.scala.html
@@ -49,9 +49,9 @@
                 <span class="finding-header__name">Some results may be ignored due to settings in AWS Trusted Advisor</span>
 
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
+                    <input type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
                     <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
-                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
+                    <input type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                     <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                 </form>
             </div>
@@ -60,7 +60,7 @@
                 <span class="finding-header__name">Some buckets may not have encryption enabled for data at rest</span>
 
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" name="showUnencryptedFindings"/>
+                    <input type="checkbox" id="show-unencrypted-findings" checked="checked" name="showUnencryptedFindings"/>
                     <label class="black-text finding-filter__label" for="show-unencrypted-findings">Show all unencrypted buckets</label>
                 </form>
             </div>

--- a/hq/app/views/s3/publicBuckets.scala.html
+++ b/hq/app/views/s3/publicBuckets.scala.html
@@ -49,9 +49,9 @@
                 <span class="finding-header__name">Some results may be ignored due to settings in AWS Trusted Advisor</span>
 
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
+                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
                     <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
-                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
+                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                     <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                 </form>
             </div>
@@ -60,7 +60,7 @@
                 <span class="finding-header__name">Some buckets may not have encryption enabled for data at rest</span>
 
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" />
+                    <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" name="showUnencryptedFindings"/>
                     <label class="black-text finding-filter__label" for="show-unencrypted-findings">Show all unencrypted buckets</label>
                 </form>
             </div>

--- a/hq/app/views/s3/publicBucketsAccount.scala.html
+++ b/hq/app/views/s3/publicBucketsAccount.scala.html
@@ -58,10 +58,10 @@
                                 Some results may be ignored due to settings in AWS Trusted Advisor</span>
 
                             <form class="finding-filter" action="#">
-                                <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
+                                <input type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
                                 <label class="black-text finding-filter__label" for="show-flagged-findings">
                                     Show flagged</label>
-                                <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
+                                <input type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                                 <label class="black-text finding-filter__label" for="show-ignored-findings">
                                     Show ignored</label>
                             </form>
@@ -73,7 +73,7 @@
                                 Some buckets may not have encryption enabled for data at rest</span>
 
                             <form class="finding-filter" action="#">
-                                <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" name="showUnencryptedFindings" />
+                                <input type="checkbox" id="show-unencrypted-findings" checked="checked" name="showUnencryptedFindings" />
                                 <label class="black-text finding-filter__label" for="show-unencrypted-findings">
                                     Show all unencrypted buckets</label>
                             </form>

--- a/hq/app/views/s3/publicBucketsAccount.scala.html
+++ b/hq/app/views/s3/publicBucketsAccount.scala.html
@@ -58,10 +58,10 @@
                                 Some results may be ignored due to settings in AWS Trusted Advisor</span>
 
                             <form class="finding-filter" action="#">
-                                <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
+                                <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
                                 <label class="black-text finding-filter__label" for="show-flagged-findings">
                                     Show flagged</label>
-                                <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
+                                <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                                 <label class="black-text finding-filter__label" for="show-ignored-findings">
                                     Show ignored</label>
                             </form>
@@ -73,7 +73,7 @@
                                 Some buckets may not have encryption enabled for data at rest</span>
 
                             <form class="finding-filter" action="#">
-                                <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" />
+                                <input class="js-finding-filter-for-s3" type="checkbox" id="show-unencrypted-findings" checked="checked" name="showUnencryptedFindings" />
                                 <label class="black-text finding-filter__label" for="show-unencrypted-findings">
                                     Show all unencrypted buckets</label>
                             </form>

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -54,9 +54,9 @@
                 <span class="finding-header__name">Some Security Groups may be ignored due to settings in AWS Trusted Advisor</span>
 
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
+                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings"/>
                     <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
-                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
+                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                     <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                 </form>
             </div>

--- a/hq/app/views/sgs/sgs.scala.html
+++ b/hq/app/views/sgs/sgs.scala.html
@@ -54,9 +54,9 @@
                 <span class="finding-header__name">Some Security Groups may be ignored due to settings in AWS Trusted Advisor</span>
 
                 <form class="finding-filter" action="#">
-                    <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings"/>
+                    <input type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings"/>
                     <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
-                    <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
+                    <input type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                     <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                 </form>
             </div>

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -40,9 +40,9 @@
                         <span class="finding-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
 
                         <form class="finding-filter" action="#">
-                            <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
+                            <input type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
                             <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
-                            <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
+                            <input type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                             <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                         </form>
                     </div>

--- a/hq/app/views/sgs/sgsAccount.scala.html
+++ b/hq/app/views/sgs/sgsAccount.scala.html
@@ -40,9 +40,9 @@
                         <span class="finding-header__name">Some Security Groups have been ignored due to settings in AWS Trusted Advisor</span>
 
                         <form class="finding-filter" action="#">
-                            <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" />
+                            <input class="js-finding-filter" type="checkbox" id="show-flagged-findings" checked="checked" name="showFlaggedFindings" />
                             <label class="black-text finding-filter__label" for="show-flagged-findings">Show flagged</label>
-                            <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" />
+                            <input class="js-finding-filter" type="checkbox" id="show-ignored-findings" name="showIgnoredFindings" />
                             <label class="black-text finding-filter__label" for="show-ignored-findings">Show ignored</label>
                         </form>
                     </div>

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -48,9 +48,20 @@ $(document).ready(function () {
     const lowFindings = $('.finding-low');
     const unknownFindings = $('.finding-unknown');
 
+    const toggleElements = (checkboxValue, elements) => {
+      if (checkboxValue === undefined) {
+        // field is not on the current page's form, nothing to do
+        return;
+      }
+
+      // Checkboxes have a value of `on` or `off`. Yay HTML forms!
+      return checkboxValue === 'on' ? elements.show() : elements.hide();
+    };
+
     form.addEventListener('input', function () {
       const formData = new FormData(form);
 
+      // values are `undefined` by default, for example if they are not on the current page's form
       const {
         // S3 and Security Group filters
         showFlaggedFindings,
@@ -67,16 +78,14 @@ $(document).ready(function () {
         showUnknownFindings,
       } = Object.fromEntries(formData);
 
-      showIgnoredFindings ? ignoredFindings.show() : ignoredFindings.hide();
-      showFlaggedFindings ? flaggedFindings.show() : flaggedFindings.hide();
-      showUnencryptedFindings
-        ? unencryptedFindings.show()
-        : unencryptedFindings.hide();
-      showCriticalFindings ? criticalFindings.show() : criticalFindings.hide();
-      showHighFindings ? highFindings.show() : highFindings.hide();
-      showMediumFindings ? mediumFindings.show() : mediumFindings.hide();
-      showLowFindings ? lowFindings.show() : lowFindings.hide();
-      showUnknownFindings ? unknownFindings.show() : unknownFindings.hide();
+      toggleElements(showIgnoredFindings, ignoredFindings);
+      toggleElements(showFlaggedFindings, flaggedFindings);
+      toggleElements(showUnencryptedFindings, unencryptedFindings);
+      toggleElements(showCriticalFindings, criticalFindings);
+      toggleElements(showHighFindings, highFindings);
+      toggleElements(showMediumFindings, mediumFindings);
+      toggleElements(showLowFindings, lowFindings);
+      toggleElements(showUnknownFindings, unknownFindings);
     });
   }
 

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -1,4 +1,4 @@
-jQuery(function($) {
+jQuery(function ($) {
   // idempotent redirect to HTTPS
   if (!/^https/.test(window.location.protocol)) {
     // eslint-disable-next-line no-console
@@ -7,20 +7,20 @@ jQuery(function($) {
   }
 });
 
-$(document).ready(function() {
+$(document).ready(function () {
   // initalizing the mobile nav and the modal
   $('.button-collapse').sideNav();
   $('.modal').modal();
   // Make any tables with the filter class filterable
   $('.filterable-table').filterTable();
 
-  $('.js-iam-expand').click(function() {
+  $('.js-iam-expand').click(function () {
     $('.collapsible-header').addClass('active');
     $('.collapsible-body').css('display', 'block');
   });
 
-  $('.js-iam-collapse').click(function() {
-    $('.collapsible-header').removeClass(function() {
+  $('.js-iam-collapse').click(function () {
+    $('.collapsible-header').removeClass(function () {
       return 'active';
     });
     $('.collapsible-body').css('display', 'none');
@@ -28,16 +28,16 @@ $(document).ready(function() {
 
   // Extra interactions for the dropdowns on the Security Groups page
   $('.js-finding-details').hover(
-    function() {
+    function () {
       $(this).collapsible('open', 0);
     },
-    function() {
+    function () {
       $(this).collapsible('close', 0);
     }
   );
 
   // filtering table results
-  $('.js-finding-filter').change(function() {
+  $('.js-finding-filter').change(function () {
     $('#show-ignored-findings')[0].checked
       ? $('.finding-suppressed--true').show()
       : $('.finding-suppressed--true').hide();
@@ -45,30 +45,30 @@ $(document).ready(function() {
       ? $('.finding-suppressed--false').show()
       : $('.finding-suppressed--false').hide();
   });
-  $('.js-finding-filter-for-s3').change(function() {
+  $('.js-finding-filter-for-s3').change(function () {
     $('#show-unencrypted-findings')[0].checked
       ? $('.finding-unencrypted').show()
       : $('.finding-unencrypted').hide();
   });
-  $('.js-finding-filter-for-gcp').change(function() {
+  $('.js-finding-filter-for-gcp').change(function () {
     $('#show-critical-findings')[0].checked
-        ? $('.finding-critical').show()
-        : $('.finding-critical').hide();
+      ? $('.finding-critical').show()
+      : $('.finding-critical').hide();
     $('#show-high-findings')[0].checked
-        ? $('.finding-high').show()
-        : $('.finding-high').hide();
+      ? $('.finding-high').show()
+      : $('.finding-high').hide();
     $('#show-medium-findings')[0].checked
-        ? $('.finding-medium').show()
-        : $('.finding-medium').hide();
+      ? $('.finding-medium').show()
+      : $('.finding-medium').hide();
     $('#show-low-findings')[0].checked
-        ? $('.finding-low').show()
-        : $('.finding-low').hide();
+      ? $('.finding-low').show()
+      : $('.finding-low').hide();
     $('#show-unknown-findings')[0].checked
-        ? $('.finding-unknown').show()
-        : $('.finding-unknown').hide();
+      ? $('.finding-unknown').show()
+      : $('.finding-unknown').hide();
   });
 
-  $('.js-finding-details').click(function() {
+  $('.js-finding-details').click(function () {
     $(this).collapsible('destroy');
 
     var clicks = $(this).data('clicks') || false;
@@ -82,49 +82,47 @@ $(document).ready(function() {
   });
 
   // Functionality for the floating menus on the Security Groups page
-  $('.js-finding-pin-close').click(function() {
-    $('html, body')
-      .stop()
-      .animate(
-        {
-          scrollTop: 0
-        },
-        'slow'
-      );
-    $('.collapsible-header').removeClass(function() {
+  $('.js-finding-pin-close').click(function () {
+    $('html, body').stop().animate(
+      {
+        scrollTop: 0,
+      },
+      'slow'
+    );
+    $('.collapsible-header').removeClass(function () {
       return 'active';
     });
     $('.collapsible').collapsible({ accordion: true });
     $('.collapsible').collapsible({ accordion: false });
   });
 
-  $('.js-finding-pin-top').click(function() {
+  $('.js-finding-pin-top').click(function () {
     const scrollTarget = $(this).closest('.js-finding-scroll');
     $('html, body')
       .stop()
       .animate(
         {
-          scrollTop: scrollTarget.offset().top - 10
+          scrollTop: scrollTarget.offset().top - 10,
         },
         'slow'
       );
   });
 
-  $('.js-finding-pin-end').click(function() {
+  $('.js-finding-pin-end').click(function () {
     const scrollTarget = $(this).closest('.js-finding-scroll');
     $('html, body')
       .stop()
       .animate(
         {
-          scrollTop: scrollTarget[0].scrollHeight - 200
+          scrollTop: scrollTarget[0].scrollHeight - 200,
         },
         'slow'
       );
   });
-  $('.tooltipped').tooltip({enterDelay: 0, inDuration: 100});
+  $('.tooltipped').tooltip({ enterDelay: 0, inDuration: 100 });
 
   // Functionality for the GCP table
-  $('.js-read-more').click(function() {
+  $('.js-read-more').click(function () {
     $(this).parent().find('.gcp-toggle').toggle();
   });
 });

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -37,36 +37,48 @@ $(document).ready(function () {
   );
 
   // filtering table results
-  $('.js-finding-filter').change(function () {
-    $('#show-ignored-findings')[0].checked
-      ? $('.finding-suppressed--true').show()
-      : $('.finding-suppressed--true').hide();
-    $('#show-flagged-findings')[0].checked
-      ? $('.finding-suppressed--false').show()
-      : $('.finding-suppressed--false').hide();
-  });
-  $('.js-finding-filter-for-s3').change(function () {
-    $('#show-unencrypted-findings')[0].checked
-      ? $('.finding-unencrypted').show()
-      : $('.finding-unencrypted').hide();
-  });
-  $('.js-finding-filter-for-gcp').change(function () {
-    $('#show-critical-findings')[0].checked
-      ? $('.finding-critical').show()
-      : $('.finding-critical').hide();
-    $('#show-high-findings')[0].checked
-      ? $('.finding-high').show()
-      : $('.finding-high').hide();
-    $('#show-medium-findings')[0].checked
-      ? $('.finding-medium').show()
-      : $('.finding-medium').hide();
-    $('#show-low-findings')[0].checked
-      ? $('.finding-low').show()
-      : $('.finding-low').hide();
-    $('#show-unknown-findings')[0].checked
-      ? $('.finding-unknown').show()
-      : $('.finding-unknown').hide();
-  });
+  const form = document.querySelector('form.finding-filter');
+  if (form) {
+    const ignoredFindings = $('.finding-suppressed--true');
+    const flaggedFindings = $('.finding-suppressed--false');
+    const unencryptedFindings = $('.finding-unencrypted');
+    const criticalFindings = $('.finding-critical');
+    const highFindings = $('.finding-high');
+    const mediumFindings = $('.finding-medium');
+    const lowFindings = $('.finding-low');
+    const unknownFindings = $('.finding-unknown');
+
+    form.addEventListener('input', function () {
+      const formData = new FormData(form);
+
+      const {
+        // S3 and Security Group filters
+        showFlaggedFindings,
+        showIgnoredFindings,
+
+        // S3 filters
+        showUnencryptedFindings,
+
+        // GCP filters
+        showCriticalFindings,
+        showHighFindings,
+        showMediumFindings,
+        showLowFindings,
+        showUnknownFindings,
+      } = Object.fromEntries(formData);
+
+      showIgnoredFindings ? ignoredFindings.show() : ignoredFindings.hide();
+      showFlaggedFindings ? flaggedFindings.show() : flaggedFindings.hide();
+      showUnencryptedFindings
+        ? unencryptedFindings.show()
+        : unencryptedFindings.hide();
+      showCriticalFindings ? criticalFindings.show() : criticalFindings.hide();
+      showHighFindings ? highFindings.show() : highFindings.hide();
+      showMediumFindings ? mediumFindings.show() : mediumFindings.hide();
+      showLowFindings ? lowFindings.show() : lowFindings.hide();
+      showUnknownFindings ? unknownFindings.show() : unknownFindings.hide();
+    });
+  }
 
   $('.js-finding-details').click(function () {
     $(this).collapsible('destroy');


### PR DESCRIPTION
## What does this change?

In this change we refactor multiple jQuery event handlers (one per checkbox) into a single event handler on the enclosing form and use `FormData` to understand what has been selected.

From https://developer.mozilla.org/en-US/docs/Web/API/FormData:

> The `FormData` interface provides a way to easily construct a set of key/value pairs representing form fields and their values

Currently, we're reaching into the DOM a few times which, whilst not expensive on small app, does result in quite a lot of code repetition. `FormData` allows us to be terser and more idiomatic.

## What is the value of this?

The end result of this change for the user is a no-op, though we do get:
  - a single event listener
  - a simpler DOM structure
  - slightly less jQuery

It should also mean adding additional filters is simpler, though this is just a hunch.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

## Any additional notes?

Lastly, my IDE runs Prettier on save, so it might be easier to review on a commit by commit basis or with whitespace ignored.