### PR TITLE
Credentials report refactoring

### DIFF
--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -101,9 +101,9 @@ object CredentialsReportDisplay {
   def reportStatusSummary(report: CredentialReportDisplay): ReportSummary = {
     val reportStatusSummary = (report.humanUsers ++ report.machineUsers).map(_.reportStatus)
 
-    val warnings = reportStatusSummary.count(_.isInstanceOf[Amber.type])
-    val errors = reportStatusSummary.count(_.isInstanceOf[Red.type])
-    val others = reportStatusSummary.count(_.isInstanceOf[Blue.type])
+    val warnings = reportStatusSummary.count({ case Amber => true })
+    val errors = reportStatusSummary.count({ case Red => true })
+    val others = reportStatusSummary.count({ case Blue => true })
 
     ReportSummary(warnings, errors, others)
   }

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -99,11 +99,13 @@ object CredentialsReportDisplay {
   }
 
   def reportStatusSummary(report: CredentialReportDisplay): ReportSummary = {
-    val reportStatusSummary = (report.humanUsers ++ report.machineUsers).map(_.reportStatus)
+    val reportStatusSummary = (report.humanUsers ++ report.machineUsers)
+      .groupBy(_.reportStatus)
+      .withDefaultValue(Seq.empty)
 
-    val warnings = reportStatusSummary.collect({ case Amber => true }).size
-    val errors = reportStatusSummary.collect({ case Red => true }).size
-    val others = reportStatusSummary.collect({ case Blue => true }).size
+    val warnings = reportStatusSummary(Amber).size
+    val errors = reportStatusSummary(Red).size
+    val others = reportStatusSummary(Blue).size
 
     ReportSummary(warnings, errors, others)
   }

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -101,9 +101,9 @@ object CredentialsReportDisplay {
   def reportStatusSummary(report: CredentialReportDisplay): ReportSummary = {
     val reportStatusSummary = (report.humanUsers ++ report.machineUsers).map(_.reportStatus)
 
-    val warnings = reportStatusSummary.count(_.isInstanceOf[Amber.type])
-    val errors = reportStatusSummary.count(_.isInstanceOf[Red.type])
-    val others = reportStatusSummary.count(_.isInstanceOf[Blue.type])
+    val warnings = reportStatusSummary.collect({ case Amber => true }).size
+    val errors = reportStatusSummary.collect({ case Red => true }).size
+    val others = reportStatusSummary.collect({ case Blue => true }).size
 
     ReportSummary(warnings, errors, others)
   }

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -57,7 +57,7 @@ object CredentialsReportDisplay {
   }
 
   def toCredentialReportDisplay(report: IAMCredentialsReport): CredentialReportDisplay = {
-    val humanUsers = report.entries.filterNot(_.rootUser).map {
+    val humanUsers = report.entries.filterNot(_.rootUser).collect {
       case cred if cred.passwordEnabled.contains(true) =>
         HumanUser(
           cred.user,
@@ -71,7 +71,7 @@ object CredentialsReportDisplay {
         )
     }
 
-    val machineUsers = report.entries.filterNot(_.rootUser).map {
+    val machineUsers = report.entries.filterNot(_.rootUser).collect {
       case cred if !cred.passwordEnabled.getOrElse(false) =>
         MachineUser(
           cred.user,

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -104,15 +104,13 @@ object CredentialsReportDisplay {
   }
 
   def reportStatusSummary(report: CredentialReportDisplay): ReportSummary = {
-    val reportStatusSummary = report.humanUsers.map(_.reportStatus) ++ report.machineUsers.map(_.reportStatus)
+    val reportStatusSummary = (report.humanUsers ++ report.machineUsers).map(_.reportStatus)
 
-    val (warnings, errors, other) = reportStatusSummary.foldLeft(0,0,0) {
-      case ( (war, err, oth), Amber ) => (war+1, err, oth)
-      case ( (war, err, oth), Red ) => (war, err+1, oth)
-      case ( (war, err, oth), Blue ) => (war, err, oth+1)
-      case ( (war, err, oth), _ ) => (war, err, oth)
-    }
-    ReportSummary(warnings, errors, other)
+    val warnings = reportStatusSummary.count(_.isInstanceOf[Amber.type])
+    val errors = reportStatusSummary.count(_.isInstanceOf[Red.type])
+    val others = reportStatusSummary.count(_.isInstanceOf[Blue.type])
+
+    ReportSummary(warnings, errors, others)
   }
 
   def exposedKeysSummary(allReports: Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]): Map[AwsAccount, Boolean] = {

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -101,9 +101,9 @@ object CredentialsReportDisplay {
   def reportStatusSummary(report: CredentialReportDisplay): ReportSummary = {
     val reportStatusSummary = (report.humanUsers ++ report.machineUsers).map(_.reportStatus)
 
-    val warnings = reportStatusSummary.count({ case Amber => true })
-    val errors = reportStatusSummary.count({ case Red => true })
-    val others = reportStatusSummary.count({ case Blue => true })
+    val warnings = reportStatusSummary.count(_.isInstanceOf[Amber.type])
+    val errors = reportStatusSummary.count(_.isInstanceOf[Red.type])
+    val others = reportStatusSummary.count(_.isInstanceOf[Blue.type])
 
     ReportSummary(warnings, errors, others)
   }

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -114,12 +114,10 @@ object CredentialsReportDisplay {
   }
 
   def exposedKeysSummary(allReports: Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]): Map[AwsAccount, Boolean] = {
-    for {
-      (account, report) <- allReports
-    } yield (account, report match {
-        case Right(keys) if keys.nonEmpty => true
-        case _ => false
-    })
+    allReports.mapValues {
+      case Right(keys) if keys.nonEmpty => true
+      case _ => false
+    }
   }
 
   def sortAccountsByReportSummary[L](reports: List[(AwsAccount, Either[L, CredentialReportDisplay])]): List[(AwsAccount, Either[L, CredentialReportDisplay])] = {

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -72,7 +72,7 @@ object CredentialsReportDisplay {
     }
 
     val machineUsers = report.entries.filterNot(_.rootUser).collect {
-      case cred if !cred.passwordEnabled.getOrElse(false) =>
+      case cred if !cred.passwordEnabled.contains(true) =>
         MachineUser(
           cred.user,
           accessKey1Details(cred),

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -204,11 +204,11 @@ sealed trait IAMUser {
 
 case class HumanUser(
   username: String,
-  hasMFA : Boolean,
+  hasMFA: Boolean,
   key1: AccessKey,
   key2: AccessKey,
   reportStatus: ReportStatus,
-  lastActivityDay : Option[Long],
+  lastActivityDay: Option[Long],
   stack: Option[AwsStack],
   tags: List[Tag]
 ) extends IAMUser


### PR DESCRIPTION
## What does this change?
I've been looking at updating the way that the report status is determined in the IAM Credentials Report, so that it better matches our expectations regarding credentials rotation. _However_ there were a few small refactors of the logic around the report that I feel improve readability. On first reading I found some of these areas of the logic to be hard to understand, so the hope is that this helps.

There is a further refactor that'd be worth doing that's closer to the logic I actually need to change around outdated credentials. However I'm leaving that until #283 is merged, because I think there will be overlap. That may mean we implement the change itself and come back for the refactor.


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Less code, more readable code (some of that is subjective)


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
No


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
