### PR TITLE
Add cloudwatch metrics and alerts to Creds Reaper

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -396,10 +396,10 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
       AlarmName: !Sub Security HQ failed to remove a vulnerable password
       AlarmDescription: !Sub The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be
-      MetricName: IamRemovePasswordExecution
+      MetricName: IamRemovePassword
       Namespace: SecurityHQ
       Dimensions:
-        - Name: Status
+        - Name: ReaperExecutionStatus
           Value: Failure
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
@@ -415,10 +415,10 @@ Resources:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
       AlarmName: !Sub Security HQ failed to disable a vulnerable access key
       AlarmDescription: !Sub The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be
-      MetricName: IamDisableAccessKeyExecution
+      MetricName: IamDisableAccessKey
       Namespace: SecurityHQ
       Dimensions:
-        - Name: Status
+        - Name: ReaperExecutionStatus
           Value: Failure
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -54,6 +54,9 @@ Parameters:
   TopicARN:
     Type: String
     Description: ARN for Anghammarad's SNS topic
+  SNSTopicForAlerts:
+    Type: String
+    Description: The name of the SNS topic used for alerting in the case of a failed credential reaper run
 
 Mappings:
   Constants:
@@ -385,6 +388,44 @@ Resources:
         Value:
           Fn::FindInMap: [ Constants, App, Value ]
         PropagateAtLaunch: true
+
+  RemovePasswordExecutionFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
+      AlarmName: !Sub Security HQ failed to remove a vulnerable password
+      AlarmDescription: !Sub The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be
+      MetricName: IamRemovePasswordExecution
+      Namespace: SecurityHQ
+      Dimensions:
+        - Name: Status
+          Value: Failure
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Sum
+      TreatMissingData: notBreaching
+
+  DisableAccessKeyExecutionFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
+      AlarmName: !Sub Security HQ failed to disable a vulnerable access key
+      AlarmDescription: !Sub The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be
+      MetricName: IamDisableAccessKeyExecution
+      Namespace: SecurityHQ
+      Dimensions:
+        - Name: Status
+          Value: Failure
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Sum
+      TreatMissingData: notBreaching
 
   SecurityHqIamDynamoTable:
     Type: AWS::DynamoDB::Table

--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -54,9 +54,9 @@ Parameters:
   TopicARN:
     Type: String
     Description: ARN for Anghammarad's SNS topic
-  SNSTopicForAlerts:
+  CloudwatchAlarmEmailDestination:
     Type: String
-    Description: The name of the SNS topic used for alerting in the case of a failed credential reaper run
+    Description: Send Security HQ cloudwatch alarms to this email address
 
 Mappings:
   Constants:
@@ -393,7 +393,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
+        - !Ref NotificationTopic
       AlarmName: !Sub Security HQ failed to remove a vulnerable password
       AlarmDescription: !Sub The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be
       MetricName: IamRemovePassword
@@ -412,7 +412,7 @@ Resources:
     Type: AWS::CloudWatch::Alarm
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:${SNSTopicForAlerts}
+        - !Ref NotificationTopic
       AlarmName: !Sub Security HQ failed to disable a vulnerable access key
       AlarmDescription: !Sub The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be
       MetricName: IamDisableAccessKey
@@ -426,6 +426,15 @@ Resources:
       EvaluationPeriods: 1
       Statistic: Sum
       TreatMissingData: notBreaching
