### PR TITLE
☠️ Credentials Reaper - check if alert already sent

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -2,10 +2,8 @@ package model
 
 import com.amazonaws.regions.Region
 import com.google.cloud.securitycenter.v1.Finding.Severity
-import com.google.protobuf.{Timestamp, Value}
-import com.gu.anghammarad.models.Notification
+import com.gu.anghammarad.models.{App, Notification, Stack, Target, Stage => AnghammaradStage}
 import org.joda.time.DateTime
-import com.gu.anghammarad.models.{App, Stack, Stage => AnghammaradStage, Target}
 
 
 case class AwsAccount(
@@ -267,12 +265,13 @@ case class IAMAlertTargetGroup(targets: List[Target], outdatedKeysUsers: Seq[Use
 
 case class UserWithOutdatedKeys(username: String, key1LastRotation: Option[DateTime], key2LastRotation: Option[DateTime], userLastActiveDay: Option[Long], tags: List[Tag]) extends IAMAlert
 case class UserNoMfa(username: String, userLastActiveDay: Option[Long], tags: List[Tag]) extends IAMAlert
+case class VulnerableUsers(outdatedKeys: Seq[UserWithOutdatedKeys], noMfa: Seq[UserNoMfa])
 
 sealed trait IamAuditNotificationType {def name: String}
 object Warning extends IamAuditNotificationType {val name = "Warning"}
 object Final extends IamAuditNotificationType {val name = "Final"}
 
 case class IamAuditAlert(dateNotificationSent: DateTime, notificationType: IamAuditNotificationType)
-case class IamAuditUser(id: String, awsAccount: String, userName: String, alerts: List[IamAuditAlert])
+case class IamAuditUser(id: String, awsAccount: String, username: String, alerts: List[IamAuditAlert])
 case class IamNotification(iamUser: IamAuditUser, anghammaradNotification: Notification)
 

--- a/hq/app/schedule/Dynamo.scala
+++ b/hq/app/schedule/Dynamo.scala
@@ -2,7 +2,8 @@ package schedule
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest, PutItemRequest}
-import model.{IamAuditAlert, IamAuditUser}
+import model.{AwsAccount, IamAuditAlert, IamAuditUser}
+import org.joda.time.DateTime
 import play.api.Logging
 
 import scala.collection.JavaConverters._
@@ -26,8 +27,40 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
       "error"
   }
 
-  def get(key: Map[String, AttributeValue]): Option[Map[String, AttributeValue]] = Option(client.getItem(
-    new GetItemRequest().withTableName(table).withKey(key.asJava)).getItem) map (_.asScala.toMap)
+  def get(key: Map[String, AttributeValue]): Option[Map[String, AttributeValue]] = {
+    try {
+      Option(client.getItem(
+        new GetItemRequest().withTableName(table).withKey(key.asJava)).getItem).map(_.asScala.toMap)
+    } catch {
+      case NonFatal(e) =>
+        logger.error(s"unable to get item from dynamoDB table: ${e.getMessage}", e)
+        None
+    }
+  }
+
+  def getAlert(awsAccount: AwsAccount, username: String): Option[IamAuditUser] = {
+    val key = Map("id" -> S(Dynamo.createId(awsAccount, username)))
+    get(key).map { r =>
+
+      val alerts = r("alerts").getL.asScala.map{ a =>
+        val alertMap = a.getM.asScala
+        IamAuditAlert(
+          new DateTime(alertMap("date").getS.toLong),
+          alertMap("notificationType").getS match {
+            case model.Warning.name => model.Warning
+            case model.Final.name => model.Final
+          }
+        )
+      }.toList
+
+      IamAuditUser(
+        r("id").getS,
+        r("awsAccount").getS,
+        r("username").getS,
+        alerts
+      )
+    }
+  }
 
   def put(item: Map[String, AttributeValue]): Unit = try {
     client.putItem(
@@ -47,8 +80,12 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
   def putAlert(alert: IamAuditUser): Unit = put(Map(
     "id" -> S(alert.id),
     "awsAccount" -> S(alert.awsAccount),
-    "userName" -> S(alert.userName),
+    "userName" -> S(alert.username),
     "alerts" -> L(alert.alerts.map(alert => M(alertToMap(alert))))
   ))
+}
+
+object Dynamo {
+  def createId(awsAccount: AwsAccount, username: String) = s"${awsAccount.id}/$username"
 }
 

--- a/hq/app/schedule/IamJob.scala
+++ b/hq/app/schedule/IamJob.scala
@@ -28,7 +28,7 @@ class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSA
     val credsReport: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = getCredsReport(cacheService)
     logger.info(s"successfully collected credentials report for $id. Report is empty: ${credsReport.isEmpty}.")
 
-    makeIamNotification(getFlaggedCredentialsReports(credsReport)).foreach { notification: IamNotification =>
+    makeIamNotification(getFlaggedCredentialsReports(credsReport, dynamo)).foreach { notification: IamNotification =>
       for {
         _ <- send(notification, topicArn, snsClient)
         _ = dynamo.putAlert(notification.iamUser)

--- a/hq/app/schedule/IamNotifier.scala
+++ b/hq/app/schedule/IamNotifier.scala
@@ -17,16 +17,15 @@ object IamNotifier extends Logging {
   val channel = Preferred(Email)
 
   def createNotification(
-    accountName: AwsAccount,
+    account: AwsAccount,
     targets: List[Target],
     message: String,
-    awsAccountId: String,
     username: String,
     alertType: IamAuditNotificationType = Warning
   ): IamNotification = {
     val alerts: List[IamAuditAlert] = List(IamAuditAlert(DateTime.now, alertType))
-    val iamAuditUser: IamAuditUser = IamAuditUser(awsAccountId, accountName.name, username, alerts)
-    val anghammaradNotification = Notification(subject(accountName), message, List.empty, targets, channel, sourceSystem)
+    val iamAuditUser: IamAuditUser = IamAuditUser(Dynamo.createId(account, username), account.name, username, alerts)
+    val anghammaradNotification = Notification(subject(account), message, List.empty, targets, channel, sourceSystem)
     IamNotification(iamAuditUser, anghammaradNotification)
   }
 

--- a/hq/test/schedule/IamAuditTest.scala
+++ b/hq/test/schedule/IamAuditTest.scala
@@ -19,7 +19,7 @@ class IamAuditTest extends FreeSpec with Matchers {
 
   "getNotificationTargetGroups" - {
     "correctly builds target groups when users have no tags " in {
-      val targetGroups = getNotificationTargetGroups(Seq(outdatedUser1, outdatedUser2), Seq(noMfaUser1, noMfaUser2))
+      val targetGroups = getNotificationTargetGroups(VulnerableUsers(Seq(outdatedUser1, outdatedUser2), Seq(noMfaUser1, noMfaUser2)))
       targetGroups.length shouldEqual 1
       targetGroups.head.noMfaUsers.length shouldEqual 2
       targetGroups.head.outdatedKeysUsers.length shouldEqual 2
@@ -41,7 +41,7 @@ class IamAuditTest extends FreeSpec with Matchers {
         noMfaUser3.copy(tags=List(Tag("Stack", "recreation")))
       )
 
-      val targetGroups = getNotificationTargetGroups(inputOutdatedUsers, inputNoMfaUsers)
+      val targetGroups = getNotificationTargetGroups(VulnerableUsers(inputOutdatedUsers, inputNoMfaUsers))
 
       targetGroups.length shouldEqual 3
 
@@ -60,7 +60,7 @@ class IamAuditTest extends FreeSpec with Matchers {
     }
 
     "correctly builds target list when there are only mfa users" in {
-      val targetGroups = getNotificationTargetGroups(Seq(), Seq(noMfaUser1, noMfaUser2))
+      val targetGroups = getNotificationTargetGroups(VulnerableUsers(Seq(), Seq(noMfaUser1, noMfaUser2)))
       targetGroups.length shouldEqual 1
       targetGroups.head.noMfaUsers.length shouldEqual 2
       targetGroups.head.outdatedKeysUsers.length shouldEqual 0
@@ -266,7 +266,7 @@ class IamAuditTest extends FreeSpec with Matchers {
       createMessage(Seq.empty, missingMfa, account) shouldEqual result
     }
     "returns nothing when there are no old access keys or missing mfas" in {
-      val allCreds = Map(AwsAccount("", "", "", "") -> CredentialReportDisplay(DateTime.now))
+      val allCreds = Map(AwsAccount("", "", "", "") -> Seq.empty)
       val result = List.empty
       makeIamNotification(allCreds) shouldEqual result
     }


### PR DESCRIPTION
## What does this change?

This PR follows the work started in PR #247 on the credentials reaper feature, which aims to disable vulnerable permanent IAM credentials. 

This particular change gets data from a DynamoDB table to check whether a notification has already been sent to a user about a vulnerable credential.

This is valuable, because the reaper feature will send 2 alerts before disabling a credential and will need to check if this has happened before doing so.

The next piece of work on this feature is to check the type of notification sent, which is stored in dynamoDB and change the alert message based on this.