### PR TITLE
Only attempt to remove passwords for human users

### DIFF
--- a/hq/app/schedule/vulnerable/IamRemovePassword.scala
+++ b/hq/app/schedule/vulnerable/IamRemovePassword.scala
@@ -20,7 +20,7 @@ object IamRemovePassword extends Logging {
     users: Seq[VulnerableUser],
     iamClients: AwsClients[AmazonIdentityManagementAsync]
   )(implicit ec: ExecutionContext): Unit = {
-    users.map { user =>
+    users.filter(_.humanUser).map { user =>
       iamClients.get(account, SOLE_REGION).map { client =>
         deleteUserLoginProfile(client, user)
       }


### PR DESCRIPTION
## What does this change?
We've become aware that  `IamVulnerableUserJob` will always call `removePassword` for both human and machine users. Machine users do not have passwords, so the call will always fail for them.

This patch solves this by having `removePassword` filter out machine users from the list of users it receives.

## What is the value of this?

The failure triggers a cloudwatch alarm, which doesn't really make sense in this instance!

## Will this require CloudFormation and/or updates to the AWS StackSet?
No