### PR TITLE
Add basic dynamo tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ node_modules/
 notes
 
 .DS_Store
+
+# Directory to contain provided jars e.g. DynamoDB Local jar used in tests
+hq/test/jars

--- a/build.sbt
+++ b/build.sbt
@@ -75,8 +75,17 @@ lazy val hq = (project in file("hq"))
       (baseDirectory.value / "systemd" * "*" get)
         .map(f => f -> s"systemd/${f.getName}"),
     unmanagedResourceDirectories in Compile += baseDirectory.value / "markdown",
+    unmanagedSourceDirectories in Test += baseDirectory.value / "test" / "jars",
     parallelExecution in Test := false,
     fork in Test := false,
+    dynamoDBLocalDownloadDir := baseDirectory.value / "test" / "jars" / "dynamodb-local",
+    dynamoDBLocalDownloadUrl :=
+      Some(s"https://s3.eu-central-1.amazonaws.com/dynamodb-local-frankfurt/dynamodb_local_${dynamoDBLocalVersion.value}.tar.gz"),
+    startDynamoDBLocal in Test := startDynamoDBLocal.dependsOn(compile in Test).value,
+    test in Test := (test in Test).dependsOn(startDynamoDBLocal).value,
+    testOnly in Test := (testOnly in Test).dependsOn(startDynamoDBLocal).evaluated,
+    testQuick in Test := (testQuick in Test).dependsOn(startDynamoDBLocal).evaluated,
+    testOptions in Test += dynamoDBLocalTestCleanup.value,
     riffRaffPackageType := (packageBin in Debian).value,
     riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
     riffRaffUploadManifestBucket := Option("riffraff-builds"),

