### PR TITLE
Adds documentation on reaper test google group

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,3 +185,14 @@ It requires AWS credentials to run, and can validate a single file like so:
 If you have it installed, you can run:
 
 `cfn_nag_scan --input-path cloudformation/*`
+
+### Credentials Reaper
+The Credentials Reaper is a feature in Security HQ which automatically disables vulnerable permanent IAM users. 
+It considers a vulnerable user to be a user that has a password, but no mfa and/or access keys which haven’t been rotated within 90 days for users with a password (human users) or 365 days for users without a password (machine users). 
+It disables users in the following way: if there’s a password, it will be removed and if there are active access keys, they will be disabled.
+
+The reaper sends email notifications to the AWS account the user is in, before disabling a user. The emails are sent via Anghammarad and uses it's AWS Account to email address mappings.
+
+To quickly see the contents of Security HQ's DynamoDB table, which contains a record of users that have been flagged as vulnerable use the `/iam/get-notifications` route. 
+You can also find the dynamo table in the Security AWS Account. 
+To send test notifications based on the current contents of Security HQ's DynamoDB table, use `/iam/test-notifications`. This will send emails to this google group: https://groups.google.com/a/guardian.co.uk/g/anghammarad.test.alerts. 


### PR DESCRIPTION
I realised when pairing with colleagues yesterday that it wasn't easy to find the google group that the reaper's test emails are sent to. I've added this detail to the documentation now along with an introduction to the reaper. I imagine that this can be added to in the future to make it easier for new developers to understand the reaper feature.