### PR TITLE
Drop TTL during migration

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1953,7 +1953,7 @@ dpkg -i /tmp/installer.deb
         "Stage": Object {
           "Ref": "Stage",
         },
-        "TTL": 3600,
+        "TTL": 60,
       },
       "Type": "Guardian::DNS::RecordSet",
     },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -134,7 +134,7 @@ dpkg -i /tmp/installer.deb`,
     new GuCname(this, 'security-hq.gutools.co.uk', {
       app: SecurityHQ.app.app,
       domainNameProps: domainNames,
-      ttl: Duration.hours(1),
+      ttl: Duration.minutes(1), // Temporarily low during DNS migration.
       resourceRecord: oldElb.attrDnsName,
     });
 


### PR DESCRIPTION
## What does this change?

(What it says.)

## What is the value of this?

Required during CDK migration to reduce risk as we switch DNS to the new stack.