--- a/hq/app/schedule/Dynamo.scala
+++ b/hq/app/schedule/Dynamo.scala
@@ -20,14 +20,14 @@ trait AttributeValues {
 
 class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends AttributeValues with Logging {
 
-  val table = tableName match {
+  private val table = tableName match {
     case Some(tableName) => tableName
     case None =>
       logger.error("unable to retrieve Iam Dynamo Table Name from config - check that table name is present in security-hq.conf in S3")
       "error"
   }
 
-  def scan: Seq[Map[String, AttributeValue]] = {
+  private def scan: Seq[Map[String, AttributeValue]] = {
     try {
       client.scan(new ScanRequest().withTableName(table)).getItems.asScala.map(_.asScala.toMap)
     } catch {
@@ -56,7 +56,7 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
     }
   }
 
-  def get(key: Map[String, AttributeValue]): Option[Map[String, AttributeValue]] = {
+  private def get(key: Map[String, AttributeValue]): Option[Map[String, AttributeValue]] = {
     try {
       Option(client.getItem(
         new GetItemRequest().withTableName(table).withKey(key.asJava)).getItem).map(_.asScala.toMap)
@@ -89,7 +89,7 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
     }
   }
 
-  def put(item: Map[String, AttributeValue]): Unit = try {
+  private def put(item: Map[String, AttributeValue]): Unit = try {
     logger.info(s"putting item to dynamoDB table: $table")
     client.putItem(
       new PutItemRequest().withTableName(table).withItem(item.asJava))
@@ -98,7 +98,7 @@ class Dynamo(client: AmazonDynamoDB, tableName: Option[String]) extends Attribut
     logger.error(s"unable to put item to dynamoDB table: ${e.getMessage}", e)
   }
 
-  def alertToMap(e: IamAuditAlert): Map[String, AttributeValue] = {
+  private def alertToMap(e: IamAuditAlert): Map[String, AttributeValue] = {
     Map(
       "type" -> S(e.`type`.name),
       "date" -> N(e.dateNotificationSent.getMillis),

--- a/hq/test/schedule/DynamoTest.scala
+++ b/hq/test/schedule/DynamoTest.scala
@@ -1,0 +1,114 @@
+package schedule
+
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
+import com.amazonaws.services.dynamodbv2.model._
+import model._
+import org.joda.time.DateTime
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+import scala.collection.JavaConverters._
+
+
+class DynamoTest extends FreeSpec with BeforeAndAfterAll with Matchers with AttributeValues {
+
+  private val client = {
+    val conf = new EndpointConfiguration("http://localhost:8000", config.Config.region.name)
+    AmazonDynamoDBClientBuilder.standard
+      .withEndpointConfiguration(conf)
+      .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("dummy", "credentials")))
+      .build
+  }
+
+  private val tableName = "security-hq-iam-TEST"
+  private val tableAttributes = Seq((Symbol("id"), ScalarAttributeType.S))
+  private val keySchemaAttributes = tableAttributes
+  private val arbitraryThroughputThatIsIgnoredByDynamoDBLocal = new ProvisionedThroughput(1L, 1L)
+
+  override def beforeAll () {
+    def attributeDefinitions(attributes: Seq[(Symbol, ScalarAttributeType)]) = {
+      attributes.map{ case (symbol, attributeType) => new AttributeDefinition(symbol.name, attributeType)}.asJava
+    }
+
+    def keySchema(attributes: Seq[(Symbol, ScalarAttributeType)]) = {
+      val hashKeyWithType :: rangeKeyWithType = attributes.toList
+      val keySchemas = hashKeyWithType._1 -> KeyType.HASH :: rangeKeyWithType.map(_._1 -> KeyType.RANGE)
+      keySchemas.map{ case (symbol, keyType) => new KeySchemaElement(symbol.name, keyType)}.asJava
+    }
+
+    client.createTable(
+      attributeDefinitions(tableAttributes),
+      tableName,
+      keySchema(keySchemaAttributes),
+      arbitraryThroughputThatIsIgnoredByDynamoDBLocal
+    )
+  }
+
+  override def afterAll () {
+    client.deleteTable(tableName)
+  }
+
+  "Dynamo" - {
+    val dynamo = new Dynamo(client, Some(tableName))
+
+    "scan method" -  {
+      "can scan an empty table for alerts" in {
+        dynamo.scanAlert() shouldEqual Seq.empty
+      }
+
+      "can scan a non-empty table for alerts" in {
+        val iamAuditUser = IamAuditUser(
+          "accountid/username",
+          "accountid",
+          "username",
+          List(
+            IamAuditAlert(VulnerableCredential, DateTime.now(), DateTime.now())
+          )
+        )
+        dynamo.putAlert(iamAuditUser)
+
+        dynamo.scanAlert().size shouldBe 1
+        dynamo.scanAlert().headOption shouldBe Some(iamAuditUser)
+
+        // clean up
+        client.deleteItem(tableName, Map(("id", S(iamAuditUser.id))).asJava)
+      }
+    }
+
+    "put and get methods" - {
+      "can write and read multiple alerts" in {
+        val iamAuditUserVulnerable = IamAuditUser(
+          "accountid/username1",
+          "accountid",
+          "username1",
+          List(
+            IamAuditAlert(VulnerableCredential, DateTime.now(), DateTime.now())
+          )
+        )
+        dynamo.putAlert(iamAuditUserVulnerable)
+        dynamo.scanAlert().size shouldBe 1
+
+        val maybeAlertVulnerable = dynamo.getAlert(AwsAccount("accountid", "name", "arn", "number"), "username1")
+        maybeAlertVulnerable shouldBe Some(iamAuditUserVulnerable)
+
+        val iamAuditUserUnrecognised = IamAuditUser(
+          "accountid/username2",
+          "accountid",
+          "username2",
+          List(
+            IamAuditAlert(UnrecognisedHumanUser, DateTime.now(), DateTime.now())
+          )
+        )
+        dynamo.putAlert(iamAuditUserUnrecognised)
+
+        dynamo.scanAlert().size shouldBe 2
+
+        val maybeAlertUnrecognised = dynamo.getAlert(AwsAccount("accountid", "name", "arn", "number"), "username2")
+        maybeAlertUnrecognised shouldBe Some(iamAuditUserUnrecognised)
+      }
+    }
+  }
+
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,8 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.9")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
+addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.2")
+
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
 
 // The Play plugin


### PR DESCRIPTION
## What does this change?
Adds some basic Dynamo tests using the[ DynamoDB local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html) jar provided by Amazon.  This jar (or rather the plugin that downloads it) provides a convenient way to run tests against an in-memory instance of DynamoDB. Unfortunately, it works by downloading the jar when the tests are run (unless it already exists) rather than as a classic project dependency. The [plugin project](https://github.com/localytics/sbt-dynamodb) also seems to be archived but it's quite simple so we could fork or recreate it. Other projects at the Guardian also already depend on it. On balance I would be willing to take the convenience over these downsides.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
More confidence making changes to dynamo code (a little more)

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
I couldn't really find a direct alternative to the sbt plugin, but I suppose the options would be:
- Add the jar to VCS directly
- Don't test dynamo this way

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
