### PR TITLE
Fix duplicate IAM notification alerts

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -288,5 +288,5 @@ case class IamAuditUser(id: String, awsAccount: String, username: String, alerts
 object IamAuditUser {
   implicit val iamAuditUserWrites = Json.writes[IamAuditUser]
 }
-case class IamNotification(iamUser: IamAuditUser, anghammaradNotification: Notification)
+case class IamNotification(warningN: Option[Notification], finalN: Option[Notification], alertedUsers: Seq[IamAuditUser])
 

--- a/hq/app/schedule/Dynamo.scala
+++ b/hq/app/schedule/Dynamo.scala
@@ -67,6 +67,7 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
   }
 
   def getAlert(awsAccount: AwsAccount, username: String): Option[IamAuditUser] = {
+    logger.info(s"Fetching alert for username ${username}, account ${awsAccount.id}")
     val key = Map("id" -> S(Dynamo.createId(awsAccount, username)))
     get(key).map { r =>
       val alerts = r("alerts").getL.asScala.map{ a =>
@@ -77,12 +78,14 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
         )
       }.toList
 
-      IamAuditUser(
+      val parsedUser = IamAuditUser(
         r("id").getS,
         r("awsAccount").getS,
         r("username").getS,
         alerts
       )
+      logger.info(s"found user $parsedUser for username ${username}, account ${awsAccount.id}")
+      parsedUser
     }
   }
 

--- a/hq/app/schedule/Dynamo.scala
+++ b/hq/app/schedule/Dynamo.scala
@@ -78,18 +78,17 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
         )
       }.toList
 
-      val parsedUser = IamAuditUser(
+      IamAuditUser(
         r("id").getS,
         r("awsAccount").getS,
         r("username").getS,
         alerts
       )
-      logger.info(s"found user $parsedUser for username ${username}, account ${awsAccount.id}")
-      parsedUser
     }
   }
 
   def put(item: Map[String, AttributeValue]): Unit = try {
+    logger.info(s"putting item to dynamoDB table: $table")
     client.putItem(
       new PutItemRequest().withTableName(table).withItem(item.asJava))
   } catch {

--- a/hq/app/schedule/IamAudit.scala
+++ b/hq/app/schedule/IamAudit.scala
@@ -1,30 +1,53 @@
 package schedule
 
-import com.gu.anghammarad.models.{Target, AwsAccount => Account}
+import com.gu.anghammarad.models.{Notification, Target, AwsAccount => Account}
 import config.Config.{iamAlertCadence, iamHumanUserRotationCadence, iamMachineUserRotationCadence}
 import logic.DateUtils
 import model._
 import org.joda.time.{DateTime, Days}
 import play.api.Logging
 import schedule.IamMessages._
-import schedule.IamNotifier.createNotification
+import schedule.IamNotifier.notification
 import utils.attempt.FailedAttempt
 
 object IamAudit extends Logging {
 
-  def makeIamNotification(flaggedCredsToNotify: Map[AwsAccount, Seq[IAMAlertTargetGroup]]): List[IamNotification] = {
+  def makeNotification(flaggedCredsToNotify: Map[AwsAccount, Seq[IAMAlertTargetGroup]]): List[IamNotification] = {
     flaggedCredsToNotify.toList.flatMap { case (awsAccount, targetGroups) =>
       if (targetGroups.isEmpty) {
         logger.info(s"found no IAM user issues for ${awsAccount.name}. No notification required.")
         None
       } else {
-        targetGroups.map { tg =>
-          logger.info(s"for ${awsAccount.name}, generating iam notification message for ${tg.users.length} user(s) with outdated keys and and/or missing mfa")
-          val (usersToReceiveWarningAlerts, usersToReceiveFinalAlerts) = sortUsersIntoWarningOrFinalAlerts(tg.users)
-          createNotifications(warning = true, usersToReceiveWarningAlerts, awsAccount, tg.targets) ++ createNotifications(warning = false, usersToReceiveFinalAlerts, awsAccount, tg.targets)
-        }
+        targetGroups.map(tg => createWarningAndFinalNotification(tg, awsAccount, createIamAuditUsers(tg.users, awsAccount)))
       }
-    }.flatten
+    }
+  }
+
+  def createIamAuditUsers(users: Seq[VulnerableUser], account: AwsAccount): Seq[IamAuditUser] = {
+    users.map { user =>
+      IamAuditUser(
+        Dynamo.createId(account, user.username), account.name, user.username,
+        List(IamAuditAlert(DateTime.now, createDeadlineIfMissing(user.disableDeadline)))
+      )
+    }
+  }
+
+  def createWarningAndFinalNotification(tg: IAMAlertTargetGroup, awsAccount: AwsAccount, users: Seq[IamAuditUser]): IamNotification = {
+    logger.info(s"for ${awsAccount.name}, generating iam notification message for ${tg.users.length} user(s) with outdated keys and and/or missing mfa")
+    val (usersToReceiveWarningAlerts, usersToReceiveFinalAlerts) = sortUsersIntoWarningOrFinalAlerts(tg.users)
+
+    val warningNotifications = {
+      if (usersToReceiveWarningAlerts.nonEmpty)
+        Some(createNotification(warning = true, usersToReceiveWarningAlerts, awsAccount, tg.targets))
+      else None
+    }
+
+    val finalNotifications =
+      if (usersToReceiveFinalAlerts.nonEmpty)
+        Some(createNotification(warning = false, usersToReceiveFinalAlerts, awsAccount, tg.targets))
+      else None
+
+    IamNotification(warningNotifications, finalNotifications, users)
   }
 
   def getFlaggedCredentialsReports(allCreds: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]], dynamo: Dynamo): Map[AwsAccount, Seq[IAMAlertTargetGroup]] = {
@@ -36,8 +59,10 @@ object IamAudit extends Logging {
         }
         (awsAccount, Left(error))
       case Right(report) =>
-        (awsAccount, Right(getTargetGroups(report, awsAccount, dynamo)))
-    }
+        // alert the Ophan AWS account using tags to ensure that the Ophan and Data Tech teams who share the same AWS account receive the right emails
+        if (awsAccount.name == "Ophan") (awsAccount, Right(getTargetGroups(report, awsAccount, dynamo)))
+        else (awsAccount, Right(Seq(IAMAlertTargetGroup(List.empty, getUsersToAlert(report, awsAccount, dynamo)))))
+      }
     }.collect { case (awsAccount, Right(report)) => (awsAccount, report) }
   }
 
