### PR TITLE
Send notification when Credentials Reaper disables an access key or removes the password of a user

### DIFF
--- a/hq/app/schedule/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/IamDisableAccessKeys.scala
@@ -5,17 +5,28 @@ import aws.iam.IAMClient.SOLE_REGION
 import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{UpdateAccessKeyRequest, UpdateAccessKeyResult}
+import com.amazonaws.services.sns.AmazonSNSAsync
+import com.gu.anghammarad.models.{AwsAccount => Account}
 import logic.VulnerableAccessKeys.isOutdated
 import model._
 import play.api.Logging
 import schedule.IamListAccessKeys.listAccountAccessKeys
+import schedule.IamMessages.{disabledAccessKeyMessage, disabledAccessKeySubject}
+import schedule.IamNotifier.{notification, send}
 import utils.attempt.Attempt
 
 import scala.concurrent.ExecutionContext
 
 object IamDisableAccessKeys extends Logging {
 
-  def disableAccessKeys(account: AwsAccount, vulnerableUsers: Seq[VulnerableUser], iamClients: AwsClients[AmazonIdentityManagementAsync])
+  def disableAccessKeys(
+    account: AwsAccount,
+    vulnerableUsers: Seq[VulnerableUser],
+    iamClients: AwsClients[AmazonIdentityManagementAsync],
+    topicArn: Option[String],
+    snsClient: AmazonSNSAsync,
+    testMode: Boolean
+  )
     (implicit ec: ExecutionContext): Unit = {
     // this does the work of taking our vulnerable users who have been flagged as potentially needing their access keys disabled
     // and converts that vulnerableUser into a user that has it's access key id attached to it
@@ -28,16 +39,17 @@ object IamDisableAccessKeys extends Logging {
         logger.info(s"attempting to disable access key id ${key.id}.")
         for {
           client <- iamClients.get(account, SOLE_REGION)
-          updateAccessKeyResult <- disableAccessKey(key, client, user.username) //TODO add some error handling here
+          updateAccessKeyResult <- disableAccessKey(key, client, user.username)
         } yield {
           val updateAccessKeyRequestId = updateAccessKeyResult.getSdkResponseMetadata.getRequestId
           logger.info(s"disabled access key for ${user.username} with access key id ${key.id} and request id: $updateAccessKeyRequestId.")
+          notifyAwsAccount(account, user.username, key.id, topicArn, snsClient, testMode)
         }
       }
     )
   }
 
-  def disableAccessKey(key: AccessKeyWithId, client: AwsClient[AmazonIdentityManagementAsync], username: String)
+  private def disableAccessKey(key: AccessKeyWithId, client: AwsClient[AmazonIdentityManagementAsync], username: String)
     (implicit ec: ExecutionContext): Attempt[UpdateAccessKeyResult] = {
       val request = new UpdateAccessKeyRequest()
         .withUserName(username)
@@ -45,4 +57,20 @@ object IamDisableAccessKeys extends Logging {
         .withStatus("Inactive")
       handleAWSErrs(client)(awsToScala(client)(_.updateAccessKeyAsync)(request))
     }
+
+  private def notifyAwsAccount(
+    account: AwsAccount,
+    username: String,
+    accessKeyId: String,
+    topicArn: Option[String],
+    snsClient: AmazonSNSAsync,
+    testMode: Boolean
+  )(implicit ec: ExecutionContext): Unit = {
+    send(
+      notification(disabledAccessKeySubject(username, account), disabledAccessKeyMessage(username, accessKeyId), List(Account(account.accountNumber))),
+      topicArn,
+      snsClient,
+      testMode
+    )
+  }
 }

--- a/hq/app/schedule/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/IamDisableAccessKeys.scala
@@ -5,14 +5,10 @@ import aws.iam.IAMClient.SOLE_REGION
 import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{UpdateAccessKeyRequest, UpdateAccessKeyResult}
-import com.amazonaws.services.sns.AmazonSNSAsync
-import com.gu.anghammarad.models.{AwsAccount => Account}
 import logic.VulnerableAccessKeys.isOutdated
 import model._
 import play.api.Logging
 import schedule.IamListAccessKeys.listAccountAccessKeys
