### PR TITLE
Small fixes to the reaper after testing

### DIFF
--- a/hq/app/schedule/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/IamDisableAccessKeys.scala
@@ -28,7 +28,7 @@ object IamDisableAccessKeys extends Logging {
         logger.info(s"attempting to disable access key id ${key.id}.")
         for {
           client <- iamClients.get(account, SOLE_REGION)
-          updateAccessKeyResult <- disableAccessKey(key, client) //TODO add some error handling here
+          updateAccessKeyResult <- disableAccessKey(key, client, user.username) //TODO add some error handling here
         } yield {
           val updateAccessKeyRequestId = updateAccessKeyResult.getSdkResponseMetadata.getRequestId
           logger.info(s"disabled access key for ${user.username} with access key id ${key.id} and request id: $updateAccessKeyRequestId.")
@@ -37,11 +37,12 @@ object IamDisableAccessKeys extends Logging {
     )
   }
 
-  def disableAccessKey(key: AccessKeyWithId, client: AwsClient[AmazonIdentityManagementAsync])
+  def disableAccessKey(key: AccessKeyWithId, client: AwsClient[AmazonIdentityManagementAsync], username: String)
     (implicit ec: ExecutionContext): Attempt[UpdateAccessKeyResult] = {
       val request = new UpdateAccessKeyRequest()
-      .withAccessKeyId(key.id)
-      .withStatus("Inactive")
+        .withUserName(username)
+        .withAccessKeyId(key.id)
+        .withStatus("Inactive")
       handleAWSErrs(client)(awsToScala(client)(_.updateAccessKeyAsync)(request))
     }
 }

--- a/hq/app/schedule/IamFlaggedUsers.scala
+++ b/hq/app/schedule/IamFlaggedUsers.scala
@@ -40,7 +40,9 @@ object IamFlaggedUsers extends Logging {
   }
 
   def findVulnerableUsers(report: CredentialReportDisplay): Seq[VulnerableUser] = {
-    outdatedKeysInfo(findOldAccessKeys(report)) ++ missingMfaInfo(findMissingMfa(report))
+    outdatedKeysInfo(findOldAccessKeys(report))
+      .union(missingMfaInfo(findMissingMfa(report)))
+      .distinct
   }
 
   def findOldAccessKeys(credsReport: CredentialReportDisplay): CredentialReportDisplay = {


### PR DESCRIPTION
There were a couple of problems with the reaper, which testing has surfaced. This PR fixes the following:

### update-access-key API
The AWS API update-access-key requires a username when the credentials used to call the API are not the same as the key that is being updated. This has been fixed by adding a username to the API call.

### repeated users to disable
The usersToDisable function in IamJob creates two lists of users to disable. The first list are users who have old access keys and the second is a list of users who require multi-factor authentication. 

In our test case, the vulnerable user had both old access keys and required mfa. This meant that the user was present in both lists, resulting in two API calls to remove the password and delete the access key of the same user. In addition, this meant that the email to AWS accounts included this user twice, which is confusing. 

This has been fixed by ensuring that the list of vulnerable users is uniques only.