+
+  NotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: Security HQ notifications
+      Subscription:
+        - Endpoint:
+            !Ref CloudwatchAlarmEmailDestination
+          Protocol: EMAIL
 
   SecurityHqIamDynamoTable:
     Type: AWS::DynamoDB::Table

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -69,12 +69,20 @@ object Cloudwatch extends Logging {
     putMetric("SecurityHQ", "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
   }
 
-  def putIamRemovePasswordMetric(value: Int): Unit = {
-    putMetric("SecurityHQ", "IamRemovePasswordExecutionReturnCode", Seq(), value)
+  def putIamRemovePasswordSuccessMetric(): Unit = {
+    putMetric("SecurityHQ", "IamRemovePasswordExecution", Seq(("Status", "Success")), 1)
   }
 
-  def putIamDisableAccessKeyMetric(value: Int): Unit = {
-    putMetric("SecurityHQ", "IamDisableAccessKeyExecutionReturnCode", Seq(), value)
+  def putIamRemovePasswordFailureMetric(): Unit = {
+    putMetric("SecurityHQ", "IamRemovePasswordExecution", Seq(("Status", "Failure")), 1)
+  }
+
+  def putIamDisableAccessKeySuccessMetric(): Unit = {
+    putMetric("SecurityHQ", "IamDisableAccessKeyExecution", Seq(("Status", "Success")), 1)
+  }
+
+  def putIamDisableAccessKeyFailureMetric(): Unit = {
+    putMetric("SecurityHQ", "IamDisableAccessKeyExecution", Seq(("Status", "Failure")), 1)
   }
 
   private def putMetric(namespace: String, metricName: String, metricDimensions: Seq[(String, String)] , value: Int): Unit = {

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -69,6 +69,10 @@ object Cloudwatch extends Logging {
     putMetric("SecurityHQ", "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
   }
 
+  def putIamRemovePasswordMetric(value: Int): Unit = {
+    putMetric("SecurityHQ", "IamDisableAccessKeyExecutionReturnCode", Seq(), value)
+  }
+
   private def putMetric(namespace: String, metricName: String, metricDimensions: Seq[(String, String)] , value: Int): Unit = {
     val dimension = metricDimensions.map( d => (new Dimension).withName(d._1).withValue(d._2)).toList
     val datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -70,7 +70,7 @@ object Cloudwatch extends Logging {
   }
 
   def putIamRemovePasswordMetric(value: Int): Unit = {
-    putMetric("SecurityHQ", "IamDisableAccessKeyExecutionReturnCode", Seq(), value)
+    putMetric("SecurityHQ", "IamRemovePasswordExecutionReturnCode", Seq(), value)
   }
 
   def putIamDisableAccessKeyMetric(value: Int): Unit = {

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -73,6 +73,10 @@ object Cloudwatch extends Logging {
     putMetric("SecurityHQ", "IamDisableAccessKeyExecutionReturnCode", Seq(), value)
   }
 
+  def putIamDisableAccessKeyMetric(value: Int): Unit = {
+    putMetric("SecurityHQ", "IamDisableAccessKeyExecutionReturnCode", Seq(), value)
+  }
+
   private def putMetric(namespace: String, metricName: String, metricDimensions: Seq[(String, String)] , value: Int): Unit = {
     val dimension = metricDimensions.map( d => (new Dimension).withName(d._1).withValue(d._2)).toList
     val datum = new MetricDatum().withMetricName(metricName).withUnit(StandardUnit.Count).withValue(value.toDouble).withDimensions(dimension.asJava)

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -17,6 +17,8 @@ object Cloudwatch extends Logging {
 
   val cloudwatchClient = AmazonCloudWatchClientBuilder.defaultClient
 
+  val defaultNamespace = "SecurityHQ"
+
   object DataType extends Enumeration {
     val s3Total = Value("s3/total")
     val iamCredentialsTotal = Value("iam/credentials/total")
@@ -27,6 +29,11 @@ object Cloudwatch extends Logging {
     val gcpTotal = Value("gcp/total")
     val gcpCritical = Value("gcp/critical")
     val gcpHigh = Value("gcp/high")
+  }
+
+  object ReaperExecutionStatus extends Enumeration {
+    val success = Value("Success")
+    val failure = Value("Failure")
   }
 
   def logMetricsForGCPReport(gcpReport: GcpReport): Unit = {
@@ -62,27 +69,19 @@ object Cloudwatch extends Logging {
   }
 
   def putAwsMetric(account: AwsAccount, dataType: DataType.Value , value: Int): Unit = {
-    putMetric("SecurityHQ", "Vulnerabilities", Seq(("Account", account.name),("DataType", dataType.toString)), value)
+    putMetric(defaultNamespace, "Vulnerabilities", Seq(("Account", account.name),("DataType", dataType.toString)), value)
   }
 
   def putGcpMetric(project: String, dataType: DataType.Value , value: Int): Unit = {
-    putMetric("SecurityHQ", "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
+    putMetric(defaultNamespace, "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
   }
 
-  def putIamRemovePasswordSuccessMetric(): Unit = {
-    putMetric("SecurityHQ", "IamRemovePasswordExecution", Seq(("Status", "Success")), 1)
+  def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value): Unit = {
+    putMetric(defaultNamespace, "IamRemovePassword", Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)), 1)
   }
 
-  def putIamRemovePasswordFailureMetric(): Unit = {
-    putMetric("SecurityHQ", "IamRemovePasswordExecution", Seq(("Status", "Failure")), 1)
-  }
-
-  def putIamDisableAccessKeySuccessMetric(): Unit = {
-    putMetric("SecurityHQ", "IamDisableAccessKeyExecution", Seq(("Status", "Success")), 1)
-  }
-
-  def putIamDisableAccessKeyFailureMetric(): Unit = {
-    putMetric("SecurityHQ", "IamDisableAccessKeyExecution", Seq(("Status", "Failure")), 1)
+  def putIamDisableAccessKeyMetric(reaperExecutionStatus: ReaperExecutionStatus.Value): Unit = {
+    putMetric(defaultNamespace, "IamDisableAccessKey", Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)), 1)
   }
 
   private def putMetric(namespace: String, metricName: String, metricDimensions: Seq[(String, String)] , value: Int): Unit = {

--- a/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
@@ -6,6 +6,7 @@ import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{UpdateAccessKeyRequest, UpdateAccessKeyResult}
 import logging.Cloudwatch
+import logging.Cloudwatch.ReaperExecutionStatus
 import logic.VulnerableAccessKeys.isOutdated
 import model.{AccessKeyWithId, AwsAccount, VulnerableAccessKey, VulnerableUser}
 import play.api.Logging
@@ -52,10 +53,10 @@ object IamDisableAccessKeys extends Logging {
       eventualResult.onComplete {
         case Failure(exception) =>
           logger.warn(s"failed to disable access key id ${key.id} for user $username.", exception)
-          Cloudwatch.putIamDisableAccessKeyFailureMetric()
+          Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
         case Success(result) =>
           logger.info(s"successfully disabled access key id ${key.id} for user $username. Response: ${result.toString}.")
-          Cloudwatch.putIamDisableAccessKeySuccessMetric()
+          Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success)
       }
     handleAWSErrs(client)(eventualResult)
   }

--- a/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
@@ -52,10 +52,10 @@ object IamDisableAccessKeys extends Logging {
       eventualResult.onComplete {
         case Failure(exception) =>
           logger.warn(s"failed to disable access key id ${key.id} for user $username.", exception)
-          Cloudwatch.putIamDisableAccessKeyMetric(1)
+          Cloudwatch.putIamDisableAccessKeyFailureMetric()
         case Success(result) =>
           logger.info(s"successfully disabled access key id ${key.id} for user $username. Response: ${result.toString}.")
-          Cloudwatch.putIamDisableAccessKeyMetric(0)
+          Cloudwatch.putIamDisableAccessKeySuccessMetric()
       }
     handleAWSErrs(client)(eventualResult)
   }

--- a/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
+++ b/hq/app/schedule/vulnerable/IamDisableAccessKeys.scala
@@ -5,6 +5,7 @@ import aws.iam.IAMClient.SOLE_REGION
 import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.{UpdateAccessKeyRequest, UpdateAccessKeyResult}
+import logging.Cloudwatch
 import logic.VulnerableAccessKeys.isOutdated
 import model.{AccessKeyWithId, AwsAccount, VulnerableAccessKey, VulnerableUser}
 import play.api.Logging
@@ -51,9 +52,10 @@ object IamDisableAccessKeys extends Logging {
       eventualResult.onComplete {
         case Failure(exception) =>
           logger.warn(s"failed to disable access key id ${key.id} for user $username.", exception)
-        // TODO trigger cloudwatch alarm for failure case
+          Cloudwatch.putIamDisableAccessKeyMetric(1)
         case Success(result) =>
           logger.info(s"successfully disabled access key id ${key.id} for user $username. Response: ${result.toString}.")
+          Cloudwatch.putIamDisableAccessKeyMetric(0)
       }
     handleAWSErrs(client)(eventualResult)
   }

--- a/hq/app/schedule/vulnerable/IamRemovePassword.scala
+++ b/hq/app/schedule/vulnerable/IamRemovePassword.scala
@@ -6,6 +6,7 @@ import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.DeleteLoginProfileRequest
 import logging.Cloudwatch
+import logging.Cloudwatch.{DataType, ReaperExecutionStatus}
 import model.{AwsAccount, VulnerableUser}
 import play.api.Logging
 
@@ -34,10 +35,10 @@ object IamRemovePassword extends Logging {
     awsToScala(client)(_.deleteLoginProfileAsync)(request).onComplete {
       case Failure(exception) =>
         logger.warn(s"failed to delete password for username: ${user.username}.", exception)
-        Cloudwatch.putIamRemovePasswordFailureMetric()
+        Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure)
       case Success(result) =>
         logger.info(s"successfully deleted password for username: ${user.username}. DeleteLoginProfile Response: ${result.toString}.")
-        Cloudwatch.putIamRemovePasswordSuccessMetric()
+        Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success)
     }
   }
 }

--- a/hq/app/schedule/vulnerable/IamRemovePassword.scala
+++ b/hq/app/schedule/vulnerable/IamRemovePassword.scala
@@ -35,7 +35,6 @@ object IamRemovePassword extends Logging {
       case Failure(exception) =>
         logger.warn(s"failed to delete password for username: ${user.username}.", exception)
         Cloudwatch.putIamRemovePasswordMetric(1)
-        // TODO trigger cloudwatch alarm for failure case
       case Success(result) =>
         logger.info(s"successfully deleted password for username: ${user.username}. DeleteLoginProfile Response: ${result.toString}.")
         Cloudwatch.putIamRemovePasswordMetric(0)

--- a/hq/app/schedule/vulnerable/IamRemovePassword.scala
+++ b/hq/app/schedule/vulnerable/IamRemovePassword.scala
@@ -5,6 +5,7 @@ import aws.iam.IAMClient.SOLE_REGION
 import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.DeleteLoginProfileRequest
+import logging.Cloudwatch
 import model.{AwsAccount, VulnerableUser}
 import play.api.Logging
 
@@ -33,9 +34,11 @@ object IamRemovePassword extends Logging {
     awsToScala(client)(_.deleteLoginProfileAsync)(request).onComplete {
       case Failure(exception) =>
         logger.warn(s"failed to delete password for username: ${user.username}.", exception)
+        Cloudwatch.putIamRemovePasswordMetric(1)
         // TODO trigger cloudwatch alarm for failure case
       case Success(result) =>
         logger.info(s"successfully deleted password for username: ${user.username}. DeleteLoginProfile Response: ${result.toString}.")
+        Cloudwatch.putIamRemovePasswordMetric(0)
     }
   }
 }

--- a/hq/app/schedule/vulnerable/IamRemovePassword.scala
+++ b/hq/app/schedule/vulnerable/IamRemovePassword.scala
@@ -34,10 +34,10 @@ object IamRemovePassword extends Logging {
     awsToScala(client)(_.deleteLoginProfileAsync)(request).onComplete {
       case Failure(exception) =>
         logger.warn(s"failed to delete password for username: ${user.username}.", exception)
-        Cloudwatch.putIamRemovePasswordMetric(1)
+        Cloudwatch.putIamRemovePasswordFailureMetric()
       case Success(result) =>
         logger.info(s"successfully deleted password for username: ${user.username}. DeleteLoginProfile Response: ${result.toString}.")
-        Cloudwatch.putIamRemovePasswordMetric(0)
+        Cloudwatch.putIamRemovePasswordSuccessMetric()
     }
   }
 }

--- a/hq/app/schedule/vulnerable/IamRemovePassword.scala
+++ b/hq/app/schedule/vulnerable/IamRemovePassword.scala
@@ -6,7 +6,7 @@ import aws.{AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.identitymanagement.model.DeleteLoginProfileRequest
 import logging.Cloudwatch
-import logging.Cloudwatch.{DataType, ReaperExecutionStatus}
+import logging.Cloudwatch.ReaperExecutionStatus
 import model.{AwsAccount, VulnerableUser}
 import play.api.Logging
 


### PR DESCRIPTION
## What does this change?

This adds two cloudwatch metrics to track the operation of creds reaper. One tracks removal of passwords, the other disabling of keys. It uses a Dimension to track if the operation was successful or not

![CloudWatch_Management_Console](https://user-images.githubusercontent.com/1672034/133099264-5f405373-d1b7-4619-ab62-762fa0a9ee24.png)

It also adds two cloudwatch alarms to email us when a failure happens. One for each type.

![Inbox__15__-_jorge_azevedo_guardian_co_uk_-_guardian_co_uk_Mail](https://user-images.githubusercontent.com/1672034/132888617-504d15d6-fa49-4426-88c5-f868a20385e1.png)

The alarm description contains a short URL to security hq's logs, which should contain the messages logged just before the `putMetric` methods are called.
https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be

![ALARM___Security_HQ_failed_to_remove_a_vulnerable_password__in_EU__Ireland__-_jorge_azevedo_guardian_co_uk_-_guardian_co_uk_Mail](https://user-images.githubusercontent.com/1672034/132888907-0c06b963-5ea6-4334-bdc6-65f579939b49.png)


## What is the value of this?

Helps us track the execution of creds reaper and be alerted when it fails.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes! This requires an SNS topic passed as a parameter. I was hoping we had one already in the security account, but I think we'll have to create one.

## Any additional notes?

Question: are SNS topics cloudformed? Are they just done in the UI?