### PR TITLE
Small documentation fixes

### DIFF
--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -25,7 +25,7 @@ object Config {
     Documentation("SSH", "Use SSM-Scala for SSH access.", "code", "ssh-access"),
     Documentation("Software dependency checks", "Integrate Snyk for software vulnerability reports.", "security", "snyk"),
     Documentation("Wazuh", "Guide to installing the Wazuh agent.", "scanner", "wazuh"),
-    Documentation("Vulnerabilities", "Developer guiide to addressing vulnerabilities.", "format_list_numbered", "vulnerability-management")
+    Documentation("Vulnerabilities", "Developer guide to addressing vulnerabilities.", "format_list_numbered", "vulnerability-management")
   )
 
   def getStage(config: Configuration): Stage = {

--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -59,7 +59,7 @@ If something's missing please tell us: devx@theguardian.com
 
 
 ### 4. AWS GuardDuty
-![guard gromit](./images/gromit.gif)
+![guard gromit](https://github.com/guardian/security-hq/raw/main/hq/markdown/images/gromit.gif)
 
 If you're signed in to AWS already, you can click [here](https://eu-west-1.console.aws.amazon.com/guardduty/home?region=eu-west-1#/findings?macros=current)
 to take a look at AWS GuardDuty. You'll likely see a big list of activity going on in your AWS account that has been identified
@@ -133,4 +133,4 @@ perfectly reasonable to not fix something if you have a justification.
 This can be the sloow, hard part! In future, there might be links to docs on dealing with e.g. awkward play upgrades,
 dodgy AWS SDK dependencies, but for now all we can say is 
 
-![good luck](./images/good-luck.gif)
+![good luck](https://github.com/guardian/security-hq/raw/main/hq/markdown/images/good-luck.gif)

--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -72,15 +72,6 @@ Common problems raised by GuardDuty - and what you do to resolve them will be do
 
 :exclamation: GuardDuty raises a large number of issues. For now focus only on 'High' severity issues
 
-### 4. AWS Security Hub
-Security Hub has a LOT of information. Right now we're only interested in the [AWS Foundational Security Best Practices](https://eu-west-1.console.aws.amazon.com/securityhub/home?region=eu-west-1#/standards/aws-foundational-security-best-practices-1.0.0)
-section, with a focus on 'Critical' and 'High' severity vulnerabilities.
-
-We've documented a fair few of the common Security Hub issues [here](./guardduty-sechub-common-problems.md) - definitely
-worth a read. If something's missing please tell us and we'll spring into action to write some more lovely markdown!
-
-:exclamation: Security Hub raises a large number of issues. For now focus only on 'High' and 'Critical' severity issues
-
 ### 5. Google Cloud Platform Security Command Centre
 If your team has any google cloud platform projects, head to [Security HQ](https://security-hq.gutools.co.uk/gcp) to check for any
 vulnerabilities identified by Security Command Centre (SCC). At the moment the amount of information it provides is a little

--- a/hq/markdown/wazuh.md
+++ b/hq/markdown/wazuh.md
@@ -1,5 +1,5 @@
 # Wazuh
-![Wazuh logo](./images/wazuh_logo.png)
+![Wazuh logo](https://github.com/guardian/security-hq/raw/main/hq/markdown/images/wazuh_logo.png)
 ## Introduction
 
 Wazuh is a security monitoring service managed by Infosec. It requires agents to be installed on our EC2 instances, which 


### PR DESCRIPTION
## What does this change?
- Fixes typo on docs main page
- Removes duplicate section from vulnerability management
- Adjust the image links so that they'll work in the web app itself as well as when reading the markdown on github. 
 
N.B. The solution for the images isn't ideal, because it'll always refer to the main branch, but after wrangling with other options (serving images as assets from the app in a location that relative URLs would work) for too long, this seems liked the sensible compromise for now.

![image](https://user-images.githubusercontent.com/8754692/129167046-6da173a0-b24f-4a7b-be41-4b42afc4ca23.png)


<!-- Screenshots may be helpful to demonstrate -->