### PR TITLE
Use report time instead of `now` for GCP report

### DIFF
--- a/hq/app/controllers/GcpController.scala
+++ b/hq/app/controllers/GcpController.scala
@@ -2,8 +2,6 @@ package controllers
 
 import auth.SecurityHQAuthActions
 import com.gu.googleauth.GoogleAuthConfig
-import model.GcpReport
-import org.joda.time.DateTime
 import play.api.Configuration
 import play.api.libs.ws.WSClient
 import play.api.mvc.{AnyContent, BaseController, BodyParser, ControllerComponents}
@@ -18,11 +16,7 @@ class GcpController(val config: Configuration, val authConfig: GoogleAuthConfig,
 
   def all = authAction.async {
     attempt {
-      for {
-        allGcpFindings <- cacheService.getGcpFindings
-        gcpProjectToFinding = allGcpFindings.groupBy(_.project)
-        report = GcpReport(DateTime.now, gcpProjectToFinding)
-      } yield Ok(views.html.gcp.gcp(report))
+      cacheService.getGcpReport.map(report => Ok(views.html.gcp.gcp(report)))
     }
   }
 }

--- a/hq/app/services/MetricService.scala
+++ b/hq/app/services/MetricService.scala
@@ -58,13 +58,13 @@ class MetricService(
     }
 
     for {
-      allGcpFindings <- cacheService.getGcpFindings
+      gcpReport <- cacheService.getGcpReport
     } yield {
       Cloudwatch.logAsMetric(allSgs, Cloudwatch.DataType.sgTotal)
       Cloudwatch.logAsMetric(allExposedKeys, Cloudwatch.DataType.iamKeysTotal)
       Cloudwatch.logAsMetric(allPublicBuckets, Cloudwatch.DataType.s3Total)
       Cloudwatch.logMetricsForCredentialsReport(allCredentials)
-      Cloudwatch.logMetricsForGCPFindings(allGcpFindings)
+      Cloudwatch.logMetricsForGCPReport(gcpReport)
     }
   }
 

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -1,9 +1,6 @@
-@import model.CredentialReportDisplay
-@import org.joda.time.DateTime
 @import model.GcpReport
 @import controllers.AssetsFinder
 @import logic.GcpDisplay
-@import model.GcpFinding
 @import com.google.cloud.securitycenter.v1.Finding.Severity
 @(report: GcpReport)(implicit assets: AssetsFinder)
 


### PR DESCRIPTION
## What does this change?
This fixes an issue where the GCP report findings each claimed to have been generated at the current time, rather than when the report was actually run (every 4 hours, and when redeployed).

Instead of creating a `GcpReport` type, which contains the report time, during the lifecycle of the request, we instead make that the type stored by the GCP `box` in the cache service and write the current date/time when the data is fetched from GCP and the box is filled in the `CacheService`.

## What is the value of this?
Accurate report dates on the GCP page.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
No


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
