### PR TITLE
Fix testing and get notifications endpoints

### DIFF
--- a/hq/app/schedule/Dynamo.scala
+++ b/hq/app/schedule/Dynamo.scala
@@ -42,8 +42,8 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
       val alerts = r("alerts").getL.asScala.map { a =>
         val alertMap = a.getM.asScala
         IamAuditAlert(
-          new DateTime(alertMap("date").getS.toLong),
-          new DateTime(alertMap("disableDeadline").getS.toLong)
+          new DateTime(alertMap("date").getN.toLong),
+          new DateTime(alertMap("disableDeadline").getN.toLong)
         )
       }.toList
       IamAuditUser(
@@ -69,12 +69,11 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
   def getAlert(awsAccount: AwsAccount, username: String): Option[IamAuditUser] = {
     val key = Map("id" -> S(Dynamo.createId(awsAccount, username)))
     get(key).map { r =>
-
       val alerts = r("alerts").getL.asScala.map{ a =>
         val alertMap = a.getM.asScala
         IamAuditAlert(
-          new DateTime(alertMap("date").getS.toLong),
-          new DateTime(alertMap("disableDeadline").getS.toLong)
+          new DateTime(alertMap("date").getN.toLong),
+          new DateTime(alertMap("disableDeadline").getN.toLong)
         )
       }.toList
 

--- a/hq/app/schedule/IamJob.scala
+++ b/hq/app/schedule/IamJob.scala
@@ -17,7 +17,7 @@ class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSA
   override val cronSchedule: CronSchedule = CronSchedules.firstMondayOfEveryMonth
   val topicArn: Option[String] = getAnghammaradSNSTopicArn(config)
 
-  def run(testMode: Boolean = false): Unit = {
+  def run(testMode: Boolean): Unit = {
     if (!enabled) {
       logger.info(s"Skipping scheduled $id job as it is not enabled")
     } else {
@@ -30,7 +30,7 @@ class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSA
 
     makeIamNotification(getFlaggedCredentialsReports(credsReport, dynamo)).foreach { notification: IamNotification =>
       for {
-        _ <- send(notification, topicArn, snsClient)
+        _ <- send(notification, topicArn, snsClient, testMode)
         _ = dynamo.putAlert(notification.iamUser)
       } yield ()
     }

--- a/hq/app/schedule/IamMessages.scala
+++ b/hq/app/schedule/IamMessages.scala
@@ -8,8 +8,8 @@ object IamMessages {
 
   val sourceSystem = "Security HQ Credentials Notifier"
 
-  def warningSubject(account: AwsAccount): String = s"Action required: Insecure credentials in the ${account.name} AWS Account scheduled for deactivaton"
-  def finalSubject(account: AwsAccount): String = s"Action required: Insecure credentials to be deactivated tomorrow in the ${account.name} AWS Account"
+  def warningSubject(account: AwsAccount): String = s"Action ${account.name}: Insecure credentials"
+  def finalSubject(account: AwsAccount): String = s"Action ${account.name}: Deactivating credentials tomorrow"
 
   def message(account: AwsAccount) = {
     s"Please check the following permanent credentials in AWS Account ${account.name}/${account.accountNumber}, which have been flagged as either needing to be rotated or requiring multi-factor authentication (if you're already planning on doing this, please ignore this message). If this is not rectified before the deadline, Security HQ will automatically disable this user:"

--- a/hq/app/schedule/JobRunner.scala
+++ b/hq/app/schedule/JobRunner.scala
@@ -13,5 +13,5 @@ abstract class JobRunner {
   val jobKey = new JobKey(name)
   val triggerKey = new TriggerKey(name)
 
-  def run(testMode: Boolean = false): Unit
+  def run(testMode: Boolean): Unit
 }

--- a/hq/app/schedule/JobWrapper.scala
+++ b/hq/app/schedule/JobWrapper.scala
@@ -11,6 +11,6 @@ class JobWrapper extends Job with Logging {
     val job = jobData.get(JobDataKeys.Runner).asInstanceOf[JobRunner]
 
     logger.info(s"Running jobId=${job.id} - ${job.description}")
-    job.run()
+    job.run(testMode = false)
   }
 }

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -57,7 +57,6 @@ snykSSOUrl = ${?SNYK_SSO_URL}
 anghammaradSnsArn = ${ANGHAMMARAD_SNS_TOPIC_ARN}
 
 iamDynamoTableName = ${IAM_DYNAMO_TABLE_NAME}
-iamDynamoTableArn = ${IAM_DYNAMO_TABLE_ARN}
 
 ## Akka
 # https://www.playframework.com/documentation/latest/ScalaAkka#Configuration


### PR DESCRIPTION
The test and get notifications endpoints were not working. This PR fixes the dynamoDB parsing fields, which were incorrect. It removes the default parameter and corrects a log line. This change has been tested on PROD and locally.