### PR TITLE
Fixes missing deadline field in IAM email alerts

### DIFF
--- a/hq/app/schedule/IamNotifications.scala
+++ b/hq/app/schedule/IamNotifications.scala
@@ -49,8 +49,11 @@ object IamNotifications extends Logging {
   }
 
   def createNotification(warning: Boolean, users: Seq[VulnerableUser], awsAccount: AwsAccount, targets: List[Target]) = {
+    val usersWithDeadlineAddedIfMissing = users.map { user =>
+      user.copy(disableDeadline = Some(createDeadlineIfMissing(user.disableDeadline)))
+    }
     val subject = if (warning) warningSubject(awsAccount) else finalSubject(awsAccount)
-    val message = if (warning) createWarningMessage(awsAccount, users) else createFinalMessage(awsAccount, users)
+    val message = if (warning) createWarningMessage(awsAccount, usersWithDeadlineAddedIfMissing) else createFinalMessage(awsAccount, usersWithDeadlineAddedIfMissing)
     notification(subject, message, targets :+ Account(awsAccount.accountNumber))
   }
 }


### PR DESCRIPTION
## Problem
The problem was that the IAM notification emails sent by security HQ (to alert users that there is a vulnerable permanent credential in their account) were missing the deadline field.

The deadline field is really important, because this is the date when SHQ would automatically disable the credential if no change has been made to rectify the problem!!

## Solution
This PR fixes this by ensuring that the logic which creates the email messages uses an existing function that creates a deadline if it does not already exist.

This may be the case if the credential is being alerted for the first time and is therefore not present in dynamoDB.

## Testing
This has been tested using the /iam/test-notifications endpoint which sends test emails to this google group: https://groups.google.com/a/guardian.co.uk/g/anghammarad.test.alerts. You can check out some of the latest emails in this group to see the result of this work.