### PR TITLE
Turn off the IAM job

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -150,7 +150,7 @@ class AppComponents(context: Context)
   val quartzScheduler = StdSchedulerFactory.getDefaultScheduler
   val iamJob = new IamJob(enabled = true, cacheService, securitySnsClient, dynamo, configuration)(executionContext)
   val jobScheduler = new JobScheduler(quartzScheduler, List(iamJob))
-  jobScheduler.initialise()
+  //jobScheduler.initialise() TODO: uncomment when ready to release creds reaper feature in PROD
 
   override def router: Router = new Routes(
     httpErrorHandler,

--- a/hq/app/schedule/CronSchedules.scala
+++ b/hq/app/schedule/CronSchedules.scala
@@ -4,6 +4,7 @@ import model.CronSchedule
 
 //a helpful quartz cron generator: https://www.freeformatter.com/cron-expression-generator-quartz.html
 object CronSchedules {
+  val everyWeekDay = CronSchedule("0 0 9 ? * MON-FRI *", "At 9am, every week day")
   val firstMondayOfEveryMonth = CronSchedule("0 0 8 ? * 2#1", "At 8am, on the 1st Monday of the month, every month")
   val secondMondayOfEveryMonth = CronSchedule("0 0 8 ? * 2#2", "At 8am, on the 1st Monday of the month, every month")
   val everyThursday = CronSchedule("0 0 9 ? * THU", "At 8am, on the 1st Monday of the month, every month")

--- a/hq/app/schedule/IamJob.scala
+++ b/hq/app/schedule/IamJob.scala
@@ -14,7 +14,7 @@ import scala.concurrent.ExecutionContext
 class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSAsync, dynamo: Dynamo,config: Configuration)(implicit val executionContext: ExecutionContext) extends JobRunner with Logging {
   override val id = "credentials report job"
   override val description = "Automated emails for old permanent credentials"
-  override val cronSchedule: CronSchedule = CronSchedules.firstMondayOfEveryMonth
+  override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
   val topicArn: Option[String] = getAnghammaradSNSTopicArn(config)
 
   def run(testMode: Boolean): Unit = {


### PR DESCRIPTION
This change stops the IAM job from running, which means that no notifications about permanent credentials will be sent to colleagues. However, the test endpoint /iam/test-notifications, still works so we will be able to continue testing this feature.
When the credentials reaper feature is ready to be released to PROD the line in app components can be uncommented.