-import schedule.IamMessages.{disabledAccessKeyMessage, disabledAccessKeySubject}
-import schedule.IamNotifier.{notification, send}
 import utils.attempt.Attempt
 
 import scala.concurrent.ExecutionContext
@@ -22,12 +18,8 @@ object IamDisableAccessKeys extends Logging {
   def disableAccessKeys(
     account: AwsAccount,
     vulnerableUsers: Seq[VulnerableUser],
-    iamClients: AwsClients[AmazonIdentityManagementAsync],
-    topicArn: Option[String],
-    snsClient: AmazonSNSAsync,
-    testMode: Boolean
-  )
-    (implicit ec: ExecutionContext): Unit = {
+    iamClients: AwsClients[AmazonIdentityManagementAsync]
+  )(implicit ec: ExecutionContext): Unit = {
     // this does the work of taking our vulnerable users who have been flagged as potentially needing their access keys disabled
     // and converts that vulnerableUser into a user that has it's access key id attached to it
     val vulnerableUserWithAccessKeyId: Attempt[List[VulnerableAccessKey]] = listAccountAccessKeys(account, vulnerableUsers, iamClients)
@@ -43,7 +35,7 @@ object IamDisableAccessKeys extends Logging {
         } yield {
           val updateAccessKeyRequestId = updateAccessKeyResult.getSdkResponseMetadata.getRequestId
           logger.info(s"disabled access key for ${user.username} with access key id ${key.id} and request id: $updateAccessKeyRequestId.")
-          notifyAwsAccount(account, user.username, key.id, topicArn, snsClient, testMode)
+          // TODO create failure case and trigger cloudwatch alarm
         }
       }
     )
@@ -57,20 +49,4 @@ object IamDisableAccessKeys extends Logging {
         .withStatus("Inactive")
       handleAWSErrs(client)(awsToScala(client)(_.updateAccessKeyAsync)(request))
     }
-
-  private def notifyAwsAccount(
-    account: AwsAccount,
-    username: String,
-    accessKeyId: String,
-    topicArn: Option[String],
-    snsClient: AmazonSNSAsync,
-    testMode: Boolean
-  )(implicit ec: ExecutionContext): Unit = {
-    send(
-      notification(disabledAccessKeySubject(username, account), disabledAccessKeyMessage(username, accessKeyId), List(Account(account.accountNumber))),
-      topicArn,
-      snsClient,
-      testMode
-    )
-  }
 }

--- a/hq/app/schedule/IamJob.scala
+++ b/hq/app/schedule/IamJob.scala
@@ -52,10 +52,8 @@ class IamJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSA
 
     // disable user if still vulnerable after notifications have been sent and send a final notification stating this
     usersToDisable(flaggedCredentials, dynamo).foreach { case (account, users) =>
-      removePasswords(account, users, iamClients)
-      disableAccessKeys(account, users, iamClients)
-      //val userDisabledAlert: Notification = ???
-      //send(userDisabledAlert, topicArn, snsClient, testMode)
+      removePasswords(account, users, iamClients, topicArn, snsClient, testMode)
+      disableAccessKeys(account, users, iamClients, topicArn, snsClient, testMode)
     }
   }
 }

--- a/hq/app/schedule/IamMessages.scala
+++ b/hq/app/schedule/IamMessages.scala
@@ -1,5 +1,8 @@
 package schedule
 
+import aws.AwsClient
+import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
+import config.Config.{iamHumanUserRotationCadence, iamMachineUserRotationCadence}
 import model.{AwsAccount, VulnerableUser}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
