### PR TITLE
Improve logging for CloudWatch metrics service

### DIFF
--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -75,8 +75,8 @@ object Cloudwatch extends Logging {
     val request = new PutMetricDataRequest().withNamespace(namespace).withMetricData(datum)
 
     Try(cloudwatchClient.putMetricData(request)) match {
-      case Success(response) => logger.info(s"putMetric: ${datum}")
-      case Failure(e) => logger.error(s"putMetric failure: ${datum}", e)
+      case Success(_) => logger.debug(s"putMetric success: $datum")
+      case Failure(e) => logger.error(s"putMetric failure: $datum", e)
     }
   }
 }


### PR DESCRIPTION
## What does this change?

This PR improves the logging related to CloudWatch metrics:

1. When individual metrics are pushed successfully, we now log at `debug` (rather than `info`) level
2. When metrics cannot be pushed due to problems with data collection, we now log more details about what has gone wrong

## What is the value of this?

1. Reduces [noise](https://logs.gutools.co.uk/goto/51d80808f26ebdf629c283e40c643be5), which should make it easier to analyse the logs
2. Helps us to debug in scenarios where [no metrics are being pushed (which seems to be the case at the time of writing!)](https://logs.gutools.co.uk/goto/4d189c03575774fcc3d9c44a6115a8f7)

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.