### PR TITLE
Log GCP vulnerabilities to cloudwatch metrics

### DIFF
--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -3,9 +3,10 @@ package logging
 import com.amazonaws.AmazonServiceException
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
+import com.google.cloud.securitycenter.v1.Finding
 import logic.CredentialsReportDisplay
 import logic.CredentialsReportDisplay.reportStatusSummary
-import model.{AwsAccount, CredentialReportDisplay}
+import model.{AwsAccount, CredentialReportDisplay, GcpFinding}
 import play.api.Logging
 import utils.attempt.FailedAttempt
 
@@ -24,15 +25,32 @@ object Cloudwatch extends Logging {
     val iamCredentialsWarning = Value("iam/credentials/warning")
     val iamKeysTotal = Value("iam/keys/total")
     val sgTotal = Value("securitygroup/total")
+    val gcpTotal = Value("gcp/total")
+    val gcpCritical = Value("gcp/critical")
+    val gcpHigh = Value("gcp/high")
+  }
+
+  def logMetricsForGCPFindings(allGcpFindings: Seq[GcpFinding]): Unit = {
+    val gcpProjectToFinding = allGcpFindings.groupBy(_.project)
+
+    gcpProjectToFinding.toSeq.foreach {
+      case (project: String, findings: Seq[GcpFinding]) =>
+        val criticalFindings = allGcpFindings.filter(_.severity == Finding.Severity.CRITICAL)
+        val highFindings = allGcpFindings.filter(_.severity == Finding.Severity.HIGH)
+        putGcpMetric(project, Cloudwatch.DataType.gcpCritical, criticalFindings.length)
+        putGcpMetric(project, Cloudwatch.DataType.gcpHigh, highFindings.length)
+        putGcpMetric(project, Cloudwatch.DataType.gcpTotal, criticalFindings.length + highFindings.length)
+    }
+
   }
 
   def logMetricsForCredentialsReport(data: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] ) : Unit = {
     data.toSeq.foreach {
       case (account: AwsAccount, Right(details: CredentialReportDisplay)) =>
         val reportSummary: CredentialsReportDisplay.ReportSummary = reportStatusSummary(details)
-        putMetric(account, DataType.iamCredentialsCritical, reportSummary.errors)
-        putMetric(account, DataType.iamCredentialsWarning, reportSummary.warnings)
-        putMetric(account, DataType.iamCredentialsTotal, reportSummary.errors + reportSummary.warnings)
+        putAwsMetric(account, DataType.iamCredentialsCritical, reportSummary.errors)
+        putAwsMetric(account, DataType.iamCredentialsWarning, reportSummary.warnings)
+        putAwsMetric(account, DataType.iamCredentialsTotal, reportSummary.errors + reportSummary.warnings)
       case (account: AwsAccount, Left(_)) =>
         logger.error(s"Attempt to log cloudwatch metric failed. IAM data is missing for account ${account.name}.")
     }
@@ -41,25 +59,28 @@ object Cloudwatch extends Logging {
   def logAsMetric[T](data: Map[AwsAccount, Either[FailedAttempt, List[T]]], dataType: DataType.Value ) : Unit = {
     data.toSeq.foreach {
       case (account: AwsAccount, Right(details: List[T])) =>
-        putMetric(account, dataType, details.length)
+        putAwsMetric(account, dataType, details.length)
       case (account: AwsAccount, Left(_)) =>
         logger.error(s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}.")
     }
   }
 
-  def putMetric(account: AwsAccount, dataType: DataType.Value , value: Int): Unit = {
-    val dimension = List(
-      (new Dimension).withName("Account").withValue(account.name),
-      (new Dimension).withName("DataType").withValue(dataType.toString)
-    )
+  def putAwsMetric(account: AwsAccount, dataType: DataType.Value , value: Int): Unit = {
+    putMetric("SecurityHQ", "Vulnerabilities", Seq(("Account", account.name),("DataType", dataType.toString)), value)
+  }
 
-    val datum = new MetricDatum().withMetricName("Vulnerabilities").withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)
-    val request = new PutMetricDataRequest().withNamespace("SecurityHQ").withMetricData(datum)
+  def putGcpMetric(project: String, dataType: DataType.Value , value: Int): Unit = {
+    putMetric("SecurityHQ", "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
+  }
+
+  def putMetric(namespace: String, metricName: String, metricDimensions: Seq[(String, String)] , value: Int): Unit = {
+    val dimension = metricDimensions.map( d => (new Dimension).withName(d._1).withValue(d._2)).toList
+    val datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)
+    val request = new PutMetricDataRequest().withNamespace(namespace).withMetricData(datum)
 
     Try(cloudwatchClient.putMetricData(request)) match {
-      case Success(response) => logger.info(s"METRIC:  Account=${account.name},DataType=${dataType},Value=${value}")
-      case Failure(e: AmazonServiceException) => logger.error(s"Put metric of type ${dataType} failed for account ${account.name}", e)
-      case Failure(e) => logger.error(s"Put metric of type ${dataType} failed for account ${account.name} with an unknown exception", e)
+      case Success(response) => logger.info(s"putMetric: ${datum}")
+      case Failure(e) => logger.error(s"putMetric failure: ${datum}", e)
     }
   }
 }

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -73,7 +73,7 @@ object Cloudwatch extends Logging {
     putMetric("SecurityHQ", "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
   }
 
-  def putMetric(namespace: String, metricName: String, metricDimensions: Seq[(String, String)] , value: Int): Unit = {
+  private def putMetric(namespace: String, metricName: String, metricDimensions: Seq[(String, String)] , value: Int): Unit = {
     val dimension = metricDimensions.map( d => (new Dimension).withName(d._1).withValue(d._2)).toList
     val datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)
     val request = new PutMetricDataRequest().withNamespace(namespace).withMetricData(datum)

--- a/hq/app/services/MetricService.scala
+++ b/hq/app/services/MetricService.scala
@@ -24,6 +24,21 @@ class MetricService(
     }
   }
 
+  /*
+   * The intended behaviour for this method is to only log data to cloudwatch if cache service has a full
+   * data set. If any of it is missing, we try again in 6 hours.
+   *
+   * This is counter intuitive. All the different datapoints (security groups, gcp vulnerabilities etc)
+   * are independent of each other, so it follows that we'd track them independently, and one being missing
+   * shouldn't affect the other.
+   *
+   * The reasoning to force them to be coupled to each other and taking this all or nothing approach is that
+   * it makes aggregation and calculating SUMs over time much easier.
+   *
+   * See these 2 PRs for further discussion and examples with data
+   * - https://github.com/guardian/security-hq/pull/211
+   * - https://github.com/guardian/security-hq/pull/245#discussion_r632548991
+   */
   def postCachedContentsAsMetrics(): Unit = {
     val allSgs = cacheService.getAllSgs
     val allExposedKeys = cacheService.getAllExposedKeys

--- a/hq/app/services/MetricService.scala
+++ b/hq/app/services/MetricService.scala
@@ -63,7 +63,7 @@ class MetricService(
 
   if (environment.mode != Mode.Test) {
     val initialDelay =
-      if (environment.mode == Mode.Prod) 5.minutes
+      if (environment.mode == Mode.Prod) 15.minutes
       else Duration.Zero
 
     val cloudwatchSubscription = Observable.interval(initialDelay, 6.hours).subscribe { _ =>

--- a/hq/app/services/MetricService.scala
+++ b/hq/app/services/MetricService.scala
@@ -35,10 +35,15 @@ class MetricService(
       return
     }
 
-    Cloudwatch.logAsMetric(allSgs, Cloudwatch.DataType.sgTotal)
-    Cloudwatch.logAsMetric(allExposedKeys, Cloudwatch.DataType.iamKeysTotal)
-    Cloudwatch.logAsMetric(allPublicBuckets, Cloudwatch.DataType.s3Total)
-    Cloudwatch.logMetricsForCredentialsReport(allCredentials)
+    for {
+      allGcpFindings <- cacheService.getGcpFindings
+    } yield {
+      Cloudwatch.logAsMetric(allSgs, Cloudwatch.DataType.sgTotal)
+      Cloudwatch.logAsMetric(allExposedKeys, Cloudwatch.DataType.iamKeysTotal)
+      Cloudwatch.logAsMetric(allPublicBuckets, Cloudwatch.DataType.s3Total)
+      Cloudwatch.logMetricsForCredentialsReport(allCredentials)
+      Cloudwatch.logMetricsForGCPFindings(allGcpFindings)
+    }
   }
 
   if (environment.mode != Mode.Test) {


### PR DESCRIPTION
## What does this change?

This patch adds logging of GCP high and critical vulnerabilities to cloudwatch alongside the existing AWS vulnerabilities metrics.

The fact that GCP vulnerabilities have a project, as opposed to AWS vulnerabilities which have an account, means that their respective cloudwatch metrics will have different dimensions, which means they will have different schemas.

Accounting for this requires a refactor of putMetric into something
parameterised that can be used for both cases.

## What is the value of this?

We'll be able to add gcp vulnerabilities to the security dashoard

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nein

## Any additional notes?

Unlike for example `cacheService.getAllSgs` which basically returns an `Either` that can be unpackaged using pattern matching, `cacheService.getGcpFindings` returns an `Attempt` which I think needs to be unpackaged using a for comprehension? It seems to work, but it's unclear to me if this needs a try or something to handle errors

The diff is made a bit more complicated than expected because unlike the metrics we have so far, it won't have Account/DataType dimensions but Project/DataType. Accommodating these two needs meant making `putMetric` fully parameterised.

