### PR TITLE
Update dns

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1945,7 +1945,7 @@ dpkg -i /tmp/installer.deb
         "ResourceRecords": Array [
           Object {
             "Fn::GetAtt": Array [
-              "LoadBalancer",
+              "LoadBalancerSecurityhqF59D9B82",
               "DNSName",
             ],
           },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -10,7 +10,6 @@ import {
   InstanceType,
   Peer,
 } from '@aws-cdk/aws-ec2';
-import type { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import type { CfnTopic } from '@aws-cdk/aws-sns';
 import { CfnInclude } from '@aws-cdk/cloudformation-include';
 import { Duration } from '@aws-cdk/core';
@@ -93,7 +92,7 @@ export class SecurityHQ extends GuStack {
       [Stage.PROD]: { domainName: 'security-hq.gutools.co.uk' },
     };
 
-    new GuEc2App(this, {
+    const ec2App = new GuEc2App(this, {
       access: {
         scope: AccessScope.RESTRICTED,
         cidrRanges: [Peer.ipv4(accessRestrictionCidr)],
@@ -128,14 +127,11 @@ dpkg -i /tmp/installer.deb`,
       },
     });
 
-    // TODO reduce TTL and point to new ALB after going live.
-    const oldElb = template.getResource('LoadBalancer') as CfnLoadBalancer;
-
     new GuCname(this, 'security-hq.gutools.co.uk', {
       app: SecurityHQ.app.app,
       domainNameProps: domainNames,
       ttl: Duration.minutes(1), // Temporarily low during DNS migration.
-      resourceRecord: oldElb.attrDnsName,
+      resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
     });
 
     // TODO replace once template deleted with commented code below.


### PR DESCRIPTION
**WARNING: this should only go live after https://github.com/guardian/security-hq/pull/338 has been live for long enough to take effect.**

## What does this change?

Follows https://github.com/guardian/security-hq/pull/338 to make the actual DNS switch as part of the CDK migration.

Note, there is risk of downtime here if the new stack doesn't work, though the new instances seem to be running/passing healthcheck.

## What is the value of this?

Part of CDK migration.
