### PR TITLE
Exclude root user from tag lookup

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -60,7 +60,11 @@ case class IAMCredential(
   cert2LastRotated: Option[DateTime],
   tags: List[Tag] = List()
                         ) {
-  val rootUser = user == "<root_account>"
+  val rootUser = IAMCredential.isRootUser(user)
+}
+
+object IAMCredential {
+  def isRootUser(user: String): Boolean = user == "<root_account>"
 }
 
 case class TrustedAdvisorCheck(


### PR DESCRIPTION
## What does this change?
The work in https://github.com/guardian/security-hq/pull/238 resulted in a lot of noisy errors appearing in security HQ logs. This was due to Security HQ making a `ListUserTagsRequest` for users with invalid usernames. I think the culprit here is the root user, which appears to get returned in the credentials report, but has angle brackets in the username: `<root_user>`. The error message we get states `The specified value for userName is invalid. It must contain only alphanumeric characters and/or the following: +=,.@_- ` - excluding the root user should reduce the noisy logging

## What is the value of this?
Less noisy logs, fewer requests to AWS which fail every time
