### PR TITLE
Centralise access key logic

### DIFF
--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -3,7 +3,6 @@ package logic
 import logic.DateUtils.dayDiff
 import model._
 import org.joda.time.{DateTime, DateTimeZone, Days}
-import schedule.IamFlaggedUsers
 import utils.attempt.FailedAttempt
 
 import java.net.URLEncoder
@@ -37,7 +36,7 @@ object CredentialsReportDisplay {
 
   private[logic] def machineReportStatus(cred: IAMCredential): ReportStatus = {
     val keys = List(accessKey1Details(cred), accessKey2Details(cred))
-    if (IamFlaggedUsers.hasOutdatedMachineKey(keys))
+    if (VulnerableAccessKeys.hasOutdatedMachineKey(keys))
       Red(Seq(OutdatedKey))
     else if (!keys.exists(_.keyStatus == AccessKeyEnabled))
       Amber
@@ -51,7 +50,7 @@ object CredentialsReportDisplay {
     //TODO: Scala 2.13 has Option builder `when` which is a nicer syntax than Some(...).filter
     val redStatusReasons: Seq[ReportStatusReason] = Seq(
       Some(MissingMfa).filterNot(_ => cred.mfaActive),
-      Some(OutdatedKey).filter(_ => IamFlaggedUsers.hasOutdatedHumanKey(keys))
+      Some(OutdatedKey).filter(_ => VulnerableAccessKeys.hasOutdatedHumanKey(keys))
     ).flatten
 
     if (redStatusReasons.nonEmpty)

--- a/hq/app/logic/VulnerableAccessKeys.scala
+++ b/hq/app/logic/VulnerableAccessKeys.scala
@@ -1,0 +1,17 @@
+package logic
+
+import config.Config.{iamHumanUserRotationCadence, iamMachineUserRotationCadence}
+import model.{AccessKey, AccessKeyEnabled, VulnerableAccessKey}
+
+object VulnerableAccessKeys {
+  def hasOutdatedHumanKey(keys: List[AccessKey]): Boolean = keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamHumanUserRotationCadence)
+
+  def hasOutdatedMachineKey(keys: List[AccessKey]): Boolean = keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamMachineUserRotationCadence)
+
+  def isOutdated(user: VulnerableAccessKey): Boolean = {
+    if (user.humanUser) user.accessKeyWithId.accessKey.keyStatus == AccessKeyEnabled &&
+      hasOutdatedHumanKey(List(user.accessKeyWithId.accessKey))
+    else user.accessKeyWithId.accessKey.keyStatus == AccessKeyEnabled &&
+      hasOutdatedMachineKey(List(user.accessKeyWithId.accessKey))
+  }
+}

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -6,7 +6,6 @@ import com.google.cloud.securitycenter.v1.Finding.Severity
 import com.gu.anghammarad.models.{App, Notification, Stack, Target, Stage => AnghammaradStage}
 import org.joda.time.DateTime
 import play.api.libs.json.{JsString, JsValue, Json, Writes}
-import schedule.IamFlaggedUsers.{hasOutdatedHumanKey, hasOutdatedMachineKey}
 
 
 case class AwsAccount(
@@ -316,15 +315,6 @@ case class VulnerableAccessKey(
   accessKeyWithId: AccessKeyWithId,
   humanUser: Boolean
 )
-
-object VulnerableAccessKey {
-  def isOutdated(user: VulnerableAccessKey): Boolean = {
-    if (user.humanUser) user.accessKeyWithId.accessKey.keyStatus == AccessKeyEnabled &&
-      hasOutdatedHumanKey(List(user.accessKeyWithId.accessKey))
-    else user.accessKeyWithId.accessKey.keyStatus == AccessKeyEnabled &&
-      hasOutdatedMachineKey(List(user.accessKeyWithId.accessKey))
-  }
-}
 
 sealed trait IamAuditNotificationType {def name: String}
 object Warning extends IamAuditNotificationType {val name = "Warning"}

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -230,6 +230,7 @@ sealed trait IAMUser {
   def lastActivityDay: Option[Long]
   def stack: Option[AwsStack]
   def tags: List[Tag]
+  def isHuman: Boolean
 }
 
 case class HumanUser(
@@ -241,7 +242,9 @@ case class HumanUser(
   lastActivityDay: Option[Long],
   stack: Option[AwsStack],
   tags: List[Tag]
-) extends IAMUser
+) extends IAMUser {
+  val isHuman = true
+}
 
 case class MachineUser(
   username: String,
@@ -251,7 +254,9 @@ case class MachineUser(
   lastActivityDay: Option[Long],
   stack: Option[AwsStack],
   tags: List[Tag]
-) extends IAMUser
+) extends IAMUser {
+  val isHuman = false
+}
 
 case class SnykToken(value: String) extends AnyVal
 
@@ -309,6 +314,18 @@ case class VulnerableUser(
   tags: List[Tag],
   disableDeadline: Option[DateTime] = None
 ) extends IAMAlert
+
+object VulnerableUser {
+  def fromIamUser(iamUser: IAMUser): VulnerableUser = {
+    VulnerableUser(
+      iamUser.username,
+      iamUser.key1,
+      iamUser.key2,
+      iamUser.isHuman,
+      iamUser.tags
+    )
+  }
+}
 
 case class VulnerableAccessKey(
   username: String,

--- a/hq/app/schedule/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/IamDisableAccessKeys.scala
@@ -5,7 +5,7 @@ import aws.iam.IAMClient.SOLE_REGION
 import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{UpdateAccessKeyRequest, UpdateAccessKeyResult}
-import model.VulnerableAccessKey.isOutdated
+import logic.VulnerableAccessKeys.isOutdated
 import model._
 import play.api.Logging
 import schedule.IamListAccessKeys.listAccountAccessKeys

--- a/hq/app/schedule/IamFlaggedUsers.scala
+++ b/hq/app/schedule/IamFlaggedUsers.scala
@@ -1,7 +1,6 @@
 package schedule
 
-import config.Config.{iamHumanUserRotationCadence, iamMachineUserRotationCadence}
-import logic.DateUtils
+import logic.VulnerableAccessKeys
 import model._
 import play.api.Logging
 import schedule.IamDeadline.filterUsersToAlert
@@ -45,13 +44,10 @@ object IamFlaggedUsers extends Logging {
   }
 
   def findOldAccessKeys(credsReport: CredentialReportDisplay): CredentialReportDisplay = {
-    val filteredMachines = credsReport.machineUsers.filter(user => hasOutdatedMachineKey(List(user.key1, user.key2)))
-    val filteredHumans = credsReport.humanUsers.filter(user => hasOutdatedHumanKey(List(user.key1, user.key2)))
+    val filteredMachines = credsReport.machineUsers.filter(user => VulnerableAccessKeys.hasOutdatedMachineKey(List(user.key1, user.key2)))
+    val filteredHumans = credsReport.humanUsers.filter(user => VulnerableAccessKeys.hasOutdatedHumanKey(List(user.key1, user.key2)))
     credsReport.copy(machineUsers = filteredMachines, humanUsers = filteredHumans)
   }
-
-  def hasOutdatedHumanKey(keys: List[AccessKey]): Boolean = keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamHumanUserRotationCadence)
-  def hasOutdatedMachineKey(keys: List[AccessKey]): Boolean = keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamMachineUserRotationCadence)
 
   def findMissingMfa(credsReport: CredentialReportDisplay): CredentialReportDisplay = {
     val removeMachineUsers = credsReport.machineUsers.filterNot(_.username == "")

--- a/hq/app/schedule/IamFlaggedUsers.scala
+++ b/hq/app/schedule/IamFlaggedUsers.scala
@@ -56,36 +56,10 @@ object IamFlaggedUsers extends Logging {
   }
 
   def outdatedKeysInfo(users: CredentialReportDisplay): Seq[VulnerableUser] = {
-    val machines = users.machineUsers.map { user =>
-      VulnerableUser(
-        user.username,
-        user.key1,
-        user.key2,
-        humanUser = false,
-        user.tags
-      )
-    }
-    val humans = users.humanUsers.map { user =>
-      VulnerableUser(
-        user.username,
-        user.key1,
-        user.key2,
-        humanUser = true,
-        user.tags
-      )
-    }
-    machines ++ humans
+    (users.machineUsers ++ users.humanUsers).map(VulnerableUser.fromIamUser)
   }
 
   def missingMfaInfo(users: CredentialReportDisplay): Seq[VulnerableUser] = {
-    users.humanUsers.map { user =>
-      VulnerableUser(
-        user.username,
-        user.key1,
-        user.key2,
-        humanUser = true,
-        user.tags
-      )
-    }
+    users.humanUsers.map(VulnerableUser.fromIamUser)
   }
 }


### PR DESCRIPTION
## What does this change?
This is a small change to centralise some access key rotation logic, which is now being shared by more than one report/job.

I also spotted a warning about duplicate code in one of the files I was changing, so the second commit adds a smaller conversion method to the model that avoids duplicated class creation code in the logic.

<!-- Screenshots may be helpful to demonstrate -->