@@ -10,6 +13,26 @@ object IamMessages {
 
   def warningSubject(account: AwsAccount): String = s"Action ${account.name}: Insecure credentials"
   def finalSubject(account: AwsAccount): String = s"Action ${account.name}: Deactivating credentials tomorrow"
+  def passwordRemovedSubject(user: VulnerableUser, client: AwsClient[AmazonIdentityManagementAsync]): String =
+    s"PASSWORD REMOVED for AWS IAM User ${user.username} in ${client.account.name}"
+  def disabledAccessKeySubject(username: String, account: AwsAccount): String = s"ACCESS KEY DISABLED for AWS IAM User $username in ${account.name}"
+
+  def passwordRemovedMessage(user: VulnerableUser): String = {
+    s"""
+       |The Permanent IAM user ${user.username}'s password has been removed today by Security HQ (https://security-hq.gutools.co.uk/), because multi factor authentication (mfa) was not enabled.
+       |This can be remediated by creating a new password (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords.html) and turning on mfa (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html).
+       |If you have any questions, please contact the Developer Experience team: devx@theguardian.com.
+       |""".stripMargin
+  }
+
+  def disabledAccessKeyMessage(username: String, accessKeyId: String): String = {
+    s"""
+       |The Permanent IAM user $username's access key (id: $accessKeyId) was disabled today by Security HQ (https://security-hq.gutools.co.uk/), because it had not been rotated.
+       |This can be remediated by creating a new access key (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey).
+       |Please remember to rotate human user access keys within ${iamHumanUserRotationCadence.toString} days or ${iamMachineUserRotationCadence.toString} days for machines.
+       |If you have any questions, please contact the Developer Experience team: devx@theguardian.com.
+       |""".stripMargin
+  }
 
   def message(account: AwsAccount) = {
     s"Please check the following permanent credentials in AWS Account ${account.name}/${account.accountNumber}, which have been flagged as either needing to be rotated or requiring multi-factor authentication (if you're already planning on doing this, please ignore this message). If this is not rectified before the deadline, Security HQ will automatically disable this user:"

--- a/hq/app/schedule/IamMessages.scala
+++ b/hq/app/schedule/IamMessages.scala
@@ -1,8 +1,5 @@
 package schedule
 
-import aws.AwsClient
-import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
-import config.Config.{iamHumanUserRotationCadence, iamMachineUserRotationCadence}
 import model.{AwsAccount, VulnerableUser}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
@@ -13,29 +10,20 @@ object IamMessages {
 
   def warningSubject(account: AwsAccount): String = s"Action ${account.name}: Insecure credentials"
   def finalSubject(account: AwsAccount): String = s"Action ${account.name}: Deactivating credentials tomorrow"
-  def passwordRemovedSubject(user: VulnerableUser, client: AwsClient[AmazonIdentityManagementAsync]): String =
-    s"PASSWORD REMOVED for AWS IAM User ${user.username} in ${client.account.name}"
-  def disabledAccessKeySubject(username: String, account: AwsAccount): String = s"ACCESS KEY DISABLED for AWS IAM User $username in ${account.name}"
+  def disabledUsersSubject(account: AwsAccount): String = s"AWS IAM User(s) DISABLED in ${account.name} Account"
 
-  def passwordRemovedMessage(user: VulnerableUser): String = {
+  def disabledUsersMessage(users: Seq[VulnerableUser]): String = {
     s"""
-       |The Permanent IAM user ${user.username}'s password has been removed today by Security HQ (https://security-hq.gutools.co.uk/), because multi factor authentication (mfa) was not enabled.
-       |This can be remediated by creating a new password (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords.html) and turning on mfa (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html).
-       |If you have any questions, please contact the Developer Experience team: devx@theguardian.com.
-       |""".stripMargin
-  }
-
-  def disabledAccessKeyMessage(username: String, accessKeyId: String): String = {
-    s"""
-       |The Permanent IAM user $username's access key (id: $accessKeyId) was disabled today by Security HQ (https://security-hq.gutools.co.uk/), because it had not been rotated.
-       |This can be remediated by creating a new access key (https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html#Using_RotateAccessKey).
-       |Please remember to rotate human user access keys within ${iamHumanUserRotationCadence.toString} days or ${iamMachineUserRotationCadence.toString} days for machines.
-       |If you have any questions, please contact the Developer Experience team: devx@theguardian.com.
+       |The following Permanent IAM user(s) have been disabled today: ${users.map(_.username).mkString(",")}.
+       |Please check Security HQ to review the IAM users in your account (https://security-hq.gutools.co.uk/iam).
+       |If you still require the disabled user, add new access keys(s) and rotate regularly going forwards, or add MFA for human users.
+       |If you no longer require the disabled user, they should be deleted.
+       |If you have any questions, contact devx@theguardian.com.
        |""".stripMargin
   }
 
   def message(account: AwsAccount) = {
-    s"Please check the following permanent credentials in AWS Account ${account.name}/${account.accountNumber}, which have been flagged as either needing to be rotated or requiring multi-factor authentication (if you're already planning on doing this, please ignore this message). If this is not rectified before the deadline, Security HQ will automatically disable this user:"
+    s"Please check the following permanent credentials in AWS Account ${account.name}, which have been flagged as either needing to be rotated or requiring multi-factor authentication (if you're already planning on doing this, please ignore this message). If this is not rectified before the deadline, Security HQ will automatically disable this user:"
   }
   def createWarningMessage(account: AwsAccount, users: Seq[VulnerableUser]): String = {
     s"""
@@ -55,7 +43,7 @@ object IamMessages {
 
   private def printFormat(user: VulnerableUser): String = {
     s"""
-       |Username: ${user.username}
+       |Username: ${user.username}.
        |If this is not rectified by ${dateTimeToString(user.disableDeadline)}, the user will be disabled.
        |""".stripMargin
   }

--- a/hq/app/schedule/IamRemovePassword.scala
+++ b/hq/app/schedule/IamRemovePassword.scala
@@ -5,28 +5,61 @@ import aws.iam.IAMClient.SOLE_REGION
 import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.DeleteLoginProfileRequest
+import com.amazonaws.services.sns.AmazonSNSAsync
+import com.gu.anghammarad.models.{AwsAccount => Account}
 import model.{AwsAccount, VulnerableUser}
 import play.api.Logging
+import schedule.IamMessages.{passwordRemovedMessage, passwordRemovedSubject}
+import schedule.IamNotifier.{notification, send}
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 object IamRemovePassword extends Logging {
 
-  def deleteUserLoginProfile(client: AwsClient[AmazonIdentityManagementAsync], user: VulnerableUser)(implicit ec: ExecutionContext): Unit = {
-    val request = new DeleteLoginProfileRequest().withUserName(user.username)
-    awsToScala(client)(_.deleteLoginProfileAsync)(request).onComplete {
-      case Failure(exception) => logger.warn(s"failed to delete password for username: ${user.username}.", exception)
-      case Success(result) => logger.info(s"successfully deleted password for username: ${user.username}. DeleteLoginProfile Response: ${result.toString}.")
-    }
-  }
-
-  def removePasswords(account: AwsAccount, users: Seq[VulnerableUser], iamClients: AwsClients[AmazonIdentityManagementAsync])
+  def removePasswords(
+    account: AwsAccount,
+    users: Seq[VulnerableUser],
+    iamClients: AwsClients[AmazonIdentityManagementAsync],
+    topicArn: Option[String],
+    snsClient: AmazonSNSAsync,
+    testMode: Boolean
+  )
     (implicit ec: ExecutionContext): Unit = {
     users.map { user =>
       iamClients.get(account, SOLE_REGION).map { client =>
-        deleteUserLoginProfile(client, user)
+        deleteUserLoginProfile(client, user, topicArn, snsClient, testMode)
       }
     }
+  }
+
+  private def deleteUserLoginProfile(
+    client: AwsClient[AmazonIdentityManagementAsync],
+    user: VulnerableUser,
+    topicArn: Option[String],
+    snsClient: AmazonSNSAsync,
+    testMode: Boolean
+  )(implicit ec: ExecutionContext): Unit = {
+    val request = new DeleteLoginProfileRequest().withUserName(user.username)
+    awsToScala(client)(_.deleteLoginProfileAsync)(request).onComplete {
+      case Failure(exception) => logger.warn(s"failed to delete password for username: ${user.username}.", exception)
+      case Success(result) =>
+        logger.info(s"successfully deleted password for username: ${user.username}. DeleteLoginProfile Response: ${result.toString}.")
+        notify(client, user, topicArn, snsClient, testMode)
+    }
+  }
+
+  private def notify(
+    client: AwsClient[AmazonIdentityManagementAsync],
+    user: VulnerableUser,
+    topicArn: Option[String],
+    snsClient: AmazonSNSAsync,
+    testMode: Boolean)(implicit ec: ExecutionContext): Unit = {
+    send(
+      notification(passwordRemovedSubject(user, client), passwordRemovedMessage(user), List(Account(client.account.accountNumber))),
+      topicArn,
+      snsClient,
+      testMode
+    )
   }
 }

--- a/hq/app/schedule/IamRemovePassword.scala
+++ b/hq/app/schedule/IamRemovePassword.scala
@@ -5,12 +5,8 @@ import aws.iam.IAMClient.SOLE_REGION
 import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.DeleteLoginProfileRequest
-import com.amazonaws.services.sns.AmazonSNSAsync
-import com.gu.anghammarad.models.{AwsAccount => Account}
 import model.{AwsAccount, VulnerableUser}
 import play.api.Logging
-import schedule.IamMessages.{passwordRemovedMessage, passwordRemovedSubject}
-import schedule.IamNotifier.{notification, send}
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
@@ -20,46 +16,26 @@ object IamRemovePassword extends Logging {
   def removePasswords(
     account: AwsAccount,
     users: Seq[VulnerableUser],
-    iamClients: AwsClients[AmazonIdentityManagementAsync],
-    topicArn: Option[String],
-    snsClient: AmazonSNSAsync,
-    testMode: Boolean
-  )
-    (implicit ec: ExecutionContext): Unit = {
+    iamClients: AwsClients[AmazonIdentityManagementAsync]
+  )(implicit ec: ExecutionContext): Unit = {
     users.map { user =>
       iamClients.get(account, SOLE_REGION).map { client =>
-        deleteUserLoginProfile(client, user, topicArn, snsClient, testMode)
+        deleteUserLoginProfile(client, user)
       }
     }
   }
 
   private def deleteUserLoginProfile(
     client: AwsClient[AmazonIdentityManagementAsync],
-    user: VulnerableUser,
-    topicArn: Option[String],
-    snsClient: AmazonSNSAsync,
-    testMode: Boolean
+    user: VulnerableUser
   )(implicit ec: ExecutionContext): Unit = {
     val request = new DeleteLoginProfileRequest().withUserName(user.username)
     awsToScala(client)(_.deleteLoginProfileAsync)(request).onComplete {
-      case Failure(exception) => logger.warn(s"failed to delete password for username: ${user.username}.", exception)
+      case Failure(exception) =>
+        logger.warn(s"failed to delete password for username: ${user.username}.", exception)
+        // TODO trigger cloudwatch alarm for failure case
       case Success(result) =>
         logger.info(s"successfully deleted password for username: ${user.username}. DeleteLoginProfile Response: ${result.toString}.")
-        notify(client, user, topicArn, snsClient, testMode)
     }
-  }
-
-  private def notify(
-    client: AwsClient[AmazonIdentityManagementAsync],
-    user: VulnerableUser,
-    topicArn: Option[String],
-    snsClient: AmazonSNSAsync,
-    testMode: Boolean)(implicit ec: ExecutionContext): Unit = {
-    send(
-      notification(passwordRemovedSubject(user, client), passwordRemovedMessage(user), List(Account(client.account.accountNumber))),
-      topicArn,
-      snsClient,
-      testMode
-    )
   }
 }


### PR DESCRIPTION
## What is this change?
This PR sends a notification email when Security HQ disables permanent IAM users (by removing the user's password and/or access key(s)). 

Here is an example of the email:
![Screenshot 2021-09-01 at 08 35 18](https://user-images.githubusercontent.com/42121379/131631305-ae1e9f7e-ce5a-412a-a583-c906fcde93ee.png)

## Why is it valuable?
This aims to communicate to AWS account holders that there has been a change in the status of the IAM users in their account and how they can remediate this if required. 

## What's next?
By the time this email is sent, the AWS account holder should have received three emails warning them about the impeding automatic disablement and telling them how to avoid this.  In the case that SHQ fails to disable the user, it's important that DevX take responsibility for remediating this vulnerable user as the AWS account holder has not taken any action. 

I've added TODOs in the code to trigger a cloudwatch alarmso that DevX can debug this and possible manually disable the user. 