### PR TITLE
add dynamoDB and put notification data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-cloudformation" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-efs" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark" % "0.62.2",
       "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
       "io.reactivex" %% "rxscala" % "0.26.5",

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -155,6 +155,25 @@ Resources:
       Roles:
       - !Ref SecurityHQInstanceRole
 
+  SecurityHQDynamoPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: security-hq-dynamodb-policy
+      PolicyDocument:
+        Statement:
+          # Read from and write to dynamodb
+          - Effect: Allow
+            Resource: !GetAtt SecurityHqIamDynamoTable.Arn
+            Action:
+              - dynamodb:GetItem
+              - dynamodb:UpdateItem
+              - dynamodb:DeleteItem
+              - dynamodb:PutItem
+              - dynamodb:Scan
+              - dynamodb:Query
+      Roles:
+        - !Ref SecurityHQInstanceRole
+
   SecurityHQSSMRunCommandPolicy:
     Type: AWS::IAM::Policy
     Properties:
@@ -366,6 +385,27 @@ Resources:
         Value:
           Fn::FindInMap: [ Constants, App, Value ]
         PropagateAtLaunch: true
+
+  SecurityHqIamDynamoTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Retain
+    Properties:
+      TableName: !Sub security-hq-iam-${Stage}
+      AttributeDefinitions:
+        - { AttributeName: id, AttributeType: S }
+      KeySchema:
+        - { AttributeName: id, KeyType: HASH }
+      ProvisionedThroughput: { ReadCapacityUnits: 5, WriteCapacityUnits: 5 }
+      Tags:
+        - Key: Stage
+          Value:
+            Ref: Stage
+        - Key: Stack
+          Value:
+            Fn::FindInMap: [ Constants, Stack, Value ]
+        - Key: App
+          Value:
+            Fn::FindInMap: [ Constants, App, Value ]
 
 Outputs:
   LoadBalancerUrl:

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -114,4 +114,5 @@ object Config {
   }
 
   def getAnghammaradSNSTopicArn(config: Configuration): Option[String] = config.getOptional[String]("anghammaradSnsArn")
+  def getIamDynamoTableName(config: Configuration): Option[String] = config.getOptional[String]("iamDynamoTableName")
 }

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -2,6 +2,8 @@ package model
 
 import com.amazonaws.regions.Region
 import com.google.cloud.securitycenter.v1.Finding.Severity
+import com.google.protobuf.{Timestamp, Value}
+import com.gu.anghammarad.models.Notification
 import org.joda.time.DateTime
 import com.gu.anghammarad.models.{App, Stack, Stage => AnghammaradStage, Target}
 
@@ -261,7 +263,16 @@ trait IAMAlert {
   def username: String
   def tags: List[Tag]
 }
+case class IAMAlertTargetGroup(targets: List[Target], outdatedKeysUsers: Seq[UserWithOutdatedKeys], noMfaUsers: Seq[UserNoMfa])
+
 case class UserWithOutdatedKeys(username: String, key1LastRotation: Option[DateTime], key2LastRotation: Option[DateTime], userLastActiveDay: Option[Long], tags: List[Tag]) extends IAMAlert
 case class UserNoMfa(username: String, userLastActiveDay: Option[Long], tags: List[Tag]) extends IAMAlert
 
-case class IAMAlertTargetGroup(targets: List[Target], outdatedKeysUsers: Seq[UserWithOutdatedKeys], noMfaUsers: Seq[UserNoMfa])
+sealed trait IamAuditNotificationType {def name: String}
+object Warning extends IamAuditNotificationType {val name = "Warning"}
+object Final extends IamAuditNotificationType {val name = "Final"}
+
+case class IamAuditAlert(dateNotificationSent: DateTime, notificationType: IamAuditNotificationType)
+case class IamAuditUser(id: String, awsAccount: String, userName: String, alerts: List[IamAuditAlert])
+case class IamNotification(iamUser: IamAuditUser, anghammaradNotification: Notification)
+

--- a/hq/app/schedule/CronSchedules.scala
+++ b/hq/app/schedule/CronSchedules.scala
@@ -6,5 +6,5 @@ import model.CronSchedule
 object CronSchedules {
   val firstMondayOfEveryMonth = CronSchedule("0 0 8 ? * 2#1", "At 8am, on the 1st Monday of the month, every month")
   val secondMondayOfEveryMonth = CronSchedule("0 0 8 ? * 2#2", "At 8am, on the 1st Monday of the month, every month")
-  val everyThursdsay = CronSchedule("0 0 9 ? * THU", "At 8am, on the 1st Monday of the month, every month")
+  val everyThursday = CronSchedule("0 0 9 ? * THU", "At 8am, on the 1st Monday of the month, every month")
 }

