### PR TITLE
Remove configraun dependency and read Snyk config from file

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,6 @@ lazy val hq = (project in file("hq"))
       "joda-time" % "joda-time" % "2.10.5",
       "org.typelevel" %% "cats-core" % "2.0.0",
       "com.github.tototoshi" %% "scala-csv" % "1.3.5",
-      "com.gu" %% "configraun" % "0.3",
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-iam" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -6,12 +6,8 @@ import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsPro
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.ec2.AmazonEC2AsyncClientBuilder
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder
 import com.google.cloud.securitycenter.v1.{SecurityCenterClient, SecurityCenterSettings}
-import com.gu.configraun.Configraun
-import com.gu.configraun.aws.AWSSimpleSystemsManagementFactory
-import com.gu.configraun.models._
 import config.Config
 import controllers._
 import filters.HstsFilter
@@ -49,7 +45,6 @@ class AppComponents(context: Context)
   )
 
   private val stack = configuration.get[String]("stack")
-  implicit val awsClient: AWSSimpleSystemsManagement = AWSSimpleSystemsManagementFactory(Config.region.getName, stack)
 
   // the aim of this is to get a list of available regions that we are able to access
   // note that:

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -110,8 +110,15 @@ object Config {
     } yield AwsAccount(id, name, roleArn, number)
   }
 
+  def getSnykConfig(config: Configuration): SnykConfig = {
+    SnykConfig(
+      SnykToken(requiredString(config, "snyk.token")),
+      SnykGroupId(requiredString(config, "snyk.organisation"))
+    )
+  }
+
   def getSnykSSOUrl(config: Configuration): Option[String] = {
-    config.getOptional[String]("snykSSOUrl")
+    config.getOptional[String]("snyk.ssoUrl")
   }
 
   def getAnghammaradSNSTopicArn(config: Configuration): Option[String] = config.getOptional[String]("anghammaradSnsArn")

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -258,9 +258,9 @@ case class MachineUser(
   val isHuman = false
 }
 
-case class SnykToken(value: String) extends AnyVal
+case class SnykConfig(snykToken: SnykToken, snykGroupId: SnykGroupId)
 
-case class SnykOrganisationName(value: String) extends AnyVal
+case class SnykToken(value: String) extends AnyVal
 
 case class SnykGroupId(value: String) extends AnyVal
 

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -33,7 +33,7 @@ class CacheService(
     config: Configuration,
     lifecycle: ApplicationLifecycle,
     environment: Environment,
-    configraun: com.gu.configraun.models.Configuration,
+    snykConfig: SnykConfig,
     wsClient: WSClient,
     ec2Clients: AwsClients[AmazonEC2Async],
     cfnClients: AwsClients[AmazonCloudFormationAsync],
@@ -138,7 +138,7 @@ class CacheService(
   def refreshSnykBox(): Unit = {
     logger.info("Started refresh of the Snyk data")
     for {
-      allSnykRuns <- Snyk.allSnykRuns(configraun, wsClient)
+      allSnykRuns <- Snyk.allSnykRuns(snykConfig, wsClient)
     } yield {
       logger.info("Sending the refreshed data to the Snyk Box")
       snykBox.send(Attempt.Right(allSnykRuns))

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -52,7 +52,11 @@ gcp {
    sccSourceId=${GCP_SCC_SOURCE_ID}
 }
 
-snykSSOUrl = ${?SNYK_SSO_URL}
+snyk {
+  token = ${SNYK_TOKEN}
+  organisation = ${SNYK_ORGANISATION}
+  ssoUrl = ${?SNYK_SSO_URL}
+}
 
 anghammaradSnsArn = ${ANGHAMMARAD_SNS_TOPIC_ARN}
 


### PR DESCRIPTION
## What does this change?

This PR removes the [configraun](https://github.com/guardian/configraun) dependency, as it is no longer maintained and is not published for Scala 2.13. 

I was originally planning to replace [configraun](https://github.com/guardian/configraun) with [simple-configuration](https://github.com/guardian/simple-configuration), but whilst researching this I noticed that we are only using this library to read 2 strings from parameter store anyway. All [other private config is currently fetched from S3](https://github.com/guardian/security-hq/blob/035c0f8de5d1a7a50b2b065d5d6878f1b779e09f/cloudformation/security-hq.template.yaml#L352) on startup.

The configraun dependency was originally introduced in https://github.com/guardian/security-hq/pull/64 with a view to migrating all config to parameter store, but as there are no current plans to do this I've opted to consolidate all config in S3 and simplify the code here instead.

## What is the value of this?

* Helps to unblock the migration to Scala 2.13
* Simplifies the codebase as all config is now read from the same place, using the same pattern

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Any additional notes?

Strangely the Snyk functionality (which relies on the config being changed here) will not work locally (regardless of whether I'm running `main` or this feature branch), which made testing this change a bit painful. I was getting a request timeout (after 2 minutes!) when attempting to make HTTP requests to Snyk's API. I've tested this in PROD and it's working fine, but I'd be interested to hear any theories which could explain this unusual behaviour in my local environment!

## To do (after merge)

- [ ] Remove redundant config from parameter store
- [ ] Remind team to pull new local config file (the app will not start up correctly if Snyk config is not found)
