### PR TITLE
Remove migration flag as only one stack atm

### DIFF
--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -8,7 +8,6 @@ deployments:
     type: autoscaling
     parameters:
       bucket: security-dist
-      asgMigrationInProgress: true
     dependencies: [security-hq-cfn]
 
   security-vpc-cfn:


### PR DESCRIPTION
Note, the RR handling of this flag is quite brittle - as it fails the deploy if only a single matching stack is found.

Introduced by https://github.com/guardian/security-hq/pull/342, which (temporarily) removed the newer CDK ASG.
