### PR TITLE
Potential fix for sending notifications

### DIFF
--- a/hq/app/schedule/Notifier.scala
+++ b/hq/app/schedule/Notifier.scala
@@ -29,7 +29,7 @@ object Notifier extends Logging {
       case Some(arn) =>
         val anghammaradNotification = {
           if (testMode) notification.copy(target = List(Stack("testing-alerts")))
-          else notification.copy(target = notification.target :+ Stack("testing-alerts"))
+          else notification
         }
         val response: Future[String] = Anghammarad.notify(anghammaradNotification, arn, snsClient)
         response.transformWith {


### PR DESCRIPTION
The Credentials Reaper has been turned on for the frontend, deploy tools and mobile account recently. Whilst an email was received by the test anghammarad google group, frontend report that they did not receive an email.

The logs from Security HQ suggest that both the frontend AWS account and the anghammarad google group were both included in the list of targets that was sent to Anghammarad.

However, the Anghammarad logs make no mention of sending the email to the frontend account and the logs only include the test google group.

This PR is testing the hypothesis that Anghammarad will send an email to one target and not two. Whilst this seems unlikely, it's easy to test and negate this theory before moving on to debugging Anghammarad.

This will be tested by creating a vulnerable user within the deploy tools account so that tomorrow an email should be sent notifying deploy Tools about this.
