### PR TITLE
Create new scheduled job for unrecognised staff

### DIFF
--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -1,0 +1,19 @@
+package schedule.unrecognised
+
+import model.CronSchedule
+import play.api.Logging
+import schedule.{CronSchedules, JobRunner}
+
+class IamUnrecognisedUserJob() extends JobRunner with Logging {
+  override val id: String = "unrecognised-iam-users"
+  override val description: String = "Check for and remove unrecognised human IAM users"
+  override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
+
+  def run(testMode: Boolean): Unit = {
+    if (testMode) {
+      logger.info(s"Skipping scheduled $id job as it is not enabled")
+    } else {
+      logger.info(s"Running scheduled job: $description")
+    }
+  }
+}

--- a/hq/app/schedule/vulnerable/IamVulnerableUserJob.scala
+++ b/hq/app/schedule/vulnerable/IamVulnerableUserJob.scala
@@ -20,15 +20,15 @@ import utils.attempt.FailedAttempt
 
 import scala.concurrent.ExecutionContext
 
-class IamVulnerableUserJob(enabled: Boolean, cacheService: CacheService, snsClient: AmazonSNSAsync, dynamo: Dynamo, config: Configuration, iamClients: AwsClients[AmazonIdentityManagementAsync])(implicit val executionContext: ExecutionContext) extends JobRunner with Logging {
-  override val id = "credentials report job"
+class IamVulnerableUserJob(cacheService: CacheService, snsClient: AmazonSNSAsync, dynamo: Dynamo, config: Configuration, iamClients: AwsClients[AmazonIdentityManagementAsync])(implicit val executionContext: ExecutionContext) extends JobRunner with Logging {
+  override val id = "vulnerable-iam-users"
   override val description = "Automated notifications and disablement of vulnerable permanent credentials"
   override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
   val topicArn: Option[String] = getAnghammaradSNSTopicArn(config)
 
 
   def run(testMode: Boolean): Unit = {
-    if (!enabled) {
+    if (testMode) {
       logger.info(s"Skipping scheduled $id job as it is not enabled")
     } else {
       logger.info(s"Running scheduled job: $description")


### PR DESCRIPTION
This PR creates a new quartz scheduler job which intends to remove permanent credentials of Guardian staff members who have left the organisation.