### PR TITLE
Port across functionality from Box

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,6 @@ lazy val hq = (project in file("hq"))
       "com.vladsch.flexmark" % "flexmark" % "0.62.2",
       "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
       "io.reactivex" %% "rxscala" % "0.26.5",
-      "com.gu" %% "box" % "0.1.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
       "org.quartz-scheduler" % "quartz" % "2.3.2",

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -13,7 +13,6 @@ import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.support.AWSSupportAsync
 import com.google.cloud.securitycenter.v1.{OrganizationName, SecurityCenterClient}
-import com.gu.Box
 import config.Config
 import logic.GcpDisplay
 import model._
@@ -25,9 +24,19 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import logging.Cloudwatch
 import org.joda.time.DateTime
 
+import java.util.concurrent.atomic.AtomicReference
+
+object Box {
+  def apply[T](initialValue: T): Box[T] = new Box[T](initialValue)
+}
+
+class Box[T](t: T) {
+  private val ref: AtomicReference[T] = new AtomicReference[T](t)
+  def get(): T = ref.get()
+  def send(t: T): Unit = ref.set(t)
+}
 
 class CacheService(
     config: Configuration,

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -25,18 +25,7 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import org.joda.time.DateTime
-
-import java.util.concurrent.atomic.AtomicReference
-
-object Box {
-  def apply[T](initialValue: T): Box[T] = new Box[T](initialValue)
-}
-
-class Box[T](t: T) {
-  private val ref: AtomicReference[T] = new AtomicReference[T](t)
-  def get(): T = ref.get()
-  def send(t: T): Unit = ref.set(t)
-}
+import utils.Box
 
 class CacheService(
     config: Configuration,

--- a/hq/app/utils/Box.scala
+++ b/hq/app/utils/Box.scala
@@ -1,0 +1,13 @@
+package utils
+
+import java.util.concurrent.atomic.AtomicReference
+
+object Box {
+  def apply[T](initialValue: T): Box[T] = new Box[T](initialValue)
+}
+
+class Box[T](t: T) {
+  private val ref: AtomicReference[T] = new AtomicReference[T](t)
+  def get(): T = ref.get()
+  def send(t: T): Unit = ref.set(t)
+}

--- a/hq/app/utils/Box.scala
+++ b/hq/app/utils/Box.scala
@@ -6,8 +6,8 @@ object Box {
   def apply[T](initialValue: T): Box[T] = new Box[T](initialValue)
 }
 
-class Box[T](t: T) {
-  private val ref: AtomicReference[T] = new AtomicReference[T](t)
+class Box[T] private (t: T) {
+  private final val ref: AtomicReference[T] = new AtomicReference[T](t)
   def get(): T = ref.get()
   def send(t: T): Unit = ref.set(t)
 }


### PR DESCRIPTION
## What does this change?

This PR ports across a simplified version of https://github.com/guardian/box. 

This library was originally used to help teams to move away from akka Agents, but it is no longer worked on and is not published for more recent Scala versions. As the code that we need to keep is minimal, I think this copy+paste option is acceptable.

## What is the value of this?

* Removes a dependency and unblocks Scala 2.13 upgrade

## Will this require CloudFormation and/or updates to the AWS StackSet?

No