### PR TITLE
Documentation on managing IAM credentials & the Credentials Reaper

### DIFF
--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -22,24 +22,41 @@ which should always be addressed first. These are:
 
 ### 1. Security HQ
 The first step of your long journey to the fountain of security involves a visit to [Security HQ](https://security-hq.gutools.co.uk).
-Here, you can review Security Groups, IAM credentials and S3 buckets for your account, and check to see if there are any
+Here, you can review Security Groups, S3 buckets and IAM credentials for your account, and check to see if there are any
 problems. *Fix these first*.  
 
 Security HQ helpfully uses the colour RED to indicate stuff that we should be worried about. When it
 comes to S3 buckets, there may be a reason a bucket is publicly accessible, but there's a good chance that reason no longer
 applies.
 
+##### Security Groups
+
 For security groups, you may have open access to a group if it is the group for a load balancer to a public service. 
 Otherwise, there should be some restrictions in place. There's no reason to allow open access to any EC2 instances - they
 should ideally be locked down to the load balancer and nothing else. Port 22 access should be removed everywhere.  
 
-With IAM credentials, note that any permanent credentials should be regularly rotated. Infosec recommend rotating credentials every 
-90 days. For credentials in a trusted 3rd  party such  as Fastly or Github, annual rotation is sufficient. 
+##### S3 Buckets
 
 Security group and S3 bucket warnings in Security HQ are powered by AWS Trusted Advisor. If  there is a bucket you believe
 is correctly public or a security group that is correctly open you can exclude it from the trusted advisor report by going to
 the [dashboard](https://console.aws.amazon.com/trustedadvisor/home?region=eu-west-1#/category/security), waiting for everything to load
 then finding your bucket or group and clicking 'exclude'.
+
+##### Permanent IAM Credentials
+
+Permanent credentials allow access to AWS, either with a username, password and multi-factor authentication (MFA) or with an access key. They are created manually by AWS account admins. 
+
+Largely at the Guardian most of us use temporary AWS credentials which we get through Janus, but some AWS accounts may have permanent credentials for humans as an emergency option only for the eventuality that Janus-enabled access is not available (eg a Google auth outage). 
+We recommend that for most accounts 2 permanent credentials is sufficient to manage this case.
+
+Credentials without a password and with access keys only are typically for machine users and can be used for interacting with APIs. If possible, we do not recommend the use of permanent machine users. For most use cases an IAM role can be assumed by the system requiring access.
+
+In the case that Permanent IAM credentials are required, they must be rotated regularly; at least 90 days for human users (users with a password) and 365 days for machine users. Also, all human users must enable MFA.
+Ideally, users should not exist with both password and access key access.
+
+Security HQ will automatically disable active access keys and remove the passwords of permanent IAM credentials which do not meet these requirements. To avoid any unwanted disablements, please regularly check [Security HQ's IAM dashboard]((https://security-hq.gutools.co.uk/iam)) and rectify any warnings.
+Also, ensure that [Anghammarad's mapping](https://github.com/guardian/anghammarad#mappings) between your AWS account and the email address attached to it is correct. This means that you'll receive email notifications from Security HQ before it disables any vulnerable users in your account.
+
 
 ### 2. Operating system patches
 You should be regularly replacing your AMIs to get the latest security patches. At present, our advice here is to use 


### PR DESCRIPTION
This addition to the documentation explains the rules around managing permanent IAM credentials and explains what the Credentials Reaper does and how developers can avoid any unwanted disablements!
