### PR TITLE
Adds reminder in PR template to update config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,13 @@
 
 <!-- Has the CloudFormation or StackSet update been completed? -->
 
+## Will this require changes to config?
+
+
+<!-- Have you updated the PROD and local config files in S3? -->
+
+<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->
+
 ## Any additional notes?
 
 


### PR DESCRIPTION
## What does this change?
Adds a prompt in the PR template so that developers will update config if their PR requires a config change. 

## What is the value of this?
This is valuable, because it should decrease the likelihood of failed deploys due to out of date config.
