### PR TITLE
Add test cases for edge case bugs in getNearestDeadline

### DIFF
--- a/hq/app/schedule/vulnerable/IamDeadline.scala
+++ b/hq/app/schedule/vulnerable/IamDeadline.scala
@@ -57,8 +57,8 @@ object IamDeadline {
   def getNearestDeadline(alerts: List[IamAuditAlert], today: DateTime = DateTime.now): DateTime = {
     val (nearestDeadline, _) = alerts.foldRight[(DateTime, Int)]((DateTime.now, iamAlertCadence)) {
       case (alert, (acc, startingNumberOfDays)) =>
-        val daysBetweenTodayAndDeadline: Int = Days.daysBetween(today, alert.disableDeadline).getDays
-        if (daysBetweenTodayAndDeadline < startingNumberOfDays) (alert.disableDeadline, daysBetweenTodayAndDeadline)
+        val daysBetweenTodayAndDeadline: Int = Days.daysBetween(today.withTimeAtStartOfDay, alert.disableDeadline).getDays
+        if (daysBetweenTodayAndDeadline < startingNumberOfDays && daysBetweenTodayAndDeadline >= 0) (alert.disableDeadline, daysBetweenTodayAndDeadline)
         else (acc, startingNumberOfDays)
     }
     nearestDeadline

--- a/hq/test/schedule/vulnerable/IamDeadlineTest.scala
+++ b/hq/test/schedule/vulnerable/IamDeadlineTest.scala
@@ -38,10 +38,24 @@ class IamDeadlineTest extends FreeSpec with Matchers {
   }
 
   "getNearestDeadline" - {
-    "returns nearest deadline" in {
+    "for two alerts in the future returns nearest deadline" in {
       val nearestDeadline = DateTime.now.plusDays(1).withTimeAtStartOfDay
       val alert1 = IamAuditAlert(VulnerableCredential, DateTime.now.minusWeeks(3), nearestDeadline)
       val alert2 = IamAuditAlert(VulnerableCredential, DateTime.now.minusWeeks(3), DateTime.now.plusDays(2).withTimeAtStartOfDay)
+      getNearestDeadline(List(alert1, alert2)) shouldEqual nearestDeadline
+    }
+
+    "for two alerts, one in the past, returns nearest (future) deadline" in {
+      val nearestDeadline = DateTime.now.plusDays(10).withTimeAtStartOfDay
+      val alert1 = IamAuditAlert(VulnerableCredential, DateTime.now.minusWeeks(3), nearestDeadline)
+      val alert2 = IamAuditAlert(VulnerableCredential, DateTime.now.minusWeeks(3), DateTime.now.minusDays(1).withTimeAtStartOfDay)
+      getNearestDeadline(List(alert1, alert2)) shouldEqual nearestDeadline
+    }
+
+    "for two alerts, one today, returns nearest deadline" in {
+      val nearestDeadline = DateTime.now.withTimeAtStartOfDay
+      val alert1 = IamAuditAlert(VulnerableCredential, DateTime.now.minusWeeks(3), nearestDeadline)
+      val alert2 = IamAuditAlert(VulnerableCredential, DateTime.now.minusWeeks(3), DateTime.now.plusDays(1).withTimeAtStartOfDay)
       getNearestDeadline(List(alert1, alert2)) shouldEqual nearestDeadline
     }
   }


### PR DESCRIPTION
## What does this change?
This adds a couple of test cases for the `getNearestDeadline` method in `IamDeadline`. I was originally looking to update the tests for all of `IamDeadline` but spotted 2 edge cases with `getNearestDeadline` we might not be covering, which I think makes this worth its own PR. Hopefully the test cases are self-explanatory. They didn't pass without the accompanying changes.
- getNearestDeadline should ignore deadlines in the past(?)
- getNearestDeadline should return "today" when choosing between today and tomorrow

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Potentially fixes some edge case bugs

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Any additional notes?
Please verify the test cases are valid, and if you can think of any other meaningful cases to add for this method specifically.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
