### PR TITLE
Add endpoint to get historical IAM alerts report

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -4,6 +4,7 @@ import com.amazonaws.regions.Region
 import com.google.cloud.securitycenter.v1.Finding.Severity
 import com.gu.anghammarad.models.{App, Notification, Stack, Target, Stage => AnghammaradStage}
 import org.joda.time.DateTime
+import play.api.libs.json.{JsString, JsValue, Json, Writes}
 
 
 case class AwsAccount(
@@ -273,6 +274,15 @@ object Warning extends IamAuditNotificationType {val name = "Warning"}
 object Final extends IamAuditNotificationType {val name = "Final"}
 
 case class IamAuditAlert(dateNotificationSent: DateTime, disableDeadline: DateTime)
+object IamAuditAlert {
+  implicit val jodaDateWrites: Writes[DateTime] = new Writes[DateTime] {
+    def writes(d: DateTime): JsValue = JsString(d.toString())
+  }
+  implicit val iamAuditAlerts = Json.writes[IamAuditAlert]
+}
 case class IamAuditUser(id: String, awsAccount: String, username: String, alerts: List[IamAuditAlert])
+object IamAuditUser {
+  implicit val iamAuditUserWrites = Json.writes[IamAuditUser]
+}
 case class IamNotification(iamUser: IamAuditUser, anghammaradNotification: Notification)
 

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -8,6 +8,7 @@ GET        /healthcheck                               controllers.HQController.h
 
 GET        /iam                                       controllers.CredentialsController.iam
 GET        /iam/send-notifications                    controllers.CredentialsController.sendNotifications(send: Boolean)
+GET        /iam/get-notifications                     controllers.CredentialsController.getNotifications
 GET        /iam/:accountId                            controllers.CredentialsController.iamAccount(accountId)
 GET        /iam/refresh/all                           controllers.CredentialsController.refresh
 

--- a/setup-local-dynamo.sh
+++ b/setup-local-dynamo.sh
@@ -11,6 +11,12 @@ aws dynamodb create-table --table-name security-hq-iam-DEV \
 --endpoint-url http://localhost:8000 \
 --region eu-west-1
 
+# Use this client in AppComponents.scala in place of existing dynamoDbClient:
+# AmazonDynamoDBClientBuilder.standard()
+#  .withCredentials(securityCredentialsProvider)
+#  .withEndpointConfiguration(new EndpointConfiguration("http://127.0.0.1:8000", Config.region.getName))
+#  .build()
+
 # query local table with the following command:
 # aws dynamodb scan --table-name security-hq-iam-DEV \
 # --endpoint-url http://127.0.0.1:8000 \


### PR DESCRIPTION
This PR adds a new route, which returns all of the data in the IAM dynamoDB table. This is useful because a) it's helped us
test that PR #256 works! and b) it means that any user can see which alerts have been sent and what the deadlines are on any flagged credentials.