### PR TITLE
Make tag fetching more resilient, show stack tag in IAM report table

### DIFF
--- a/hq/app/views/iam/iamCredReportBody.scala.html
+++ b/hq/app/views/iam/iamCredReportBody.scala.html
@@ -27,6 +27,7 @@
                     <th>Password/MFA</th>
                     <th>Last Activity</th>
                     <th>Status</th>
+                    <th>Stack</th>
                 </tr>
             </thead>
             <tbody>
@@ -66,6 +67,7 @@
                         <span>@CredentialsReportDisplay.toDayString(cred.lastActivityDay)</span>
                     </td>
                     <td>@views.html.fragments.humanReportStatus(cred.reportStatus)</td>
+                    <td>@cred.tags.find(t => t.key == "Stack").map(_.value).getOrElse("")</td>
                 </tr>
             }
 
@@ -100,6 +102,7 @@
                         <span>@CredentialsReportDisplay.toDayString(cred.lastActivityDay)</span>
                     </td>
                     <td>@views.html.fragments.machineReportStatus(cred.reportStatus)</td>
+                    <td>@cred.tags.find(t => t.key == "Stack").map(_.value).getOrElse("")</td>
                 </tr>
             }
             </tbody>


### PR DESCRIPTION
## What does this change?
This change adds a 'recover' step to aws sdk requests to fetch tags for the user for when the request fails. It also simplifies the logic around enriching a credentials report with tags (https://github.com/guardian/security-hq/pull/251/commits/dd99f32d35e4dd1c84a4f4bcc9928c4032b8a4ac).

Also, expose the Stack tag in a column in the IAM report ui to make it easier to distinguish credentials in the same account being managed by different teams, it looks like this:
<img width="1122" alt="Screenshot 2021-06-23 at 10 20 43" src="https://user-images.githubusercontent.com/3606555/123071672-c7b29e00-d40c-11eb-9dd7-b29f3aea5e7a.png">

