### PR TITLE
IAM alert message determined by flagged user deadline

### DIFF
--- a/hq/app/schedule/IamNotifier.scala
+++ b/hq/app/schedule/IamNotifier.scala
@@ -3,11 +3,10 @@ package schedule
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.gu.anghammarad.Anghammarad
 import com.gu.anghammarad.models.{Email, Notification, Preferred, Target}
-import config.Config.iamAlertCadence
 import model._
 import org.joda.time.DateTime
 import play.api.Logging
-import schedule.IamMessages.{sourceSystem, subject}
+import schedule.IamMessages.sourceSystem
 import utils.attempt.{Attempt, FailedAttempt}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -21,12 +20,13 @@ object IamNotifier extends Logging {
     account: AwsAccount,
     targets: List[Target],
     message: String,
+    subject: String,
     username: String,
     disableDate: DateTime,
   ): IamNotification = {
     val alerts: List[IamAuditAlert] = List(IamAuditAlert(DateTime.now, disableDate))
     val iamAuditUser: IamAuditUser = IamAuditUser(Dynamo.createId(account, username), account.name, username, alerts)
-    val anghammaradNotification = Notification(subject(account), message, List.empty, targets, channel, sourceSystem)
+    val anghammaradNotification = Notification(subject, message, List.empty, targets, channel, sourceSystem)
     IamNotification(iamAuditUser, anghammaradNotification)
   }
 

--- a/hq/test/schedule/IamAuditTest.scala
+++ b/hq/test/schedule/IamAuditTest.scala
@@ -144,5 +144,36 @@ class IamAuditTest extends FreeSpec with Matchers {
       val result = List.empty
       makeIamNotification(allCreds) shouldEqual result
     }
+    "returns true when the deadline is one week away" in {
+      val deadline = DateTime.now.plusWeeks(1)
+      val today = DateTime.now
+      isWarningAlert(deadline, today) shouldBe true
+    }
+    "returns true when the deadline is three weeks away" in {
+      val deadline = DateTime.now.plusWeeks(3)
+      val today = DateTime.now
+      isWarningAlert(deadline, today) shouldBe true
+    }
+    "returns false when the deadline is not one or three weeks away" in {
+      val deadline = DateTime.now.plusWeeks(2)
+      val today = DateTime.now
+      isWarningAlert(deadline, today) shouldBe false
+    }
+    "returns true when the deadline is the next day" in {
+      val deadline = DateTime.now.plusDays(1)
+      val today = DateTime.now
+      isFinalAlert(deadline, today) shouldBe true
+    }
+    "returns false when the deadline is not the next day" in {
+      val deadline = DateTime.now.plusDays(2)
+      val today = DateTime.now
+      isFinalAlert(deadline, today) shouldBe false
+    }
+    "returns nearest deadline" in {
+      val nearestDeadline = DateTime.now.plusDays(1).withTimeAtStartOfDay
+      val alert1 = IamAuditAlert(DateTime.now.minusWeeks(3), nearestDeadline)
+      val alert2 = IamAuditAlert(DateTime.now.minusWeeks(3), DateTime.now.plusDays(2).withTimeAtStartOfDay)
+      getNearestDeadline(List(alert1, alert2)) shouldEqual nearestDeadline
+    }
   }
 }


### PR DESCRIPTION
## What is the problem?

Security HQ's IAM alerts send an email to a Guardian AWS account if one of the users in this account has permanent credentials which need rotating or are missing multi factor authentication.

Currently one generic email is sent on a monthly basis. The credentials reaper feature will send two emails; a warning email (similar to the current one) and a final email notifying the AWS account that the problematic permanent credential will be disabled the next day. 

Other credentials reaper PRs: #247 and #249.

## What is the solution?
This change makes it possible for SHQ to determine which text it should send in the email; the warning text or the final text.

It determines this by checking the deadline that is assigned to the problematic permanent credential. If the deadline is tomorrow, SHQ knows to send a final email. If the deadline has not been assigned yet, SHQ knows to send a warning email and **set** the deadline.

## Has this been tested?
There are unit tests for some of the Joda DateTime functions. We will manually test the GET request to the database.



