### PR TITLE
Endpoint for testing notifications

### DIFF
--- a/hq/app/controllers/CredentialsController.scala
+++ b/hq/app/controllers/CredentialsController.scala
@@ -46,8 +46,8 @@ class CredentialsController(val config: Configuration, cacheService: CacheServic
     Ok("Refreshing IAM credentials reports (may take a minute or so to appear)")
   }
 
-  def sendNotifications(send: Boolean) = authAction {
-    if (send) iamJob.run()
+  def testNotifications() = authAction {
+    iamJob.run(testMode = true)
     Ok("Triggered notifications job")
   }
 

--- a/hq/app/schedule/IamJob.scala
+++ b/hq/app/schedule/IamJob.scala
@@ -17,7 +17,7 @@ class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSA
   override val cronSchedule: CronSchedule = CronSchedules.firstMondayOfEveryMonth
   val topicArn: Option[String] = getAnghammaradSNSTopicArn(config)
 
-  def run(): Unit = {
+  def run(testMode: Boolean = false): Unit = {
     if (!enabled) {
       logger.info(s"Skipping scheduled $id job as it is not enabled")
     } else {

--- a/hq/app/schedule/IamNotifier.scala
+++ b/hq/app/schedule/IamNotifier.scala
@@ -2,7 +2,7 @@ package schedule
 
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.gu.anghammarad.Anghammarad
-import com.gu.anghammarad.models.{Email, Notification, Preferred, Target}
+import com.gu.anghammarad.models.{Email, Notification, Preferred, Stack, Target}
 import model._
 import org.joda.time.DateTime
 import play.api.Logging
@@ -33,18 +33,21 @@ object IamNotifier extends Logging {
   def send(
     notification: IamNotification,
     topicArn: Option[String],
-    snsClient: AmazonSNSAsync)(implicit executionContext: ExecutionContext): Attempt[String] = {
+    snsClient: AmazonSNSAsync,
+    testMode: Boolean = false
+  )(implicit executionContext: ExecutionContext): Attempt[String] = {
     logger.info(s"attempting to send iam notification to topic arn: $topicArn to targets: ${notification.anghammaradNotification.target}")
     Attempt{
       topicArn match {
       case Some(arn) =>
-        val response: Future[String] = Anghammarad.notify(notification.anghammaradNotification, arn, snsClient)
+        val anghammaradNotification = if (testMode) notification.anghammaradNotification.copy(target = List(Stack("testing-alerts"))) else notification.anghammaradNotification
+        val response: Future[String] = Anghammarad.notify(anghammaradNotification, arn, snsClient)
         response.transformWith {
           case Success(id) =>
             logger.info(s"Sent notification to ${notification.anghammaradNotification.target}: $id")
             Future(Right(id))
           case Failure(err) =>
-            logger.error("Failed to send notification", err)
+            logger.error(s"Failed to send notification for username: ${notification.iamUser.username} in AWS account: ${notification.iamUser.awsAccount} with subject ${notification.anghammaradNotification.subject}", err)
             Future(Left(FailedAttempt(utils.attempt.Failure("", "", 1, None, Some(err)))))
         }
       case None =>

--- a/hq/app/schedule/JobRunner.scala
+++ b/hq/app/schedule/JobRunner.scala
@@ -13,5 +13,5 @@ abstract class JobRunner {
   val jobKey = new JobKey(name)
   val triggerKey = new TriggerKey(name)
 
-  def run(): Unit
+  def run(testMode: Boolean = false): Unit
 }

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -7,7 +7,7 @@ GET        /                                          controllers.HQController.i
 GET        /healthcheck                               controllers.HQController.healthcheck
 
 GET        /iam                                       controllers.CredentialsController.iam
-GET        /iam/send-notifications                    controllers.CredentialsController.sendNotifications(send: Boolean)
+GET        /iam/test-notifications                    controllers.CredentialsController.testNotifications
 GET        /iam/get-notifications                     controllers.CredentialsController.getNotifications
 GET        /iam/:accountId                            controllers.CredentialsController.iamAccount(accountId)
 GET        /iam/refresh/all                           controllers.CredentialsController.refresh


### PR DESCRIPTION
Creates a route to send notifications to a test anghammarad target, which uses this google group: https://groups.google.com/a/guardian.co.uk/g/anghammarad.test.alerts?pli=1. 

This is great, because it means we can more easily test the email notifications.