### PR TITLE
Initialise s3Clients for all available regions

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -77,7 +77,7 @@ class AppComponents(context: Context)
   private val ec2Clients = AWS.ec2Clients(configuration, availableRegions)
   private val cfnClients = AWS.cfnClients(configuration, availableRegions)
   private val taClients = AWS.taClients(configuration)
-  private val s3Clients = AWS.s3Clients(configuration)
+  private val s3Clients = AWS.s3Clients(configuration, availableRegions)
   private val iamClients = AWS.iamClients(configuration, availableRegions)
   private val efsClients = AWS.efsClients(configuration, availableRegions)
   val securityCredentialsProvider =

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -60,8 +60,8 @@ object AWS {
   def taClients(configuration: Configuration, region: Regions = Regions.US_EAST_1): AwsClients[AWSSupportAsync] =
     clients(AWSSupportAsyncClientBuilder.standard(), configuration, region)
 
-  def s3Clients(configuration: Configuration, region: Regions = Regions.US_EAST_1): AwsClients[AmazonS3] =
-    clients(AmazonS3ClientBuilder.standard(), configuration, region)
+  def s3Clients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonS3] =
+    clients(AmazonS3ClientBuilder.standard(), configuration, regions:_*)
 
   def iamClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonIdentityManagementAsync] =
     clients(AmazonIdentityManagementAsyncClientBuilder.standard(), configuration, regions:_*)

--- a/hq/app/aws/support/TrustedAdvisorS3.scala
+++ b/hq/app/aws/support/TrustedAdvisorS3.scala
@@ -2,6 +2,7 @@ package aws.support
 
 import aws.support.TrustedAdvisor.{getTrustedAdvisorCheckDetails, parseTrustedAdvisorCheckResult}
 import aws.{AwsClient, AwsClients}
+import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.support.AWSSupportAsync
@@ -46,7 +47,7 @@ object TrustedAdvisorS3 {
   private def publicBucketsForAccount(account: AwsAccount, taClients: AwsClients[AWSSupportAsync], s3Clients: AwsClients[AmazonS3])(implicit ec: ExecutionContext): Attempt[List[BucketDetail]] = {
     for {
       supportClient <- taClients.get(account)
-      s3Client <- s3Clients.get(account)
+      s3Client <- s3Clients.get(account, Regions.US_EAST_1)
       bucketResult <- getBucketReport(supportClient)
       enhancedBuckets = bucketResult.flaggedResources.map(addEncryptionStatus(_, s3Client))
     } yield enhancedBuckets


### PR DESCRIPTION
## What does this change?

This PR initialises s3Clients for all available aws regions, instead of just a single region, which defaulted to `US_EAST_1`.

## What is the value of this?

`IamUnrecognisedUserJob.scala` relies on querying an s3 file, which is specified by bucket, key and region. The job fetches the client for the necessary region, and then calls `getObject`  

```scala
      client <- s3Clients.get(config.securityAccount, config.janusUserBucketRegion)
      s3Object <- getS3Object(client, config.janusUserBucket, config.janusDataFileKey)
```

Meanwhile, in `AppComponents` s3Clients is initialised to a single region, which defaults to `US_EAST_1`. This  is unlike `iamClients`, for example, which gets passed a list of regions to build clients for.

```scala
    private val s3Clients = AWS.s3Clients(configuration)
    private val iamClients = AWS.iamClients(configuration, availableRegions)
```

This means that the job will run OK if config.janusUserBucketRegion is `US_EAST_1`, but fail if it's `EU_WEST_1` which is our case!

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Will this require changes to config?

No
