### PR TITLE
Commit synthed template for VPC stack

### DIFF
--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -9,3 +9,4 @@ dist
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+!cdk.out/security-vpc.template.json

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -27,7 +27,15 @@ There are two stacks:
     SecurityVpc - the security account VPC
     SecurityHQ - the EC2 app, load balancer, etc.
 
-Both are continuously built and deployed.
+`SecurityHQ` is continuously built and deployed, but `SecurityVpc` needs to be
+synthed locally and changes committed because it is
+['environment-aware'](https://docs.aws.amazon.com/cdk/latest/guide/environments.html).
+
+You can do this by:
+
+    $ ./script/generate security-vpc
+
+(Janus credentials for the security account are required for this to work.)
 
 As `SecurityHQ` depends on the output of `SecurityVpc`, if creating a new
 staging environment, you will need to deploy only the VPC step in Riffraff

--- a/cdk/bin/security-hq.ts
+++ b/cdk/bin/security-hq.ts
@@ -4,8 +4,6 @@
 import 'source-map-support/register';
 import { App } from '@aws-cdk/core';
 import { SecurityHQ } from '../lib/security-hq';
-import { SecurityVpc } from '../lib/security-vpc';
 
 const app = new App();
-new SecurityVpc(app, 'security-vpc', { stack: 'security' });
 new SecurityHQ(app, 'security-hq', { stack: 'security' });

--- a/cdk/bin/security-vpc.ts
+++ b/cdk/bin/security-vpc.ts
@@ -1,0 +1,14 @@
+import 'source-map-support/register';
+import { App } from '@aws-cdk/core';
+import { SecurityVpc } from '../lib/security-vpc';
+
+// Note, this stack is synthed locally rather than in CI as it is
+// 'environment-aware'
+// (https://docs.aws.amazon.com/cdk/latest/guide/environments.html) and so
+// requires AWS crendentials. Ideally, longer-term we'd support this in Github
+// Actions somehow.
+const app = new App();
+new SecurityVpc(app, 'security-vpc', {
+  stack: 'security',
+  env: { region: 'eu-west-1', account: process.env.CDK_DEFAULT_ACCOUNT }, // Crucial to ensure VPC uses all AZs.
+});

--- a/cdk/cdk.out/security-vpc.template.json
+++ b/cdk/cdk.out/security-vpc.template.json
@@ -1,0 +1,1055 @@
+{
+  "Parameters": {
+    "Stage": {
+      "Type": "String",
+      "Default": "CODE",
+      "AllowedValues": [
+        "CODE",
+        "PROD"
+      ],
+      "Description": "Stage name"
+    }
+  },
+  "Resources": {
+    "SecurityVpcC9F88B5F": {
+      "Type": "AWS::EC2::VPC",
+      "Properties": {
+        "CidrBlock": "10.248.208.0/21",
+        "EnableDnsHostnames": true,
+        "EnableDnsSupport": true,
+        "InstanceTenancy": "default",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet1Subnet05FBA99B": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.248.208.0/24",
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "AvailabilityZone": "eu-west-1a",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "ingress"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public"
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet1"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet1RouteTable61C07043": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet1"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet1RouteTableAssociation2F959041": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcingressSubnet1RouteTable61C07043"
+        },
+        "SubnetId": {
+          "Ref": "SecurityVpcingressSubnet1Subnet05FBA99B"
+        }
+      }
+    },
+    "SecurityVpcingressSubnet1DefaultRoute57910054": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcingressSubnet1RouteTable61C07043"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "SecurityVpcIGW1FA8C444"
+        }
+      },
+      "DependsOn": [
+        "SecurityVpcVPCGW04B79F1B"
+      ]
+    },
+    "SecurityVpcingressSubnet1EIP434574C0": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet1"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet1NATGateway438B0307": {
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "SecurityVpcingressSubnet1Subnet05FBA99B"
+        },
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "SecurityVpcingressSubnet1EIP434574C0",
+            "AllocationId"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet1"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet2Subnet1FFC175C": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.248.209.0/24",
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "AvailabilityZone": "eu-west-1b",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "ingress"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public"
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet2"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet2RouteTable2F4574FC": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet2"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet2RouteTableAssociation48414133": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcingressSubnet2RouteTable2F4574FC"
+        },
+        "SubnetId": {
+          "Ref": "SecurityVpcingressSubnet2Subnet1FFC175C"
+        }
+      }
+    },
+    "SecurityVpcingressSubnet2DefaultRoute96BDDAF3": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcingressSubnet2RouteTable2F4574FC"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "SecurityVpcIGW1FA8C444"
+        }
+      },
+      "DependsOn": [
+        "SecurityVpcVPCGW04B79F1B"
+      ]
+    },
+    "SecurityVpcingressSubnet2EIP50487DC3": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet2"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet2NATGatewayF3D0D1A4": {
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "SecurityVpcingressSubnet2Subnet1FFC175C"
+        },
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "SecurityVpcingressSubnet2EIP50487DC3",
+            "AllocationId"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet2"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet3SubnetD79B8CC0": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.248.210.0/24",
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "AvailabilityZone": "eu-west-1c",
+        "MapPublicIpOnLaunch": true,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "ingress"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Public"
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet3"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet3RouteTableEF514D66": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet3"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet3RouteTableAssociation61ACE3C1": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcingressSubnet3RouteTableEF514D66"
+        },
+        "SubnetId": {
+          "Ref": "SecurityVpcingressSubnet3SubnetD79B8CC0"
+        }
+      }
+    },
+    "SecurityVpcingressSubnet3DefaultRoute6C1FA951": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcingressSubnet3RouteTableEF514D66"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "GatewayId": {
+          "Ref": "SecurityVpcIGW1FA8C444"
+        }
+      },
+      "DependsOn": [
+        "SecurityVpcVPCGW04B79F1B"
+      ]
+    },
+    "SecurityVpcingressSubnet3EIP46C0674F": {
+      "Type": "AWS::EC2::EIP",
+      "Properties": {
+        "Domain": "vpc",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet3"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcingressSubnet3NATGateway6482F9D1": {
+      "Type": "AWS::EC2::NatGateway",
+      "Properties": {
+        "SubnetId": {
+          "Ref": "SecurityVpcingressSubnet3SubnetD79B8CC0"
+        },
+        "AllocationId": {
+          "Fn::GetAtt": [
+            "SecurityVpcingressSubnet3EIP46C0674F",
+            "AllocationId"
+          ]
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/ingressSubnet3"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcapplicationSubnet1Subnet892DAC9A": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.248.211.0/24",
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "AvailabilityZone": "eu-west-1a",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "application"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private"
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/applicationSubnet1"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcapplicationSubnet1RouteTable2D39C8C6": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/applicationSubnet1"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcapplicationSubnet1RouteTableAssociation53813CE4": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcapplicationSubnet1RouteTable2D39C8C6"
+        },
+        "SubnetId": {
+          "Ref": "SecurityVpcapplicationSubnet1Subnet892DAC9A"
+        }
+      }
+    },
+    "SecurityVpcapplicationSubnet1DefaultRoute49AD2D3C": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcapplicationSubnet1RouteTable2D39C8C6"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "SecurityVpcingressSubnet1NATGateway438B0307"
+        }
+      }
+    },
+    "SecurityVpcapplicationSubnet2Subnet424B60D5": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.248.212.0/24",
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "AvailabilityZone": "eu-west-1b",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "application"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private"
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/applicationSubnet2"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcapplicationSubnet2RouteTable7C5FA2DB": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/applicationSubnet2"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcapplicationSubnet2RouteTableAssociation101749FD": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcapplicationSubnet2RouteTable7C5FA2DB"
+        },
+        "SubnetId": {
+          "Ref": "SecurityVpcapplicationSubnet2Subnet424B60D5"
+        }
+      }
+    },
+    "SecurityVpcapplicationSubnet2DefaultRouteB442138F": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcapplicationSubnet2RouteTable7C5FA2DB"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "SecurityVpcingressSubnet2NATGatewayF3D0D1A4"
+        }
+      }
+    },
+    "SecurityVpcapplicationSubnet3SubnetED2D5E56": {
+      "Type": "AWS::EC2::Subnet",
+      "Properties": {
+        "CidrBlock": "10.248.213.0/24",
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "AvailabilityZone": "eu-west-1c",
+        "MapPublicIpOnLaunch": false,
+        "Tags": [
+          {
+            "Key": "aws-cdk:subnet-name",
+            "Value": "application"
+          },
+          {
+            "Key": "aws-cdk:subnet-type",
+            "Value": "Private"
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/applicationSubnet3"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcapplicationSubnet3RouteTable9B73BF18": {
+      "Type": "AWS::EC2::RouteTable",
+      "Properties": {
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc/applicationSubnet3"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcapplicationSubnet3RouteTableAssociationDA56471C": {
+      "Type": "AWS::EC2::SubnetRouteTableAssociation",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcapplicationSubnet3RouteTable9B73BF18"
+        },
+        "SubnetId": {
+          "Ref": "SecurityVpcapplicationSubnet3SubnetED2D5E56"
+        }
+      }
+    },
+    "SecurityVpcapplicationSubnet3DefaultRouteD0CCCC94": {
+      "Type": "AWS::EC2::Route",
+      "Properties": {
+        "RouteTableId": {
+          "Ref": "SecurityVpcapplicationSubnet3RouteTable9B73BF18"
+        },
+        "DestinationCidrBlock": "0.0.0.0/0",
+        "NatGatewayId": {
+          "Ref": "SecurityVpcingressSubnet3NATGateway6482F9D1"
+        }
+      }
+    },
+    "SecurityVpcIGW1FA8C444": {
+      "Type": "AWS::EC2::InternetGateway",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "31.0.0"
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq"
+          },
+          {
+            "Key": "Name",
+            "Value": "security-vpc/SecurityVpc"
+          },
+          {
+            "Key": "Stack",
+            "Value": "security"
+          },
+          {
+            "Key": "Stage",
+            "Value": {
+              "Ref": "Stage"
+            }
+          }
+        ]
+      }
+    },
+    "SecurityVpcVPCGW04B79F1B": {
+      "Type": "AWS::EC2::VPCGatewayAttachment",
+      "Properties": {
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "InternetGatewayId": {
+          "Ref": "SecurityVpcIGW1FA8C444"
+        }
+      }
+    },
+    "SecurityVpcs3AB4B81E1": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "ServiceName": {
+          "Fn::Join": [
+            "",
+            [
+              "com.amazonaws.",
+              {
+                "Ref": "AWS::Region"
+              },
+              ".s3"
+            ]
+          ]
+        },
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "RouteTableIds": [
+          {
+            "Ref": "SecurityVpcapplicationSubnet1RouteTable2D39C8C6"
+          },
+          {
+            "Ref": "SecurityVpcapplicationSubnet2RouteTable7C5FA2DB"
+          },
+          {
+            "Ref": "SecurityVpcapplicationSubnet3RouteTable9B73BF18"
+          },
+          {
+            "Ref": "SecurityVpcingressSubnet1RouteTable61C07043"
+          },
+          {
+            "Ref": "SecurityVpcingressSubnet2RouteTable2F4574FC"
+          },
+          {
+            "Ref": "SecurityVpcingressSubnet3RouteTableEF514D66"
+          }
+        ],
+        "VpcEndpointType": "Gateway"
+      }
+    },
+    "SecurityVpcdynamodbA5EDFBD1": {
+      "Type": "AWS::EC2::VPCEndpoint",
+      "Properties": {
+        "ServiceName": {
+          "Fn::Join": [
+            "",
+            [
+              "com.amazonaws.",
+              {
+                "Ref": "AWS::Region"
+              },
+              ".dynamodb"
+            ]
+          ]
+        },
+        "VpcId": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "RouteTableIds": [
+          {
+            "Ref": "SecurityVpcapplicationSubnet1RouteTable2D39C8C6"
+          },
+          {
+            "Ref": "SecurityVpcapplicationSubnet2RouteTable7C5FA2DB"
+          },
+          {
+            "Ref": "SecurityVpcapplicationSubnet3RouteTable9B73BF18"
+          },
+          {
+            "Ref": "SecurityVpcingressSubnet1RouteTable61C07043"
+          },
+          {
+            "Ref": "SecurityVpcingressSubnet2RouteTable2F4574FC"
+          },
+          {
+            "Ref": "SecurityVpcingressSubnet3RouteTableEF514D66"
+          }
+        ],
+        "VpcEndpointType": "Gateway"
+      }
+    },
+    "vpcIDEC623FC3": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Type": "String",
+        "Value": {
+          "Ref": "SecurityVpcC9F88B5F"
+        },
+        "Name": "/account/vpc/primary/id",
+        "Tags": {
+          "gu:cdk:version": "31.0.0",
+          "gu:repo": "guardian/security-hq",
+          "Stack": "security",
+          "Stage": {
+            "Ref": "Stage"
+          }
+        }
+      }
+    },
+    "publicSubnetsFE05F27B": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Type": "StringList",
+        "Value": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "SecurityVpcingressSubnet1Subnet05FBA99B"
+              },
+              ",",
+              {
+                "Ref": "SecurityVpcingressSubnet2Subnet1FFC175C"
+              },
+              ",",
+              {
+                "Ref": "SecurityVpcingressSubnet3SubnetD79B8CC0"
+              }
+            ]
+          ]
+        },
+        "Name": "/account/vpc/primary/subnets/public",
+        "Tags": {
+          "gu:cdk:version": "31.0.0",
+          "gu:repo": "guardian/security-hq",
+          "Stack": "security",
+          "Stage": {
+            "Ref": "Stage"
+          }
+        }
+      }
+    },
+    "privateSubnetsEA64D674": {
+      "Type": "AWS::SSM::Parameter",
+      "Properties": {
+        "Type": "StringList",
+        "Value": {
+          "Fn::Join": [
+            "",
+            [
+              {
+                "Ref": "SecurityVpcapplicationSubnet1Subnet892DAC9A"
+              },
+              ",",
+              {
+                "Ref": "SecurityVpcapplicationSubnet2Subnet424B60D5"
+              },
+              ",",
+              {
+                "Ref": "SecurityVpcapplicationSubnet3SubnetED2D5E56"
+              }
+            ]
+          ]
+        },
+        "Name": "/account/vpc/primary/subnets/private",
+        "Tags": {
+          "gu:cdk:version": "31.0.0",
+          "gu:repo": "guardian/security-hq",
+          "Stack": "security",
+          "Stage": {
+            "Ref": "Stage"
+          }
+        }
+      }
+    }
+  }
+}

