### PR TITLE
Should security HQ disable a user today?

### DIFF
--- a/hq/app/schedule/IamDisable.scala
+++ b/hq/app/schedule/IamDisable.scala
@@ -1,0 +1,18 @@
+package schedule
+
+import model.{AwsAccount, IamAuditUser, VulnerableUser}
+import org.joda.time.DateTime
+import play.api.Logging
+import schedule.IamDeadline.getNearestDeadline
+
+object IamDisable extends Logging {
+
+  def getUsersToDisable(users: Seq[VulnerableUser], awsAccount: AwsAccount, dynamo: Dynamo): Seq[IamAuditUser] = {
+    users.flatMap{ user =>
+      dynamo.getAlert(awsAccount, user.username).filter(u => toDisableToday(getNearestDeadline(u.alerts)))
+    }
+  }
+
+  def toDisableToday(deadline: DateTime, today: DateTime = DateTime.now): Boolean =
+    deadline.withTimeAtStartOfDay == today.withTimeAtStartOfDay
+}

--- a/hq/test/schedule/IamNotificationsTest.scala
+++ b/hq/test/schedule/IamNotificationsTest.scala
@@ -5,6 +5,7 @@ import model._
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
 import schedule.IamDeadline.{getNearestDeadline, isFinalAlert, isWarningAlert}
+import schedule.IamDisable.toDisableToday
 import schedule.IamFlaggedUsers.{findMissingMfa, findOldAccessKeys}
 import schedule.IamNotifications._
 import schedule.IamTargetGroups.getNotificationTargetGroups
@@ -171,6 +172,15 @@ class IamNotificationsTest extends FreeSpec with Matchers {
       val deadline = DateTime.now.plusDays(2)
       val today = DateTime.now
       isFinalAlert(deadline, today) shouldBe false
+    }
+    "returns true when the deadline is today" in {
+      val deadline = DateTime.now
+      val today = DateTime.now
+      toDisableToday(deadline, today) shouldBe true
+    }
+    "returns false when the deadline is not today" in {
+      val deadline = DateTime.now.minusDays(1)
+      toDisableToday(deadline) shouldBe false
     }
     "returns nearest deadline" in {
       val nearestDeadline = DateTime.now.plusDays(1).withTimeAtStartOfDay


### PR DESCRIPTION
This PR adds logic to pull the data from dynamoDB that tells us if an AWS account has been alerted about users with vulnerable permanent credentials in their account.

It checks to see if there are any deadlines that should be disabled today. Unit tests have been added to check that the DateTime check is working. I'm happy that the logic for pulling from the db is working as `scanAlert` is very similar to `getAlert` and is currently working nicely in PROD.