### PR TITLE
Expose account numbers and allow account filtering

### DIFF
--- a/hq/app/views/index.scala.html
+++ b/hq/app/views/index.scala.html
@@ -86,6 +86,15 @@
     <div class="accounts__container">
         <div class="container">
             <div class="row">
+                <div class="accounts__filter z-depth-1">
+                    <form>
+                        <div class="input-field" >
+                            <i class="material-icons prefix accounts__filter-icon">search</i>
+                            <input type="text" placeholder="Name or number" id="account-number-filter" />
+                            <label for="account-number-filter">Filter accounts</label>
+                        </div>
+                    </form>
+                </div>
                 <div class="accounts__header">
                     <h2 class="white-text">Individual accounts</h2>
                 </div>
@@ -94,6 +103,9 @@
                         <div class="accounts__account z-depth-2">
                             <div class="accounts__account-heading">
                                 <span>@awsAccount.name</span>
+                            </div>
+                            <div class="accounts__account-number">
+                                <span>@awsAccount.accountNumber</span>
                             </div>
                             <div class="accounts__account-actions">
                                 <a href="/security-groups/@awsAccount.id" class="btn-flat accounts__link tooltipped" data-position="top" data-delay="50" data-tooltip="Security Groups">

--- a/hq/public/javascripts/app.js
+++ b/hq/public/javascripts/app.js
@@ -26,6 +26,46 @@ $(document).ready(function() {
     $('.collapsible-body').css('display', 'none');
   });
 
+  // Filter accounts by account number on the homepage
+  $('.accounts__container').each(function(i, el) {
+    const container = $(el);
+    const filterIcon = container.find('.accounts__filter-icon');
+    const filterInput = container.find('#account-number-filter');
+    const accountContainers = container.find('.accounts__account');
+    filterIcon.css('cursor', 'pointer');
+
+    function updateFilter() {
+      const filterTerm = filterInput.val();
+      if (filterTerm === '') {
+        filterIcon.html("search");
+      } else {
+        filterIcon.html("close");
+      }
+      accountContainers.css('display', 'block');
+      if (filterTerm) {
+        const nonMatching = accountContainers.filter(function(i, el) {
+          const accountContainer = $(el);
+          const matchesNumber = accountContainer.find('.accounts__account-number').text().includes(filterTerm);
+          const matchesName = accountContainer.find('.accounts__account-heading').text().toLowerCase().includes(filterTerm);
+          // we want accounts that do not match either category
+          return !matchesNumber && !matchesName;
+        });
+        nonMatching.css('display', 'none');
+      }
+    }
+
+    filterInput.on("input", updateFilter);
+    filterInput.on("blur", updateFilter);
+    filterIcon.click(function() {
+      if (filterInput.val() === '') {
+        filterInput.focus();
+      } else {
+        filterInput.val('');
+      }
+      updateFilter();
+    });
+  });
+
   // Extra interactions for the dropdowns on the Security Groups page
   $('.js-finding-details').hover(
     function() {

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -151,6 +151,32 @@ nav {
   padding-bottom: 20px;
 }
 
+.accounts__filter {
+  background-color: rgba(255, 255, 255, 0.9);
+  width: 100%;
+  padding: 5px 5px 0 5px;
+}
+
+@media (min-width: 500px) {
+  .accounts__filter {
+    float: right;
+    width: 200px;
+    transform: scale(0.8);
+    transform-origin: top right;
+  }
+}
+
+.accounts__filter-icon {
+  margin-top: 7px;
+}
+
+#account-number-filter {
+  margin-bottom: 10px;
+  /* removing box shadows fixes a rendering bug when scaled */
+  box-shadow: none;
+  -moz-box-shadow: none;
+}
+
 .accounts__header {
   padding: 5px 0;
 }
@@ -190,6 +216,12 @@ nav {
   font-size: 24px;
   font-weight: 300;
   line-height: 110%;
+}
+
+.accounts__account-number {
+  padding: 0 10px;
+  font-size: 12px;
+  color: rgba(78, 128, 152, 0.87);
 }
 
 .accounts__link {


### PR DESCRIPTION
## What does this change?

The index page includes a list of all the AWS accounts monitored by Security HQ. This overview now exposes the account IDs.

We also add the ability to filter the full list of accounts (which is now quite large) by name or number. 

## What is the value of this?

At the moment there isn't an easy way to lookup account by ID, so this page now exposes this value in the UI. In tools like AWS Security Hub, only the account ID is exposed (not our internal name for the account).

The filtering mechanism allows someone to investigate a security issue by filtering based on the AWS account ID.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

No, this is a clientside-only change.

## Any additional notes?

Screenshots of the behaviour are included below. The design changes at small sizes, to fit onto "mobile" sized devices.


### New UI elements
![account-numbers](https://user-images.githubusercontent.com/29761/138110636-5da63cf1-acbf-45ed-9ecf-e80fe2ae6a04.png)

### Filtering by account ID
![account-numbers-filtered](https://user-images.githubusercontent.com/29761/138110668-98ad8c03-c511-407e-8e4c-9bbfaab3fe07.png)

### Filtering by account name
![account-numbers-filtered-name](https://user-images.githubusercontent.com/29761/138110689-fb09c0a0-26fa-41cc-8558-c15865be6dbe.png)

### Filtering by a partial match
![account-numbers-filtered-partial-match](https://user-images.githubusercontent.com/29761/138110703-f3495df0-16e5-4dd4-b5ef-280efaad5661.png)

### Mobile-friendly
![account-numbers-mobile](https://user-images.githubusercontent.com/29761/138110728-00f707d0-f3bf-41db-9792-8aea4d22b768.png)
