### PR TITLE
Clarify credentials section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ account's health from a security point of view.
 
 ### AWS Configuration
 
+_Note: this section is only necessary if you do not already have another means of accessing your account(s) with the required permissions. Particularly, that is true for Guardian developers, who can use temporary credentials from Janus in the usual way._
+
 The security-test-user CloudFormation template should create a user with all the required permissions.
 
 Once the CloudFormation is complete and the user created, you will need to create an access key for this user.


### PR DESCRIPTION
## What does this change?
Adds a clarifying note to the start of the AWS configuration section in the README. After some deliberation, we think this section was written with the non-Guardian user in mind (because otherwise using Janus credentials is fine).


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Less confusing set-up steps (I was certainly stumped why that section was necessary)


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
No


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
