### PR TITLE
Find IAM users who are not Janus users

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -149,7 +149,7 @@ class AppComponents(context: Context)
   //initialise job to alert on and remove vulnerable IAM users
   val vulnerableUserJob = new IamVulnerableUserJob(cacheService, securitySnsClient, dynamo, configuration, iamClients)(executionContext)
   //initialise job to check for and remove unrecognised human IAM users
-  val unrecognisedUserJob = new IamUnrecognisedUserJob() //TODO set enable to true when ready to start job
+  val unrecognisedUserJob = new IamUnrecognisedUserJob(cacheService) //TODO set enable to true when ready to start job
 
   val quartzScheduler = StdSchedulerFactory.getDefaultScheduler
   val jobScheduler = new JobScheduler(quartzScheduler, List(vulnerableUserJob, unrecognisedUserJob))

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -1,12 +1,15 @@
 package schedule.unrecognised
 
 import com.gu.janus.model.{ACL, AwsAccount, JanusData, SupportACL}
-import model.CronSchedule
+import model.{CredentialReportDisplay, CronSchedule, HumanUser, AwsAccount => Account}
 import org.joda.time.Seconds
 import play.api.Logging
+import schedule.unrecognised.IamUnrecognisedUsers.{filterUnrecognisedIamUsers, getHumanUsers, getJanusUsernames}
 import schedule.{CronSchedules, JobRunner}
+import services.CacheService
+import utils.attempt.FailedAttempt
 
-class IamUnrecognisedUserJob() extends JobRunner with Logging {
+class IamUnrecognisedUserJob(cacheService: CacheService) extends JobRunner with Logging {
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
@@ -19,15 +22,12 @@ class IamUnrecognisedUserJob() extends JobRunner with Logging {
     }
   }
 
-  val dummyJanusData = JanusData(
-    Set(AwsAccount("Deploy Tools", "deployTools")),
-    ACL(Map("firstName.secondName" -> Set.empty)),
-    ACL(Map.empty),
-    SupportACL(Map.empty, Set.empty, Seconds.ZERO),
-    None
-  )
+  val dummyJanusData: JanusData = ???
+  val janusUsers: List[String] = getJanusUsernames(dummyJanusData)
+  val credsReport = cacheService.getAllCredentials
+  val iamHumanUsers: List[HumanUser] = getHumanUsers(credsReport)
+  val unrecognisedIamUsers: List[HumanUser] = filterUnrecognisedIamUsers(iamHumanUsers, "name", janusUsers)
 
-  //TODO
-  // grab all IAM users
-  //compare tags on IAM users to the list
+  //TODO disable access key and remove password
+  //TODO send notification that this has been done
 }

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUsers.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUsers.scala
@@ -1,0 +1,22 @@
+package schedule.unrecognised
+
+import com.gu.janus.model.JanusData
+import model.{AwsAccount, CredentialReportDisplay, HumanUser, Tag}
+import utils.attempt.FailedAttempt
+
+object IamUnrecognisedUsers {
+  def getJanusUsernames(janusData: JanusData): List[String] =
+    janusData.access.userAccess.keys.toList
+
+  def getHumanUsers(credsReport: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]): List[HumanUser] =
+    credsReport.values.collect { case Right(report) => report.humanUsers }.flatten.toList
+
+  def filterUnrecognisedIamUsers(iamHumanUsersWithTargetTag: List[HumanUser], targetKey: String, janusUsernames: List[String]): List[HumanUser] =
+    iamHumanUsersWithTargetTag.filterNot { iamUser =>
+      val maybeTag = iamUser.tags.find(tag => tag.key == targetKey)
+      maybeTag match {
+        case Some(tag) => janusUsernames.contains(tag.value) // filter out human users that have tags which match the janus usernames
+        case None => true
+      }
+    }
+}

--- a/hq/test/schedule/IamUnrecognisedUserTest.scala
+++ b/hq/test/schedule/IamUnrecognisedUserTest.scala
@@ -1,0 +1,46 @@
+package schedule
+
+import com.gu.janus.model.{ACL, AwsAccount, JanusData, SupportACL}
+import model.{AccessKey, CredentialReportDisplay, Green, HumanUser, NoKey, Tag, AwsAccount => Account}
+import org.joda.time.{DateTime, Seconds}
+import org.scalatest.{FreeSpec, Matchers}
+import schedule.unrecognised.IamUnrecognisedUsers.{filterUnrecognisedIamUsers, getHumanUsers, getJanusUsernames}
+import utils.attempt.FailedAttempt
+
+class IamUnrecognisedUserTest extends FreeSpec with Matchers {
+  val humanUser1 = HumanUser("", true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, List(Tag("name", "ade.bimbola")))
+  val humanUser2 = humanUser1.copy(tags = List(Tag("name", "john.akindele")))
+  val humanUser3 = humanUser1.copy(tags = List(Tag("name", "khadija.omodara")))
+  val humanUser4 = humanUser1.copy(tags = List(Tag("name", "nneka.obi")))
+
+  val credsReportDisplay = CredentialReportDisplay(
+    DateTime.now,
+    Seq.empty,
+    Seq(humanUser1, humanUser2, humanUser3, humanUser4)
+  )
+
+  "findUnrecognisedIamUsers" - {
+    "get janus usernames" in {
+      val dummyJanusData = JanusData(
+        Set(AwsAccount("Deploy Tools", "deployTools")),
+        ACL(Map("firstName.secondName" -> Set.empty)),
+        ACL(Map.empty),
+        SupportACL(Map.empty, Set.empty, Seconds.ZERO),
+        None
+      )
+
+      getJanusUsernames(dummyJanusData) shouldEqual List("firstName.secondName")
+    }
+    "get human users from credentials report" in {
+      val credsReport: Map[Account, Either[FailedAttempt, CredentialReportDisplay]] =
+        Map(Account("id", "name", "roleArn", "accountNumber") -> Right(credsReportDisplay))
+      val result: List[HumanUser] = List(humanUser1, humanUser2, humanUser3, humanUser4)
+      getHumanUsers(credsReport) shouldEqual result
+    }
+    "get unrecognised human users" in {
+      val permanentIamUsers: List[HumanUser] = List(humanUser1, humanUser2, humanUser3, humanUser4)
+      val janusUsers: List[String] = List("ade.bimbola", "john.akindele", "khadija.omodara")
+      filterUnrecognisedIamUsers(permanentIamUsers, "name", janusUsers) shouldEqual List(humanUser4)
+    }
+  }
+}


### PR DESCRIPTION
## What does this change?
This adds logic to find all the latest human users who are not janus users. This means that these are the people with IAM permanent credentials who have left the Guardian. The next PR will be to disable these users' permanent credentials.
