### PR TITLE
Improve formatting of IAM notification emails

### DIFF
--- a/hq/app/schedule/IamMessages.scala
+++ b/hq/app/schedule/IamMessages.scala
@@ -38,6 +38,8 @@ object IamMessages {
   }
 
   val boilerPlateText = List(
+    "----------------------------------------------------------------------------------",
+    "",
     "To see why these keys have been flagged and how to rectify this, see Security HQ (https://security-hq.gutools.co.uk/iam).",
     "",
     "Here is some helpful documentation on:",


### PR DESCRIPTION
Security HQ sends email notifications when IAM permanent credentials are vulnerable. Currently the email formatting is a little bit confusing, because there's a lot of text. 

As a quick fix, this PR adds a line of dashes, which gmail formats quite nicely as a line that runs across the email dividing the part of the email that details the flagged users and the part of the email that describes where to go for more information.

Hopefully this quick fix helps the readability of the email for readers! You can see what this looks like by checking out the latest test emails here in this google group: https://groups.google.com/a/guardian.co.uk/g/anghammarad.test.alerts 