### PR TITLE
Create a dummy Janus user

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ lazy val hq = (project in file("hq"))
       // `com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0`
       "net.logstash.logback" % "logstash-logback-encoder" % "6.4" exclude("com.fasterxml.jackson.core", "jackson-databind"),
       "com.gu" % "kinesis-logback-appender" % "1.4.4",
+      "com.gu" %% "janus-config-tools" % "0.0.4",
     ),
     pipelineStages in Assets := Seq(digest),
     // exclude docs

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -1,6 +1,8 @@
 package schedule.unrecognised
 
+import com.gu.janus.model.{ACL, AwsAccount, JanusData, SupportACL}
 import model.CronSchedule
+import org.joda.time.Seconds
 import play.api.Logging
 import schedule.{CronSchedules, JobRunner}
 
@@ -16,4 +18,16 @@ class IamUnrecognisedUserJob() extends JobRunner with Logging {
       logger.info(s"Running scheduled job: $description")
     }
   }
+
+  val dummyJanusData = JanusData(
+    Set(AwsAccount("Deploy Tools", "deployTools")),
+    ACL(Map("firstName.secondName" -> Set.empty)),
+    ACL(Map.empty),
+    SupportACL(Map.empty, Set.empty, Seconds.ZERO),
+    None
+  )
+
+  //TODO
+  // grab all IAM users
+  //compare tags on IAM users to the list
 }


### PR DESCRIPTION
This PR creates a dummy Janus user using Janus's config library for 2 reasons.

First, so that the unrecognised former staff feature can use the library's built in methods for parsing a file as this feature intends to read a file from S3 which holds all of the users in Janus. The intention for this is to ensure that no IAM permanent credentials are assigned to anyone who is NOT included in Janus.

Second, the dummy user is being created so that we can concentrate on writing the main functionality of the feature comparing the Janus user name to names in IAM tags) and write the S3 file reading afterwards.
