### PR TITLE
Fix Riffraff deploy

### DIFF
--- a/cloudformation/security-hq.template.yaml
+++ b/cloudformation/security-hq.template.yaml
@@ -373,8 +373,7 @@ Resources:
       - Ref: LoadBalancer
       Tags:
       - Key: Stage
-        Value:
-          Ref: Stage
+        Value: OLD
         PropagateAtLaunch: true
       - Key: Stack
         Value:


### PR DESCRIPTION
Re: https://github.com/guardian/security-hq/pull/329 which has just merged.

At the moment Riffraff refuses to deploy because there are two ASGs with matching tags. This change temporarily changes tags for the old ASG to ensure Security HQ can be deployed while the CDK DNS changes are made and CDK cleanup.