### PR TITLE
Turn on the Credentials Reaper for beta testers

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -149,7 +149,7 @@ class AppComponents(context: Context)
   val quartzScheduler = StdSchedulerFactory.getDefaultScheduler
   val iamJob = new IamVulnerableUserJob(enabled = true, cacheService, securitySnsClient, dynamo, configuration, iamClients)(executionContext)
   val jobScheduler = new JobScheduler(quartzScheduler, List(iamJob))
-  //jobScheduler.initialise() TODO: uncomment when ready to release creds reaper feature in PROD
+  jobScheduler.initialise()
 
   override def router: Router = new Routes(
     httpErrorHandler,

--- a/hq/app/schedule/CronSchedules.scala
+++ b/hq/app/schedule/CronSchedules.scala
@@ -4,8 +4,5 @@ import model.CronSchedule
 
 //a helpful quartz cron generator: https://www.freeformatter.com/cron-expression-generator-quartz.html
 object CronSchedules {
-  val everyWeekDay = CronSchedule("0 0 9 ? * MON-FRI *", "At 9am, every week day")
-  val firstMondayOfEveryMonth = CronSchedule("0 0 8 ? * 2#1", "At 8am, on the 1st Monday of the month, every month")
-  val secondMondayOfEveryMonth = CronSchedule("0 0 8 ? * 2#2", "At 8am, on the 1st Monday of the month, every month")
-  val everyThursday = CronSchedule("0 0 9 ? * THU", "At 8am, on the 1st Monday of the month, every month")
+  val everyWeekDay = CronSchedule("0 0 14 ? * MON-FRI *", "At 2pm, every week day")
 }

--- a/hq/app/schedule/Notifier.scala
+++ b/hq/app/schedule/Notifier.scala
@@ -28,7 +28,8 @@ object Notifier extends Logging {
       topicArn match {
       case Some(arn) =>
         val anghammaradNotification = {
-          if (testMode) notification.copy(target = List(Stack("testing-alerts"))) else notification
+          if (testMode) notification.copy(target = List(Stack("testing-alerts")))
+          else notification.copy(target = notification.target :+ Stack("testing-alerts"))
         }
         val response: Future[String] = Anghammarad.notify(anghammaradNotification, arn, snsClient)
         response.transformWith {

--- a/hq/app/schedule/vulnerable/IamVulnerableUserJob.scala
+++ b/hq/app/schedule/vulnerable/IamVulnerableUserJob.scala
@@ -36,7 +36,9 @@ class IamVulnerableUserJob(enabled: Boolean, cacheService: CacheService, snsClie
 
     val credsReport: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] = cacheService.getAllCredentials
     logger.info(s"successfully collected credentials report for $id. Report is empty: ${credsReport.isEmpty}.")
+    val betaTestAccounts = List("frontend", "mobile", "deploy-tools")
     val flaggedCredentials = IamFlaggedUsers.getVulnerableUsers(credsReport)
+      .filterKeys(account => betaTestAccounts.contains(account.name)) //TODO remove after beta-testing
 
     def sendNotificationAndRecord(notification: Notification, users: Seq[IamAuditUser]): Unit = {
       for {


### PR DESCRIPTION
This PR turns on the Credentials Reaper job for beta tester AWS accounts; frontend, mobile and deploy tools. This will be the first time that the reaper is in production with its ability to disable active access keys and remove passwords, so we're just testing it with a few accounts so as not to wreak havoc across the department!