### PR TITLE
Failure case for disable access key request 

### DIFF
--- a/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
@@ -8,10 +8,11 @@ import com.amazonaws.services.identitymanagement.model.{UpdateAccessKeyRequest, 
 import logic.VulnerableAccessKeys.isOutdated
 import model.{AccessKeyWithId, AwsAccount, VulnerableAccessKey, VulnerableUser}
 import play.api.Logging
-import IamListAccessKeys.listAccountAccessKeys
+import schedule.vulnerable.IamListAccessKeys.listAccountAccessKeys
 import utils.attempt.Attempt
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 object IamDisableAccessKeys extends Logging {
 
@@ -35,7 +36,6 @@ object IamDisableAccessKeys extends Logging {
         } yield {
           val updateAccessKeyRequestId = updateAccessKeyResult.getSdkResponseMetadata.getRequestId
           logger.info(s"disabled access key for ${user.username} with access key id ${key.id} and request id: $updateAccessKeyRequestId.")
-          // TODO create failure case and trigger cloudwatch alarm
         }
       }
     )
@@ -47,6 +47,14 @@ object IamDisableAccessKeys extends Logging {
         .withUserName(username)
         .withAccessKeyId(key.id)
         .withStatus("Inactive")
-      handleAWSErrs(client)(awsToScala(client)(_.updateAccessKeyAsync)(request))
-    }
+      val eventualResult: Future[UpdateAccessKeyResult] = awsToScala(client)(_.updateAccessKeyAsync)(request)
+      eventualResult.onComplete {
+        case Failure(exception) =>
+          logger.warn(s"failed to disable access key id ${key.id} for user $username.", exception)
+        // TODO trigger cloudwatch alarm for failure case
+        case Success(result) =>
+          logger.info(s"successfully disabled access key id ${key.id} for user $username. Response: ${result.toString}.")
+      }
+    handleAWSErrs(client)(eventualResult)
+  }
 }


### PR DESCRIPTION
This PR adds a failure case to the disable access key request so that a cloudwatch alarm can be triggered. 

This is valuable, because in the case that SHQ is unable to disable a vulnerable access key, the DevX team will be notified and they can take appropriate to action to understand what caused the failure, fix it or get in touch with the AWS account owner to disable the access key manually if required.