### PR TITLE
Revert "Update dns"

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1945,7 +1945,7 @@ dpkg -i /tmp/installer.deb
         "ResourceRecords": Array [
           Object {
             "Fn::GetAtt": Array [
-              "LoadBalancerSecurityhqF59D9B82",
+              "LoadBalancer",
               "DNSName",
             ],
           },


### PR DESCRIPTION
Reverts guardian/security-hq#339 as part (1) of the VPC-fix steps.