--- a/hq/app/schedule/Dynamo.scala
+++ b/hq/app/schedule/Dynamo.scala
@@ -1,0 +1,54 @@
+package schedule
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest, PutItemRequest}
+import model.{IamAuditAlert, IamAuditUser}
+import play.api.Logging
+
+import scala.collection.JavaConverters._
+import scala.util.control.NonFatal
+
+trait AttributeValues {
+  def S(str: String) = new AttributeValue().withS(str)
+  def L(list: List[AttributeValue]) = new AttributeValue().withL(list.asJava)
+  def N(number: Long) = new AttributeValue().withN(number.toString)
+  def N(number: Double) = new AttributeValue().withN(number.toString)
+  def B(boolean: Boolean) = new AttributeValue().withBOOL(boolean)
+  def M(map: Map[String,  AttributeValue]) = new AttributeValue().withM(map.asJava)
+}
+
+class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends AttributeValues with Logging {
+
+  val table = tableName match {
+    case Some(tableName) => tableName
+    case None =>
+      logger.error("unable to retrieve Iam Dynamo Table Name from config - check that table name is present in security-hq.conf in S3")
+      "error"
+  }
+
+  def get(key: Map[String, AttributeValue]): Option[Map[String, AttributeValue]] = Option(client.getItem(
+    new GetItemRequest().withTableName(table).withKey(key.asJava)).getItem) map (_.asScala.toMap)
+
+  def put(item: Map[String, AttributeValue]): Unit = try {
+    client.putItem(
+      new PutItemRequest().withTableName(table).withItem(item.asJava))
+  } catch {
+    case NonFatal(e) =>
+    logger.error(s"unable to put item to dynamoDB table: ${e.getMessage}", e)
+  }
+
+  def alertToMap(e: IamAuditAlert): Map[String, AttributeValue] = {
+    Map(
+      "date" -> N(e.dateNotificationSent.getMillis),
+      "notificationType" -> S(e.notificationType.name)
+    )
+  }
+
+  def putAlert(alert: IamAuditUser): Unit = put(Map(
+    "id" -> S(alert.id),
+    "awsAccount" -> S(alert.awsAccount),
+    "userName" -> S(alert.userName),
+    "alerts" -> L(alert.alerts.map(alert => M(alertToMap(alert))))
+  ))
+}
+

--- a/hq/app/schedule/IamJob.scala
+++ b/hq/app/schedule/IamJob.scala
@@ -4,14 +4,14 @@ import com.amazonaws.services.sns.AmazonSNSAsync
 import config.Config.getAnghammaradSNSTopicArn
 import model._
 import play.api.{Configuration, Logging}
-import schedule.IamAudit.makeCredentialsNotification
+import schedule.IamAudit.{getFlaggedCredentialsReports, makeIamNotification}
 import schedule.IamNotifier.send
 import services.CacheService
 import utils.attempt.FailedAttempt
 
 import scala.concurrent.ExecutionContext
 
-class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSAsync, config: Configuration)(executionContext: ExecutionContext) extends JobRunner with Logging {
+class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSAsync, dynamo: Dynamo,config: Configuration)(implicit val executionContext: ExecutionContext) extends JobRunner with Logging {
   override val id = "credentials report job"
   override val description = "Automated emails for old permanent credentials"
   override val cronSchedule: CronSchedule = CronSchedules.firstMondayOfEveryMonth
@@ -24,12 +24,15 @@ class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSA
       logger.info(s"Running scheduled job: $description")
     }
 
+    def getCredsReport(cacheService: CacheService): Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = cacheService.getAllCredentials
     val credsReport: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = getCredsReport(cacheService)
-    logger.info(s"successfully collected credentials report for $id. Report is not empty: ${credsReport.nonEmpty}.")
-    makeCredentialsNotification(credsReport).foreach { notification =>
-      send(notification, topicArn, snsClient)(executionContext)
+    logger.info(s"successfully collected credentials report for $id. Report is empty: ${credsReport.isEmpty}.")
+
+    makeIamNotification(getFlaggedCredentialsReports(credsReport)).foreach { notification: IamNotification =>
+      for {
+        _ <- send(notification, topicArn, snsClient)
+        _ = dynamo.putAlert(notification.iamUser)
+      } yield ()
     }
   }
-
-  def getCredsReport(cacheService: CacheService): Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = cacheService.getAllCredentials
 }

--- a/hq/app/schedule/IamNotifier.scala
+++ b/hq/app/schedule/IamNotifier.scala
@@ -3,36 +3,54 @@ package schedule
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.gu.anghammarad.Anghammarad
 import com.gu.anghammarad.models.{Email, Notification, Preferred, Target}
-import model.AwsAccount
+import model._
+import org.joda.time.DateTime
 import play.api.Logging
 import schedule.IamMessages.{sourceSystem, subject}
