### PR TITLE
Merge two vulnerable user types into one

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -263,27 +263,10 @@ trait IAMAlert {
 }
 case class IAMAlertTargetGroup(
   targets: List[Target],
-  outdatedKeysUsers: Seq[UserWithOutdatedKeys],
-  noMfaUsers: Seq[UserNoMfa]
+  users: Seq[VulnerableUser]
 )
 
-case class UserWithOutdatedKeys(
-  username: String,
-  key1LastRotation: Option[DateTime],
-  key2LastRotation: Option[DateTime],
-  userLastActiveDay: Option[Long],
-  tags: List[Tag],
-  disableDeadline: Option[DateTime] = None
-) extends IAMAlert
-
-case class UserNoMfa(
-  username: String,
-  userLastActiveDay: Option[Long],
-  tags: List[Tag],
-  disableDeadline: Option[DateTime] = None
-) extends IAMAlert
-
-case class VulnerableUsers(outdatedKeys: Seq[UserWithOutdatedKeys], noMfa: Seq[UserNoMfa])
+case class VulnerableUser(username: String, tags: List[Tag], disableDeadline: Option[DateTime] = None) extends IAMAlert
 
 sealed trait IamAuditNotificationType {def name: String}
 object Warning extends IamAuditNotificationType {val name = "Warning"}

--- a/hq/app/schedule/IamMessages.scala
+++ b/hq/app/schedule/IamMessages.scala
@@ -1,17 +1,17 @@
 package schedule
 
-import model.{AwsAccount, UserNoMfa, UserWithOutdatedKeys}
+import model.{AwsAccount, VulnerableUser}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
 object IamMessages {
   def subject(account: AwsAccount) = s"Action required: Insecure credentials in the ${account.name} AWS Account scheduled for deactivaton"
   val sourceSystem = "Security HQ Credentials Notifier"
-  def outdatedKeysMessage(account: AwsAccount) =
-    s"Please rotate the following IAM access keys in AWS Account ${account.name}/${account.accountNumber} or delete them if they are disabled and unused (if you're already planning to do this, please ignore this message). If this is not rectified before the disable deadline, Security HQ will automatically disable this user:"
-  def missingMfaMessage(account: AwsAccount) =
-    s"Please add multi-factor authentication to the following AWS IAM users in Account ${account.name}/${account.accountNumber}. If this is not rectified before the disable deadline, Security HQ will automatically disable this user:"
+  def message(account: AwsAccount) =
+    s"Please check the following permanent credentials in AWS Account ${account.name}/${account.accountNumber}, which have been flagged as either needing to be rotated or requiring multi-factor authentication (if you're already planning on doing this, please ignore this message). If this is not rectified before the deadline, Security HQ will automatically disable this user:"
   val boilerPlateText = List(
+    "To see why these keys have been flagged and how to rectify this, see Security HQ (https://security-hq.gutools.co.uk/iam).",
+    "",
     "Here is some helpful documentation on:",
     "",
     "rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,",
@@ -20,53 +20,21 @@ object IamMessages {
     "",
     "multi-factor authentication: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html.",
     "",
-    "For an overview of security vulnerabilities in your AWS account, see Security HQ (https://security-hq.gutools.co.uk/).",
     "If you have any questions, please contact the Developer Experience team: devx@theguardian.com."
   ).mkString("\n")
 
-  def createMessage(outdatedKeys: Seq[UserWithOutdatedKeys], missingMfa: Seq[UserNoMfa], account: AwsAccount): String = {
-    if (outdatedKeys.isEmpty)
+  def createMessage(users: Seq[VulnerableUser], account: AwsAccount): String = {
       s"""
-         |${missingMfaMessage(account)}
-         |${missingMfa.map(printFormatMissingMfa).mkString("\n")}
-         |$boilerPlateText
-         |""".stripMargin
-    else if (missingMfa.isEmpty)
-    s"""
-       |${outdatedKeysMessage(account)}
-       |${outdatedKeys.map(printFormatOutdatedKeys).mkString("\n")}
-       |$boilerPlateText
-       |""".stripMargin
-    else
-      s"""
-         |${outdatedKeysMessage(account)}
-         |${outdatedKeys.map(printFormatOutdatedKeys).mkString("\n")}
-         |${missingMfaMessage(account)}
-         |${missingMfa.map(printFormatMissingMfa).mkString("\n")}
+         |${message(account)}
+         |${users.map(printFormat).mkString("\n")}
          |$boilerPlateText
          |""".stripMargin
   }
-  private def printFormatOutdatedKeys(user: UserWithOutdatedKeys): String = {
+  private def printFormat(user: VulnerableUser): String = {
     s"""
       |Username: ${user.username}
-      |Key 1 last rotation: ${dateTimeToString(user.key1LastRotation)}
-      |Key 2 last rotation: ${dateTimeToString(user.key2LastRotation)}
-      |Last active: ${dateToString(user.userLastActiveDay)}
       |If this is not rectified by ${dateTimeToString(user.disableDeadline)}, the user will be disabled.
       |""".stripMargin
-  }
-  private def printFormatMissingMfa(user: UserNoMfa): String = {
-    s"""
-      |Username: ${user.username}
-      |Last active: ${dateToString(user.userLastActiveDay)}
-      |If this is not rectified by ${dateTimeToString(user.disableDeadline)}, the user will be disabled.
-      |""".stripMargin
-  }
-  private def dateToString(day: Option[Long]): String = day match {
-    case Some(0) => "Today"
-    case Some(1) => "Yesterday"
-    case Some(d) => s"${d.toString} days ago"
-    case _ => "Unknown"
   }
   private def dateTimeToString(day: Option[DateTime]): String = {
     val dateTimeFormatPattern = DateTimeFormat.forPattern("dd/MM/yyyy")


### PR DESCRIPTION
Writing the credentials reaper feature managing two separate user case classes was becoming cumbersome. There was one user type for keys which are old and the other for keys that are missing mfa. Each change to the users required double the code to handle each user type. This change makes it easier to complete the credentials reaper feature.

The downside of this change is that the email alert to users will not include why the user has been flagged. This shouldn't be a major problem as these details are including on the security HQ dashboard.