### PR TITLE
Creds reaper testing: finding flagged users

### DIFF
--- a/hq/app/schedule/IamNotifications.scala
+++ b/hq/app/schedule/IamNotifications.scala
@@ -48,7 +48,8 @@ object IamNotifications extends Logging {
     IamNotification(warningNotifications, finalNotifications, users)
   }
 
-  private def createVulnerableCredentialsNotification(warning: Boolean, users: Seq[VulnerableUser], awsAccount: AwsAccount, targets: List[Target]): Notification = {
+  // TODO: this should be private as it's only used by tests and internally
+  def createVulnerableCredentialsNotification(warning: Boolean, users: Seq[VulnerableUser], awsAccount: AwsAccount, targets: List[Target]): Notification = {
     val usersWithDeadlineAddedIfMissing = users.map { user =>
       user.copy(disableDeadline = Some(createDeadlineIfMissing(user.disableDeadline)))
     }

--- a/hq/app/schedule/IamNotifications.scala
+++ b/hq/app/schedule/IamNotifications.scala
@@ -5,18 +5,29 @@ import model._
 import org.joda.time.DateTime
 import play.api.Logging
 import schedule.IamMessages._
+import schedule.IamTargetGroups.getNotificationTargetGroups
 import schedule.Notifier.notification
 import schedule.vulnerable.IamDeadline.{createDeadlineIfMissing, sortUsersIntoWarningOrFinalAlerts}
 
 object IamNotifications extends Logging {
 
-  def makeNotification(flaggedCredsToNotify: Map[AwsAccount, Seq[IAMAlertTargetGroup]]): List[IamNotification] = {
-    flaggedCredsToNotify.toList.flatMap { case (awsAccount, targetGroups) =>
-      if (targetGroups.isEmpty) {
+  def makeNotifications(flaggedCredsToNotify: Map[AwsAccount, Seq[VulnerableUser]]): List[IamNotification] = {
+    flaggedCredsToNotify.toList.flatMap { case (awsAccount, users) =>
+      if (users.isEmpty) {
         logger.info(s"found no vulnerable IAM users for ${awsAccount.name}. No notification required.")
         None
       } else {
-        targetGroups.map(tg => createWarningAndFinalNotification(tg, awsAccount, createIamAuditUsers(tg.users, awsAccount)))
+        // TODO: can we just apply getNotificationTargetGroups for all accounts?
+        val targetGroupsFromTags: Seq[IAMAlertTargetGroup] =
+          if(awsAccount.name == "Ophan") getNotificationTargetGroups(users)
+          else Seq(IAMAlertTargetGroup(List.empty, users))
+
+        targetGroupsFromTags.map(tg => {
+          // Always include the account as a notification target
+          val targetGroupWithAccounts = tg.copy(targets = tg.targets :+ Account(awsAccount.accountNumber))
+          val iamAuditUsers = createIamAuditUsers(targetGroupWithAccounts.users, awsAccount)
+          createWarningAndFinalNotification(targetGroupWithAccounts, awsAccount, iamAuditUsers)
+        })
       }
     }
   }

--- a/hq/app/schedule/IamNotifications.scala
+++ b/hq/app/schedule/IamNotifications.scala
@@ -66,6 +66,6 @@ object IamNotifications extends Logging {
     }
     val subject = if (warning) VulnerableCredentials.warningSubject(awsAccount) else VulnerableCredentials.finalSubject(awsAccount)
     val message = if (warning) VulnerableCredentials.createWarningMessage(awsAccount, usersWithDeadlineAddedIfMissing) else VulnerableCredentials.createFinalMessage(awsAccount, usersWithDeadlineAddedIfMissing)
-    notification(subject, message, targets :+ Account(awsAccount.accountNumber))
+    notification(subject, message, targets)
   }
 }

--- a/hq/app/schedule/IamUsersToDisable.scala
+++ b/hq/app/schedule/IamUsersToDisable.scala
@@ -1,13 +1,13 @@
 package schedule
 
-import model.{AwsAccount, IAMAlertTargetGroup, VulnerableUser}
+import model.{AwsAccount, VulnerableUser}
 import org.joda.time.DateTime
 import schedule.vulnerable.IamDeadline.getNearestDeadline
 
 object IamUsersToDisable {
-  def usersToDisable(flaggedUsers: Map[AwsAccount, Seq[IAMAlertTargetGroup]], dynamo: DynamoAlertService, today: DateTime = DateTime.now): Map[AwsAccount, Seq[VulnerableUser]] = {
-    flaggedUsers.map { case (awsAccount, targetGroups) =>
-      awsAccount -> getUsersToDisable(targetGroups.flatMap(_.users), awsAccount, dynamo, today)
+  def usersToDisable(flaggedUsers: Map[AwsAccount, Seq[VulnerableUser]], dynamo: DynamoAlertService, today: DateTime = DateTime.now): Map[AwsAccount, Seq[VulnerableUser]] = {
+    flaggedUsers.map { case (awsAccount, users) =>
+      awsAccount -> getUsersToDisable(users, awsAccount, dynamo, today)
     }
   }
 

--- a/hq/app/schedule/vulnerable/IamDeadline.scala
+++ b/hq/app/schedule/vulnerable/IamDeadline.scala
@@ -1,7 +1,7 @@
 package schedule.vulnerable
 
 import config.Config.iamAlertCadence
-import model.{AwsAccount, IAMAlertTargetGroup, IamAuditAlert, VulnerableUser}
+import model.{AwsAccount, IamAuditAlert, VulnerableUser}
 import org.joda.time.{DateTime, Days}
 import schedule.DynamoAlertService
 
@@ -26,11 +26,9 @@ object IamDeadline {
   }
   def isFinalAlert(deadline: DateTime, today: DateTime = DateTime.now): Boolean = deadline.withTimeAtStartOfDay == today.withTimeAtStartOfDay.plusDays(1)
 
-  def getVulnerableUsersToAlert(users: Map[AwsAccount, Seq[IAMAlertTargetGroup]], dynamo: DynamoAlertService): Map[AwsAccount, Seq[IAMAlertTargetGroup]] = {
-    users.map { case (account, targetGroups) =>
-      account -> targetGroups.map { tg =>
-        tg.copy(users = filterUsersToAlert(targetGroups.flatMap(_.users), account, dynamo))
-      }
+  def getVulnerableUsersToAlert(users: Map[AwsAccount, Seq[VulnerableUser]], dynamo: DynamoAlertService): Map[AwsAccount, Seq[VulnerableUser]] = {
+    users.map { case (account, users) =>
+      account -> filterUsersToAlert(users, account, dynamo)
     }
   }
 

--- a/hq/app/schedule/vulnerable/IamFlaggedUsers.scala
+++ b/hq/app/schedule/vulnerable/IamFlaggedUsers.scala
@@ -43,6 +43,7 @@ object IamFlaggedUsers extends Logging {
   }
 
   def findMissingMfa(credsReport: CredentialReportDisplay): CredentialReportDisplay = {
+    //TODO: change this filter, apply transform functions (below) here
     val removeMachineUsers = credsReport.machineUsers.filterNot(_.username == "")
     val filteredHumans = credsReport.humanUsers.filterNot(_.hasMFA)
     credsReport.copy(machineUsers = removeMachineUsers, humanUsers = filteredHumans)

--- a/hq/app/schedule/vulnerable/IamFlaggedUsers.scala
+++ b/hq/app/schedule/vulnerable/IamFlaggedUsers.scala
@@ -3,9 +3,7 @@ package schedule.vulnerable
 import logic.VulnerableAccessKeys
 import model.{AwsAccount, CredentialReportDisplay, IAMAlertTargetGroup, VulnerableUser}
 import play.api.Logging
-import schedule.DynamoAlertService
 import schedule.IamTargetGroups.getNotificationTargetGroups
-import schedule.vulnerable.IamDeadline.filterUsersToAlert
 import utils.attempt.FailedAttempt
 
 /**
@@ -30,14 +28,6 @@ object IamFlaggedUsers extends Logging {
         }
     }
     }.collect { case (awsAccount, Right(report)) => (awsAccount, report) }
-  }
-
-  def getVulnerableUsersToAlert(users: Map[AwsAccount, Seq[IAMAlertTargetGroup]], dynamo: DynamoAlertService): Map[AwsAccount, Seq[IAMAlertTargetGroup]] = {
-    users.map { case (account, targetGroups) =>
-      account -> targetGroups.map { tg =>
-        tg.copy(users = filterUsersToAlert(targetGroups.flatMap(_.users), account, dynamo))
-      }
-    }
   }
 
   private def findVulnerableUsers(report: CredentialReportDisplay): Seq[VulnerableUser] = {

--- a/hq/app/schedule/vulnerable/IamVulnerableUserJob.scala
+++ b/hq/app/schedule/vulnerable/IamVulnerableUserJob.scala
@@ -11,8 +11,8 @@ import schedule.IamMessages.VulnerableCredentials.{disabledUsersMessage, disable
 import schedule.IamNotifications.makeNotification
 import schedule.IamUsersToDisable.usersToDisable
 import schedule.Notifier.{notification, send}
+import schedule.vulnerable.IamDeadline.getVulnerableUsersToAlert
 import schedule.vulnerable.IamDisableAccessKeys.disableAccessKeys
-import schedule.vulnerable.IamFlaggedUsers.getVulnerableUsersToAlert
 import schedule.vulnerable.IamRemovePassword.removePasswords
 import schedule.{CronSchedules, DynamoAlertService, JobRunner}
 import services.CacheService

--- a/hq/test/schedule/IamNotificationsTest.scala
+++ b/hq/test/schedule/IamNotificationsTest.scala
@@ -2,14 +2,14 @@ package schedule
 
 import model.AwsAccount
 import org.scalatest.{FreeSpec, Matchers}
-import schedule.IamNotifications.makeNotification
+import schedule.IamNotifications.makeNotifications
 
 class IamNotificationsTest extends FreeSpec with Matchers {
   "makeNotification" - {
     "returns nothing when there are no old access keys or missing mfas" in {
       val allCreds = Map(AwsAccount("", "", "", "") -> Seq.empty)
       val result = List.empty
-      makeNotification(allCreds) shouldEqual result
+      makeNotifications(allCreds) shouldEqual result
     }
   }
 }

--- a/hq/test/schedule/IamUsersToDisableTest.scala
+++ b/hq/test/schedule/IamUsersToDisableTest.scala
@@ -1,6 +1,5 @@
 package schedule
 
-import com.gu.anghammarad.models.Stack
 import model._
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
@@ -11,17 +10,14 @@ class IamUsersToDisableTest extends FreeSpec with Matchers {
   private val dynamo: DynamoAlertService = new MockDynamoAlertService()
 
   private val account = AwsAccount("accountId","accountName","accountRole","accountNumber")
-  def flaggedUserWithUsername(username: String) = Map(
-     account -> Seq(
-      IAMAlertTargetGroup(
-        List(Stack("test-stack")),
-        Seq(
-          VulnerableUser(
-            username = username,
-            humanUser = true,
-            tags = List.empty,
-            disableDeadline = None
-  )))))
+  def flaggedUserWithUsername(username: String) =
+    Map(account -> Seq(
+      VulnerableUser(
+        username = username,
+        humanUser = true,
+        tags = List.empty,
+        disableDeadline = None))
+    )
 
   "usersToDisable" - {
     "returns the user when the deadline is today" in {

--- a/hq/test/schedule/SendTestNotifications.scala
+++ b/hq/test/schedule/SendTestNotifications.scala
@@ -12,7 +12,8 @@ import org.scalatest.{DoNotDiscover, FreeSpec, Matchers}
 import org.scalatestplus.play.components.OneAppPerSuiteWithComponents
 import play.api.routing.Router
 import play.api.{BuiltInComponents, BuiltInComponentsFromContext, NoHttpFiltersComponents}
-import schedule.IamMessages.VulnerableCredentials.{disabledUsersMessage, disabledUsersSubject}
+import schedule.IamMessages.VulnerableCredentials.disabledUsersMessage
+import schedule.IamMessages.disabledUsersSubject
 import schedule.Notifier.notification
 import utils.attempt.{Attempt, AttemptValues}
 

--- a/hq/test/schedule/vulnerable/IamFlaggedUsersTest.scala
+++ b/hq/test/schedule/vulnerable/IamFlaggedUsersTest.scala
@@ -7,115 +7,93 @@ import schedule.vulnerable.IamFlaggedUsers.{findMissingMfa, findOldAccessKeys}
 
 class IamFlaggedUsersTest extends FreeSpec with Matchers {
   "IamFlaggedUsers" - {
+    val oldHumanAccessKeyEnabled = AccessKey(AccessKeyEnabled, Some(DateTime.now.minusMonths(6)))
+    val oldHumanAccessKeyDisabled = oldHumanAccessKeyEnabled.copy(keyStatus = AccessKeyDisabled)
+    val oldHumanAccessKeyDisabledUser = HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty)
+    val oldHumanAccessKeyEnabledUser = oldHumanAccessKeyDisabledUser.copy(key1 = oldHumanAccessKeyEnabled)
+
+    val oldMachineAccessKeyEnabled = AccessKey(AccessKeyEnabled, Some(DateTime.now.minusMonths(18)))
+    val oldMachineAccessKeyDisabled = oldMachineAccessKeyEnabled.copy(keyStatus = AccessKeyDisabled)
+    val oldMachineAccessKeyEnabledUser = MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty)
+    val oldMachineAccessKeyDisabledUser = oldMachineAccessKeyEnabledUser.copy(key1 = oldMachineAccessKeyDisabled)
+
+    val newAccessKeyDisabled = AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1)))
+    val newAccessKeyEnabled = newAccessKeyDisabled.copy(keyStatus = AccessKeyEnabled)
+    val newMachineAccessKeyDisabledUser = MachineUser("", newAccessKeyDisabled, AccessKey(NoKey, None), Green, None, None, List.empty)
+    val newHumanAccessKeyEnabledUser = HumanUser("", true, newAccessKeyEnabled, AccessKey(NoKey, None), Green, None, None, List.empty)
+
+    val humanMfaMissingUser = HumanUser("", false, newAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(MissingMfa)), None, None, List.empty)
+
     "findOldAccessKeys" - {
       "returns CredentialReportDisplays with access keys greater than 90 days old" in {
-        val oldHumanAccessKeyEnabled: AccessKey = AccessKey(AccessKeyEnabled, Some(new DateTime(2021, 1, 15, 1, 1)))
-        val oldHumanAccessKeyDisabled: AccessKey = AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1)))
-        val oldMachineAccessKeyEnabled: AccessKey = AccessKey(AccessKeyEnabled, Some(new DateTime(2019, 1, 15, 1, 1)))
-        val oldMachineAccessKeyDisabled: AccessKey = AccessKey(AccessKeyDisabled, Some(new DateTime(2018, 9, 1, 1, 1)))
-
         val credsReport: CredentialReportDisplay =
           CredentialReportDisplay(
             new DateTime(2021, 1, 1, 1, 1),
             Seq(
-              MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-              MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Green, None, None, List.empty),
-              MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
+              oldMachineAccessKeyEnabledUser,
+              newMachineAccessKeyDisabledUser,
+              oldMachineAccessKeyDisabledUser
             ),
             Seq(
-              HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-              HumanUser("", true, oldHumanAccessKeyEnabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-              HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Amber, None, None, List.empty),
+              oldHumanAccessKeyDisabledUser,
+              oldHumanAccessKeyEnabledUser,
+              newHumanAccessKeyEnabledUser,
             )
           )
-        val result: CredentialReportDisplay =
-          CredentialReportDisplay(
-            new DateTime(2021, 1, 1, 1, 1),
-            Seq(
-              MachineUser("", oldMachineAccessKeyEnabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-              // We've only temporarily commented out these cases as the logic ought to be reverted to align the dashboard and scheduled job
-              // MachineUser("", oldMachineAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-            ),
-            Seq(
-              // HumanUser("", true, oldHumanAccessKeyDisabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-              HumanUser("", true, oldHumanAccessKeyEnabled, AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-            )
-          )
+
+        val result: Seq[VulnerableUser] = Seq(
+          oldMachineAccessKeyEnabledUser,
+          // We've only temporarily commented out these cases as the logic ought to be reverted to align the dashboard and scheduled job
+          // oldMachineAccessKeyDisabledUser,
+          // oldHumanAccessKeyDisabledUser,
+          oldHumanAccessKeyEnabledUser
+        ).map(VulnerableUser.fromIamUser)
+
         findOldAccessKeys(credsReport) shouldEqual result
       }
-      "returns empty human user and machine user lists when there are no access keys greater than 90 days old" in {
+      "returns empty human user and machine user lists when there are no access keys greater than 90/365 days old" in {
         val credsReport: CredentialReportDisplay = CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
-          Seq(
-            MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(11))), AccessKey(NoKey, None), Green, None, None, List.empty),
-          ),
-          Seq(
-            HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Green, None, None, List.empty),
-          )
+          Seq(newMachineAccessKeyDisabledUser),
+          Seq(newHumanAccessKeyEnabledUser)
         )
-        val result: CredentialReportDisplay = CredentialReportDisplay(
-          reportDate = new DateTime(2021, 1, 1, 1, 1),
-          machineUsers = Seq.empty,
-          humanUsers = Seq.empty
-        )
-        findOldAccessKeys(credsReport) shouldEqual result
+
+        findOldAccessKeys(credsReport) shouldEqual Seq.empty
       }
       "returns empty human user and machine user lists when there are no active access keys (even if older than 90/365 days)" in {
         val credsReport: CredentialReportDisplay = CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
-          Seq(
-            MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(18))), AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-          ),
-          Seq(
-            HumanUser("", true, AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(6))), AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
-          )
+          Seq(oldMachineAccessKeyDisabledUser),
+          Seq(oldHumanAccessKeyDisabledUser)
         )
-        val result: CredentialReportDisplay = CredentialReportDisplay(
-          reportDate = new DateTime(2021, 1, 1, 1, 1),
-          machineUsers = Seq.empty,
-          humanUsers = Seq.empty
-        )
-        findOldAccessKeys(credsReport) shouldEqual result
+
+        findOldAccessKeys(credsReport) shouldEqual Seq.empty
       }
     }
     "findMissingMfa" - {
       "returns a list of human users in the credential report displays with missing Mfas" in {
         val credsReport: CredentialReportDisplay = CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
+          Seq(newMachineAccessKeyDisabledUser),
           Seq(
-            MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(10))), AccessKey(NoKey, None), Green, None, None, List.empty),
-          ),
-          Seq(
-            HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Green, None, None, List.empty),
-            HumanUser("", false, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red(Seq(MissingMfa)), None, None, List.empty),
+            newHumanAccessKeyEnabledUser,
+            humanMfaMissingUser
           )
         )
-        val result: CredentialReportDisplay = CredentialReportDisplay(
-          new DateTime(2021, 1, 1, 1, 1),
-          Seq.empty,
-          Seq(
-            HumanUser("", false, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red(Seq(MissingMfa)), None, None, List.empty),
-          )
-        )
+        val result = Seq(humanMfaMissingUser).map(VulnerableUser.fromIamUser)
+
         findMissingMfa(credsReport) shouldEqual result
       }
       "returns an empty human user list in the credential report displays when there are no human users with missing Mfas" in {
         val credsReport: CredentialReportDisplay = CredentialReportDisplay(
           new DateTime(2021, 1, 1, 1, 1),
+          Seq(newMachineAccessKeyDisabledUser),
           Seq(
-            MachineUser("", AccessKey(AccessKeyDisabled, Some(DateTime.now().minusMonths(9))), AccessKey(NoKey, None), Green, None, None, List.empty),
-          ),
-          Seq(
-            HumanUser("", true, AccessKey(AccessKeyEnabled, Some(DateTime.now().minusMonths(1))), AccessKey(NoKey, None), Green, None, None, List.empty),
-            HumanUser("", true, AccessKey(AccessKeyDisabled, Some(new DateTime(2020, 9, 1, 1, 1))), AccessKey(NoKey, None), Red(Seq(OutdatedKey)), None, None, List.empty),
+            newHumanAccessKeyEnabledUser,
+            oldHumanAccessKeyDisabledUser
           )
         )
-        val result: CredentialReportDisplay = CredentialReportDisplay(
-          new DateTime(2021, 1, 1, 1, 1),
-          Seq.empty,
-          Seq.empty
-        )
-        findMissingMfa(credsReport) shouldEqual result
+        findMissingMfa(credsReport) shouldEqual Seq.empty
       }
     }
   }

--- a/hq/test/schedule/vulnerable/IamFlaggedUsersTest.scala
+++ b/hq/test/schedule/vulnerable/IamFlaggedUsersTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FreeSpec, Matchers}
 import schedule.vulnerable.IamFlaggedUsers.{findMissingMfa, findOldAccessKeys}
 
 class IamFlaggedUsersTest extends FreeSpec with Matchers {
-  "findOldCredentialsAndMissingMfas" - {
+  "IamFlaggedUsers" - {
     "findOldAccessKeys" - {
       "returns CredentialReportDisplays with access keys greater than 90 days old" in {
         val oldHumanAccessKeyEnabled: AccessKey = AccessKey(AccessKeyEnabled, Some(new DateTime(2021, 1, 15, 1, 1)))


### PR DESCRIPTION
## What does this change?
This is the second part of a closer look at the test coverage of the credentials reaper feature. With this PR I was targeting testing of the functionality that isolates users from the credentials report that are actually vulnerable. This logic is contained in `IamFlaggedUsers` and so I was looking at how to effectively test that class. In the end, both the tests and source code were changed in the following ways:
- `IamFlaggedUsers` and the tests were simplified a bit by moving a small piece of notifications logic. This leads to a return type including `VulnerableUser` rather than `IamAlertTargetGroup`. This is beneficial to isolate the notification types/logic from `IamFlaggedUsers`, and it'll mean we have decent test coverage of `IamFlaggedUsers` because that was the main untested part
- `getVulnerableUsers` was also moved into `IamDeadline` as a notifictions-related piece of logic (although this was much simpler because it was already coupled with `IamDeadline` more than `IamFlaggedUsers`)
- The tests were also refactored a little to share more test data `val`s - without changing the tests themselves
- `Seq[VulnerableUser]` was used as the primary type in a couple of other places, now that it was available in the top level job. Previously we had to extract the vulnerable users out from each `IamAlertTargetGroup`.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
We're working towards better test coverage for this feature and this should cover `IamFlaggedUsers` as part of that.


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
