### PR TITLE
Update references to outdated methods for the dashboard

### DIFF
--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -36,7 +36,7 @@ object CredentialsReportDisplay {
 
   private[logic] def machineReportStatus(cred: IAMCredential): ReportStatus = {
     val keys = List(accessKey1Details(cred), accessKey2Details(cred))
-    if (VulnerableAccessKeys.hasOutdatedMachineKeyIncludedDisabled(keys))
+    if (VulnerableAccessKeys.hasOutdatedMachineKeyIncludingDisabled(keys))
       Red(Seq(OutdatedKey))
     else if (!keys.exists(_.keyStatus == AccessKeyEnabled))
       Amber

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -36,7 +36,7 @@ object CredentialsReportDisplay {
 
   private[logic] def machineReportStatus(cred: IAMCredential): ReportStatus = {
     val keys = List(accessKey1Details(cred), accessKey2Details(cred))
-    if (VulnerableAccessKeys.hasOutdatedMachineKey(keys))
+    if (VulnerableAccessKeys.hasOutdatedMachineKeyIncludedDisabled(keys))
       Red(Seq(OutdatedKey))
     else if (!keys.exists(_.keyStatus == AccessKeyEnabled))
       Amber
@@ -50,7 +50,7 @@ object CredentialsReportDisplay {
     //TODO: Scala 2.13 has Option builder `when` which is a nicer syntax than Some(...).filter
     val redStatusReasons: Seq[ReportStatusReason] = Seq(
       Some(MissingMfa).filterNot(_ => cred.mfaActive),
-      Some(OutdatedKey).filter(_ => VulnerableAccessKeys.hasOutdatedHumanKey(keys))
+      Some(OutdatedKey).filter(_ => VulnerableAccessKeys.hasOutdatedHumanKeyIncludingDisabled(keys))
     ).flatten
 
     if (redStatusReasons.nonEmpty)

--- a/hq/app/logic/VulnerableAccessKeys.scala
+++ b/hq/app/logic/VulnerableAccessKeys.scala
@@ -21,7 +21,7 @@ object VulnerableAccessKeys {
   def hasOutdatedHumanKeyIncludingDisabled(keys: List[AccessKey]): Boolean =
     keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamHumanUserRotationCadence)
 
-  def hasOutdatedMachineKeyIncludedDisabled(keys: List[AccessKey]): Boolean =
+  def hasOutdatedMachineKeyIncludingDisabled(keys: List[AccessKey]): Boolean =
     keys.exists(key => DateUtils.dayDiff(key.lastRotated).getOrElse(1L) > iamMachineUserRotationCadence)
 
   def isOutdated(user: VulnerableAccessKey): Boolean = {


### PR DESCRIPTION
## What does this change?
Noticed that #299 missed a step to start using the newly duplicated methods for checking outdated status of keys. This fixes the dashboard to use the _old_ logic - that is to consider disabled keys as vulnerable.