### PR TITLE
Use only findings belonging to the current project

### DIFF
--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -35,8 +35,8 @@ object Cloudwatch extends Logging {
 
     gcpProjectToFinding.toSeq.foreach {
       case (project: String, findings: Seq[GcpFinding]) =>
-        val criticalFindings = allGcpFindings.filter(_.severity == Finding.Severity.CRITICAL)
-        val highFindings = allGcpFindings.filter(_.severity == Finding.Severity.HIGH)
+        val criticalFindings = findings.filter(_.severity == Finding.Severity.CRITICAL)
+        val highFindings = findings.filter(_.severity == Finding.Severity.HIGH)
         putGcpMetric(project, Cloudwatch.DataType.gcpCritical, criticalFindings.length)
         putGcpMetric(project, Cloudwatch.DataType.gcpHigh, highFindings.length)
         putGcpMetric(project, Cloudwatch.DataType.gcpTotal, criticalFindings.length + highFindings.length)


### PR DESCRIPTION
## What does this change?

There's a bug in the GCP metrics code. Current code is sending a `Vulnerabilities` metric per GcpProject, but instead of listing only the findings for that project it's counting _all of them_. So currently every GcpProject is listed as having 5 high vulnerabilities. In reality almost all of them have 0, except one that has 3 and another which has 2.

## What is the value of this?

Getting correct data in cloudwatch.