--- a/cdk/script/generate
+++ b/cdk/script/generate
@@ -14,5 +14,5 @@ if [[ -z $APP ]]; then
 fi
 
 pushd "${ROOT_DIR}" > /dev/null || exit
-yarn --silent cdk synth --app="ts-node ${ROOT_DIR}/bin/${APP}.ts"  -o "${OUTPUT_DIR}" --path-metadata false --version-reporting false "*"
+yarn --silent cdk synth --profile security --app="ts-node ${ROOT_DIR}/bin/${APP}.ts"  -o "${OUTPUT_DIR}" --path-metadata false --version-reporting false "*"
 popd > /dev/null


### PR DESCRIPTION
Step **3** of the VPC fix. Follows:

* 1 https://github.com/guardian/security-hq/pull/341
* 2 https://github.com/guardian/security-hq/pull/342
* 3 <-- THIS PR
* 4 revert step number 2
* 5 revert step number 1


**NOTE: old VPC will need to be deleted manually first.**

## What does this change?

Recreates VPC and makes synth for VPC manual.

This is required because the stack needs to be 'environment-aware'
to generate the right number of subnets and associated resources.
We don't have a way to provide credentials for this in CI (yet) so
need to do it manually for now.

https://docs.aws.amazon.com/cdk/latest/guide/environments.html


## What is the value of this?

Corrects VPC setup.

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
