### PR TITLE
docs: Add a comment about where the StackSet lives

### DIFF
--- a/cloudformation/watched-account.template.yaml
+++ b/cloudformation/watched-account.template.yaml
@@ -1,3 +1,7 @@
+# This CloudFormation template is deployed as a CloudFormation Stack Set from the root account
+# The stack set is called "watched-account" and instances of the stack set are called something like "StackSet-abcde-12345".
+# It is easiest to find a stack set instance in a target account by filtering for stacks with a description matching this template's description.
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: Sets up a role for monitoring via Security HQ and a Security Group lambda for real time alerting
 


### PR DESCRIPTION
## What does this change?

As it is not immediately obvious where the watched-account template is deployed, add a comment to explain it.

## What is the value of this?

It is slightly easier to get started with this template.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

## Any additional notes?

This is a no-op.