### PR TITLE
Fix imports after merge

### DIFF
--- a/hq/test/schedule/SendTestNotifications.scala
+++ b/hq/test/schedule/SendTestNotifications.scala
@@ -12,7 +12,8 @@ import org.scalatest.{DoNotDiscover, FreeSpec, Matchers}
 import org.scalatestplus.play.components.OneAppPerSuiteWithComponents
 import play.api.routing.Router
 import play.api.{BuiltInComponents, BuiltInComponentsFromContext, NoHttpFiltersComponents}
-import schedule.IamMessages.VulnerableCredentials.{disabledUsersMessage, disabledUsersSubject}
+import schedule.IamMessages.VulnerableCredentials.disabledUsersMessage
+import schedule.IamMessages.disabledUsersSubject
 import schedule.Notifier.notification
 import utils.attempt.{Attempt, AttemptValues}
 


### PR DESCRIPTION
## What does this change?
A recent PR moved `disabledUsersSubject`, while another introduced a new usage of it but was branched from main before the merge of the first PR, and was not rebased. This caused compilation error on main post-merge of the latter.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Fix main build

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