+import utils.attempt.{Attempt, FailedAttempt}
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 
 object IamNotifier extends Logging {
   val channel = Preferred(Email)
 
-  def createNotification(accountName: AwsAccount, targets: List[Target], message: String): Notification = {
-    Notification(subject(accountName), message, List.empty, targets, channel, sourceSystem)
+  def createNotification(
+    accountName: AwsAccount,
+    targets: List[Target],
+    message: String,
+    awsAccountId: String,
+    username: String,
+    alertType: IamAuditNotificationType = Warning
+  ): IamNotification = {
+    val alerts: List[IamAuditAlert] = List(IamAuditAlert(DateTime.now, alertType))
+    val iamAuditUser: IamAuditUser = IamAuditUser(awsAccountId, accountName.name, username, alerts)
+    val anghammaradNotification = Notification(subject(accountName), message, List.empty, targets, channel, sourceSystem)
+    IamNotification(iamAuditUser, anghammaradNotification)
   }
 
   def send(
-    notification: Notification,
+    notification: IamNotification,
     topicArn: Option[String],
-    snsClient: AmazonSNSAsync)(implicit executionContext: ExecutionContext): Unit = {
-    logger.info(s"attempting to send iam notification to topic arn: $topicArn to targets: ${notification.target}")
-    topicArn match {
+    snsClient: AmazonSNSAsync)(implicit executionContext: ExecutionContext): Attempt[String] = {
+    logger.info(s"attempting to send iam notification to topic arn: $topicArn to targets: ${notification.anghammaradNotification.target}")
+    Attempt{
+      topicArn match {
       case Some(arn) =>
-        val response = Anghammarad.notify(notification, arn, snsClient)
-        response.onComplete{
+        val response: Future[String] = Anghammarad.notify(notification.anghammaradNotification, arn, snsClient)
+        response.transformWith {
           case Success(id) =>
-            logger.info(s"Sent notification to ${notification.target}: $id")
+            logger.info(s"Sent notification to ${notification.anghammaradNotification.target}: $id")
+            Future(Right(id))
           case Failure(err) =>
             logger.error("Failed to send notification", err)
+            Future(Left(FailedAttempt(utils.attempt.Failure("", "", 1, None, Some(err)))))
         }
-      case None => logger.error("Failed to send notification: no SNS topic provided")
+      case None =>
+        logger.error("Failed to send notification: no SNS topic provided")
+        Future(Left(FailedAttempt(utils.attempt.Failure("", "", 1, None, None))))
+      }
     }
   }
 }

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -56,6 +56,9 @@ snykSSOUrl = ${?SNYK_SSO_URL}
 
 anghammaradSnsArn = ${ANGHAMMARAD_SNS_TOPIC_ARN}
 
+iamDynamoTableName = ${IAM_DYNAMO_TABLE_NAME}
+iamDynamoTableArn = ${IAM_DYNAMO_TABLE_ARN}
+
 ## Akka
 # https://www.playframework.com/documentation/latest/ScalaAkka#Configuration
 # https://www.playframework.com/documentation/latest/JavaAkka#Configuration

--- a/setup-local-dynamo.sh
+++ b/setup-local-dynamo.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# starts up a local dynamoDB server and creates local table
+# useful for testing IamJob, which saves state in dynamoDB.
+
+docker run -p 8000:8000 amazon/dynamodb-local
+
+aws dynamodb create-table --table-name security-hq-iam-DEV \
+--attribute-definitions AttributeName=id,AttributeType=S \
+--key-schema AttributeName=id,KeyType=HASH \
+--billing-mode PAY_PER_REQUEST \
+--endpoint-url http://localhost:8000 \
+--region eu-west-1
+
+# query local table with the following command:
+# aws dynamodb scan --table-name security-hq-iam-DEV \
+# --endpoint-url http://127.0.0.1:8000 \
+# --region eu-west-1


### PR DESCRIPTION
## What does this change?
This PR adds dynamoDB so that Security HQ's IAM notification job can record which notifications have been successfully
sent. 

## What is the value of this?
The aim is that this data will be used for two reasons. 

First, so that a new feature, the Credentials Reaper, can be built which automatically disables permanent credentials which are either deemed too old or are missing multi factor authentication. This new feature should only disable a credential if 2 notifications have been sent, hence the need to store data on whether the notification has been sent in a database.

The second reason is that we hope this data will provide a helpful audit trail for Infosec.

## How has this been tested?
This work was tested locally using this https://github.com/aws-samples/aws-sam-java-rest. Here are the steps to use this:

start the server: `docker run -p 8000:8000 amazon/dynamodb-local`

create your dynamoDB table (make sure the same table name is used in your application code):
```
aws dynamodb create-table --table-name security-hq-iam-DEV \
--attribute-definitions AttributeName=id,AttributeType=S \
--key-schema AttributeName=id,KeyType=HASH \
--billing-mode PAY_PER_REQUEST \
--endpoint-url http://localhost:8000 \
--region eu-west-1
```
create a local client in your application code:
```
val dynamoDbClient: AmazonDynamoDB = AmazonDynamoDBClientBuilder.standard()
    .withCredentials(securityCredentialsProvider)
    //.withRegion(Config.region.getName)
    .withEndpointConfiguration(new EndpointConfiguration("http://127.0.0.1:8000", Config.region.getName))
    .build()
```
here's an example request using the AWS SDK within your application code:
```
  def put(item: Map[String, AttributeValue]): Unit = try {
    client.putItem(
      new PutItemRequest().withTableName(tableName).withItem(item.asJava))
  } catch {
    case NonFatal(e) =>
    logger.error(s"unable to put item to dynamoDB table: ${e.getMessage}", e)
  }
```

query your local table:
```
aws dynamodb scan --table-name security-hq-iam-DEV \
--endpoint-url http://127.0.0.1:8000 \
--region eu-west-1
```