@@ -47,11 +72,10 @@ object IamAudit extends Logging {
     (warningAlerts, finalAlerts)
   }
 
-  private def createNotifications(warning: Boolean, users: Seq[VulnerableUser], awsAccount: AwsAccount, targets: List[Target]): Seq[IamNotification] = {
-    users.map { user =>
-      val message = if (warning) createWarningMessage(awsAccount, users) else createFinalMessage(awsAccount, users)
-      createNotification(awsAccount, targets :+ Account(awsAccount.accountNumber), message, warningSubject(awsAccount), user.username, createDeadlineIfMissing(user.disableDeadline))
-    }
+  private def createNotification(warning: Boolean, users: Seq[VulnerableUser], awsAccount: AwsAccount, targets: List[Target]) = {
+    val subject = if (warning) warningSubject(awsAccount) else finalSubject(awsAccount)
+    val message = if (warning) createWarningMessage(awsAccount, users) else createFinalMessage(awsAccount, users)
+    notification(subject, message, targets :+ Account(awsAccount.accountNumber))
   }
 
   private def createDeadlineIfMissing(date: Option[DateTime]): DateTime = date.getOrElse(DateTime.now.plusDays(iamAlertCadence))
@@ -62,12 +86,13 @@ object IamAudit extends Logging {
   }
   def isFinalAlert(deadline: DateTime, today: DateTime = DateTime.now): Boolean = deadline.withTimeAtStartOfDay == today.withTimeAtStartOfDay.plusDays(1)
 
-  private def getTargetGroups(report: CredentialReportDisplay, awsAccount: AwsAccount, dynamo: Dynamo): Seq[IAMAlertTargetGroup] = {
+  private def getUsersToAlert(report: CredentialReportDisplay, awsAccount: AwsAccount, dynamo: Dynamo): Seq[VulnerableUser] = {
     val vulnerableUsers = findVulnerableUsers(report)
-    val vulnerableUsersToAlert = filterUsersToAlert(vulnerableUsers, awsAccount, dynamo)
-    val targetGroups: Seq[IAMAlertTargetGroup] = getNotificationTargetGroups(vulnerableUsersToAlert)
-    logger.info(s"AWSAccount: ${awsAccount.name}, target groups: ${targetGroups.map(_.targets).mkString("/")}")
-    targetGroups
+    filterUsersToAlert(vulnerableUsers, awsAccount, dynamo)
+  }
+
+  private def getTargetGroups(report: CredentialReportDisplay, awsAccount: AwsAccount, dynamo: Dynamo): Seq[IAMAlertTargetGroup] = {
+    getNotificationTargetGroups(getUsersToAlert(report, awsAccount, dynamo))
   }
 
   private def findVulnerableUsers(report: CredentialReportDisplay): Seq[VulnerableUser] = {
@@ -77,10 +102,8 @@ object IamAudit extends Logging {
   // if the user is not present in dynamo, that means they've never been alerted before, so mark them as ready to be alerted
   private def filterUsersToAlert(users: Seq[VulnerableUser], awsAccount: AwsAccount, dynamo: Dynamo): Seq[VulnerableUser] = {
     val usersWithDeadline = enrichUsersWithDeadline(users, awsAccount, dynamo)
-    logger.info(s"(maybe) enriched users ${usersWithDeadline.map(_.username).mkString(",")}")
     usersWithDeadline.filter { user =>
-
-      user.disableDeadline.exists(u => isWarningAlert(u) || isFinalAlert(u)) || user.disableDeadline.isEmpty
+      user.disableDeadline.exists(deadline => isWarningAlert(deadline) || isFinalAlert(deadline)) || user.disableDeadline.isEmpty
     }
   }
 

--- a/hq/app/schedule/IamAudit.scala
+++ b/hq/app/schedule/IamAudit.scala
@@ -65,7 +65,9 @@ object IamAudit extends Logging {
   private def getTargetGroups(report: CredentialReportDisplay, awsAccount: AwsAccount, dynamo: Dynamo): Seq[IAMAlertTargetGroup] = {
     val vulnerableUsers = findVulnerableUsers(report)
     val vulnerableUsersToAlert = filterUsersToAlert(vulnerableUsers, awsAccount, dynamo)
-    getNotificationTargetGroups(vulnerableUsersToAlert)
+    val targetGroups: Seq[IAMAlertTargetGroup] = getNotificationTargetGroups(vulnerableUsersToAlert)
+    logger.info(s"AWSAccount: ${awsAccount.name}, target groups: ${targetGroups.map(_.targets).mkString("/")}")
+    targetGroups
   }
 
   private def findVulnerableUsers(report: CredentialReportDisplay): Seq[VulnerableUser] = {

--- a/hq/test/schedule/IamAuditTest.scala
+++ b/hq/test/schedule/IamAuditTest.scala
@@ -142,7 +142,7 @@ class IamAuditTest extends FreeSpec with Matchers {
     "returns nothing when there are no old access keys or missing mfas" in {
       val allCreds = Map(AwsAccount("", "", "", "") -> Seq.empty)
       val result = List.empty
-      makeIamNotification(allCreds) shouldEqual result
+      makeNotification(allCreds) shouldEqual result
     }
     "returns true when the deadline is one week away" in {
       val deadline = DateTime.now.plusWeeks(1)


### PR DESCRIPTION
## Problem
Security HQ sends emails to AWS accounts which have permanent credentials that pose a security risk. After making some changes to this feature in order to implement the credentials reaper (this will automate the disabling of credentials), the tests on PROD showed that more than one email was being sent per AWS account. Sometimes the emails would include a subsection of the flagged users, instead of all flagged users in one email. 

## Solution
We've fixed the code that was causing multiple emails to be sent. 

In addition, we also added that only the ophan account should split emails by tags, as this AWS account is shared by both the ophan and data lake teams. We did this, because it was causing emails to be split by stack for all the AWS accounts when the benefit of this was not clear for other teams. 

## Testing
This has been tested locally and on PROD with the new /test-notifications route.