### PR TITLE
Don't flag disabled keys in credentials reaper

### DIFF
--- a/hq/app/logic/VulnerableAccessKeys.scala
+++ b/hq/app/logic/VulnerableAccessKeys.scala
@@ -4,9 +4,25 @@ import config.Config.{iamHumanUserRotationCadence, iamMachineUserRotationCadence
 import model.{AccessKey, AccessKeyEnabled, VulnerableAccessKey}
 
 object VulnerableAccessKeys {
-  def hasOutdatedHumanKey(keys: List[AccessKey]): Boolean = keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamHumanUserRotationCadence)
 
-  def hasOutdatedMachineKey(keys: List[AccessKey]): Boolean = keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamMachineUserRotationCadence)
+  def hasOutdatedHumanKey(keys: List[AccessKey]): Boolean =
+    keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamHumanUserRotationCadence
+      && key.keyStatus == AccessKeyEnabled)
+
+  def hasOutdatedMachineKey(keys: List[AccessKey]): Boolean =
+    keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamMachineUserRotationCadence
+      && key.keyStatus == AccessKeyEnabled)
+
+
+  /*
+    * These two methods are used only for the IAM dashboard (credentials report display). It is intended to be
+    * temporary, because eventually the logic for dashboard and scheduled job (IamJob) should be the same
+  */
+  def hasOutdatedHumanKeyIncludingDisabled(keys: List[AccessKey]): Boolean =
+    keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamHumanUserRotationCadence)
+
+  def hasOutdatedMachineKeyIncludedDisabled(keys: List[AccessKey]): Boolean =
+    keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamMachineUserRotationCadence)
 
   def isOutdated(user: VulnerableAccessKey): Boolean = {
     if (user.humanUser) user.accessKeyWithId.accessKey.keyStatus == AccessKeyEnabled &&

--- a/hq/test/schedule/IamNotificationsTest.scala
+++ b/hq/test/schedule/IamNotificationsTest.scala
@@ -81,10 +81,11 @@ class IamNotificationsTest extends FreeSpec with Matchers {
           new DateTime(2021, 1, 1, 1, 1),
           Seq(
             MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-            MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
+            // We've only temporarily commented out these cases as the logic ought to be reverted to align the dashboard and scheduled job
+            // MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
           ),
           Seq(
-            HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
+            // HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
             HumanUser("", true, oldHumanAccessKeyEnabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
           )
         )
@@ -101,7 +102,26 @@ class IamNotificationsTest extends FreeSpec with Matchers {
         )
       )
       val result: CredentialReportDisplay = CredentialReportDisplay(
+        reportDate = new DateTime(2021, 1, 1, 1, 1),
+        machineUsers = Seq.empty,
+        humanUsers = Seq.empty
+      )
+      findOldAccessKeys(credsReport) shouldEqual result
+    }
+    "returns empty human user and machine user lists when there are no active access keys (even if older than 90/365 days)" in {
+      val credsReport: CredentialReportDisplay = CredentialReportDisplay(
         new DateTime(2021, 1, 1, 1, 1),
+        Seq(
+          MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(18))), AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
+        ),
+        Seq(
+          HumanUser("", true, AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(6))), AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
+        )
+      )
+      val result: CredentialReportDisplay = CredentialReportDisplay(
+        reportDate = new DateTime(2021, 1, 1, 1, 1),
+        machineUsers = Seq.empty,
+        humanUsers = Seq.empty
       )
       findOldAccessKeys(credsReport) shouldEqual result
     }


### PR DESCRIPTION
## What does this change?
This is a slight adjustment to the logic for determining flagged IAM users in the credentials reaper job. At the moment, even disabled keys will be flagged, but because the action on those keys is only to disable them, we would end up with circular logic until we actually implement key _deletion_.  We've decided to focus on the rollout of the reaper over deletion for now, so this change allows us to move ahead with a working system.

For now, we've duplicated some of the `isOutdated*` logic because we want to continue to flag in the UI that disabled keys should be removed.


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Decouples the rollout of the reaper from implementing key deletion. We'd like to have confidence running the current version in production before adding deletion.


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
Paired on with @Nirvikalpa108 and @jorgeazevedo, thanks!

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
