### PR TITLE
Revert "Removes CDK resources (temporarily)"

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -15,10 +15,16 @@ Object {
     },
     "securityhq": Object {
       "CODE": Object {
+        "alarmActionsEnabled": false,
         "domainName": "security-hq.code.dev-gutools.co.uk",
+        "maxInstances": 2,
+        "minInstances": 1,
       },
       "PROD": Object {
+        "alarmActionsEnabled": true,
         "domainName": "security-hq.gutools.co.uk",
+        "maxInstances": 2,
+        "minInstances": 1,
       },
     },
   },
@@ -55,6 +61,15 @@ Object {
     },
   },
   "Outputs": Object {
+    "LoadBalancerSecurityhqDnsName": Object {
+      "Description": "DNS entry for LoadBalancerSecurityhq",
+      "Value": Object {
+        "Fn::GetAtt": Array [
+          "LoadBalancerSecurityhqF59D9B82",
+          "DNSName",
+        ],
+      },
+    },
     "LoadBalancerUrl": Object {
       "Value": Object {
         "Fn::GetAtt": Array [
@@ -69,6 +84,10 @@ Object {
       "Description": "Base AMI for Security HQ instances",
       "Type": "AWS::EC2::Image::Id",
     },
+    "AMISecurityhq": Object {
+      "Description": "Amazon Machine Image ID for the app security-hq. Use this in conjunction with AMIgo to keep AMIs up to date.",
+      "Type": "AWS::EC2::Image::Id",
+    },
     "AccessRestrictionCidr": Object {
       "Description": "CIDR block from which access to Security HQ should be allowed",
       "Type": "String",
@@ -77,6 +96,11 @@ Object {
       "Description": "Send Security HQ cloudwatch alarms to this email address",
       "Type": "String",
     },
+    "DistributionBucketName": Object {
+      "Default": "/account/services/artifact.bucket",
+      "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "InstanceType": Object {
       "Description": "AWS instance type (e.g. t4g.large)",
       "Type": "String",
@@ -84,6 +108,11 @@ Object {
     "LoggingRoleToAssumeArn": Object {
       "Description": "Name of IAM role in logging account e.g. arn:aws:iam::222222222222:role/LoggingRole",
       "Type": "String",
+    },
+    "LoggingStreamName": Object {
+      "Default": "/account/services/logging.stream.name",
+      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "OldVpcId": Object {
       "Description": "ID of the VPC Security HQ will run in",
@@ -114,8 +143,179 @@ Object {
       "Description": "ARN for Anghammarad's SNS topic",
       "Type": "String",
     },
+    "VpcId": Object {
+      "Default": "/account/vpc/primary/id",
+      "Description": "Virtual Private Cloud to run EC2 instances within",
+      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "securityhqPrivateSubnets": Object {
+      "Default": "/account/vpc/primary/subnets/private",
+      "Description": "A list of private subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
+    "securityhqPublicSubnets": Object {
+      "Default": "/account/vpc/primary/subnets/public",
+      "Description": "A list of public subnets",
+      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
+    },
   },
   "Resources": Object {
+    "AutoScalingGroupSecurityhqASG8DD277A5": Object {
+      "Properties": Object {
+        "HealthCheckGracePeriod": 120,
+        "HealthCheckType": "ELB",
+        "LaunchConfigurationName": Object {
+          "Ref": "AutoScalingGroupSecurityhqLaunchConfig4307528E",
+        },
+        "MaxSize": Object {
+          "Fn::FindInMap": Array [
+            "securityhq",
+            Object {
+              "Ref": "Stage",
+            },
+            "maxInstances",
+          ],
+        },
+        "MinSize": Object {
+          "Fn::FindInMap": Array [
+            "securityhq",
+            Object {
+              "Ref": "Stage",
+            },
+            "minInstances",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "PropagateAtLaunch": true,
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:pattern-name",
+            "PropagateAtLaunch": true,
+            "Value": "GuEc2App",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "PropagateAtLaunch": true,
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "PropagateAtLaunch": true,
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": "security-hq/AutoScalingGroupSecurityhq",
+          },
+          Object {
+            "Key": "Stack",
+            "PropagateAtLaunch": true,
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "PropagateAtLaunch": true,
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "TargetGroupARNs": Array [
+          Object {
+            "Ref": "TargetGroupSecurityhq530DEDAA",
+          },
+        ],
+        "VPCZoneIdentifier": Object {
+          "Ref": "securityhqPrivateSubnets",
+        },
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "AutoScalingGroupSecurityhqInstanceProfile9E45D8A7": Object {
+      "Properties": Object {
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::InstanceProfile",
+    },
+    "AutoScalingGroupSecurityhqLaunchConfig4307528E": Object {
+      "DependsOn": Array [
+        "InstanceRoleSecurityhq7C08CA33",
+      ],
+      "Properties": Object {
+        "IamInstanceProfile": Object {
+          "Ref": "AutoScalingGroupSecurityhqInstanceProfile9E45D8A7",
+        },
+        "ImageId": Object {
+          "Ref": "AMISecurityhq",
+        },
+        "InstanceType": "t4g.large",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
+              "WazuhSecurityGroup",
+              "GroupId",
+            ],
+          },
+        ],
+        "UserData": Object {
+          "Fn::Base64": Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "#!/bin/bash -ev
+# setup security-hq
+mkdir -p /etc/gu
+
+aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/security/",
+                Object {
+                  "Ref": "Stage",
+                },
+                "/security-hq/security-hq.conf /etc/gu
+aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/security/",
+                Object {
+                  "Ref": "Stage",
+                },
+                "/security-hq/security-hq-service-account-cert.json /etc/gu
+aws --region eu-west-1 s3 cp s3://",
+                Object {
+                  "Ref": "DistributionBucketName",
+                },
+                "/security/",
+                Object {
+                  "Ref": "Stage",
+                },
+                "/security-hq/security-hq.deb /tmp/installer.deb
+
+dpkg -i /tmp/installer.deb",
+              ],
+            ],
+          },
+        },
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
     "AutoscalingGroup": Object {
       "Properties": Object {
         "AvailabilityZones": Object {
@@ -186,6 +386,47 @@ Object {
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
     },
+    "CertificateSecurityhqD266EC9D": Object {
+      "DeletionPolicy": "Retain",
+      "Properties": Object {
+        "DomainName": Object {
+          "Fn::FindInMap": Array [
+            "securityhq",
+            Object {
+              "Ref": "Stage",
+            },
+            "domainName",
+          ],
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
+    },
     "CloudWatchMetrics": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -203,6 +444,32 @@ Object {
         "Roles": Array [
           Object {
             "Ref": "SecurityHQInstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DescribeEC2PolicyFF5F9295": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeAutoScalingGroups",
+                "ec2:DescribeTags",
+                "ec2:DescribeInstances",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
           },
         ],
       },
@@ -237,6 +504,371 @@ Object {
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DisableAccessKeyFailureAlarm03FFC3CB": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "securityhq",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":undefined",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to disable a vulnerable access key (new stack)",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Failure",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "IamDisableAccessKey",
+        "Namespace": "SecurityHQ",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DynamoReadF4CBA3FD": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "dynamodb:BatchGetItem",
+                "dynamodb:GetItem",
+                "dynamodb:Scan",
+                "dynamodb:Query",
+                "dynamodb:GetRecords",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:dynamodb:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    Object {
+                      "Fn::Sub": Array [
+                        "security-hq-iam-\${Stage}",
+                        Object {
+                          "Stage": Object {
+                            "Ref": "Stage",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoReadF4CBA3FD",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DynamoWrite95D291C9": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "dynamodb:BatchWriteItem",
+                "dynamodb:PutItem",
+                "dynamodb:DeleteItem",
+                "dynamodb:UpdateItem",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:dynamodb:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":table/",
+                    Object {
+                      "Fn::Sub": Array [
+                        "security-hq-iam-\${Stage}",
+                        Object {
+                          "Stage": Object {
+                            "Ref": "Stage",
+                          },
+                        },
+                      ],
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DynamoWrite95D291C9",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GetDistributablePolicySecurityhqC6808A6A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/security/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/security-hq/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GetDistributablePolicySecurityhqC6808A6A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow all outbound HTTPS traffic",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow all outbound HTTPS traffic",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "GuHttpsEgressSecurityGroupSecurityhqfromsecurityhqLoadBalancerSecurityhqSecurityGroup3F506C5990004DFA1452": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityhqSecurityGroup66272916",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuHttpsEgressSecurityGroupSecurityhqfromsecurityhqRestrictedIngressSecurityGroupSecurityhq2DC7AECE90009FDEBE14": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "RestrictedIngressSecurityGroupSecurityhqCA18D247",
+            "GroupId",
+          ],
+        },
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "GuLogShippingPolicy981BFE5A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "kinesis:Describe*",
+                "kinesis:Put*",
+              ],
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:kinesis:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":stream/",
+                    Object {
+                      "Ref": "LoggingStreamName",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "InstanceRoleSecurityhq7C08CA33": Object {
+      "Properties": Object {
+        "AssumeRolePolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": Object {
+                "Service": Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      "ec2.",
+                      Object {
+                        "Ref": "AWS::URLSuffix",
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "Path": "/",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "InstanceSecurityGroup": Object {
       "Properties": Object {
@@ -348,6 +980,31 @@ dpkg -i /tmp/installer.deb
         },
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration",
+    },
+    "ListenerSecurityhq0F356342": Object {
+      "Properties": Object {
+        "Certificates": Array [
+          Object {
+            "CertificateArn": Object {
+              "Ref": "CertificateSecurityhqD266EC9D",
+            },
+          },
+        ],
+        "DefaultActions": Array [
+          Object {
+            "TargetGroupArn": Object {
+              "Ref": "TargetGroupSecurityhq530DEDAA",
+            },
+            "Type": "forward",
+          },
+        ],
+        "LoadBalancerArn": Object {
+          "Ref": "LoadBalancerSecurityhqF59D9B82",
+        },
+        "Port": 443,
+        "Protocol": "HTTPS",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
     "LoadBalancer": Object {
       "Properties": Object {
@@ -489,6 +1146,114 @@ dpkg -i /tmp/installer.deb
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
+    "LoadBalancerSecurityhqF59D9B82": Object {
+      "Properties": Object {
+        "LoadBalancerAttributes": Array [
+          Object {
+            "Key": "deletion_protection.enabled",
+            "Value": "true",
+          },
+        ],
+        "Scheme": "internet-facing",
+        "SecurityGroups": Array [
+          Object {
+            "Fn::GetAtt": Array [
+              "LoadBalancerSecurityhqSecurityGroup66272916",
+              "GroupId",
+            ],
+          },
+          Object {
+            "Fn::GetAtt": Array [
+              "RestrictedIngressSecurityGroupSecurityhqCA18D247",
+              "GroupId",
+            ],
+          },
+        ],
+        "Subnets": Object {
+          "Ref": "securityhqPublicSubnets",
+        },
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "Type": "application",
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    },
+    "LoadBalancerSecurityhqSecurityGroup66272916": Object {
+      "Properties": Object {
+        "GroupDescription": "Automatically created Security Group for ELB securityhqLoadBalancerSecurityhq4820B44E",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "LoadBalancerSecurityhqSecurityGrouptosecurityhqGuHttpsEgressSecurityGroupSecurityhqFDD8E89C90004679E20B": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "LoadBalancerSecurityhqSecurityGroup66272916",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
     "LoggingPolicy": Object {
       "Properties": Object {
         "PolicyDocument": Object {
@@ -546,6 +1311,46 @@ dpkg -i /tmp/installer.deb
       },
       "Type": "AWS::SNS::Topic",
     },
+    "ParameterStoreReadSecurityhq5E138D38": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:ssm:",
+                    Object {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    Object {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/",
+                    Object {
+                      "Ref": "Stage",
+                    },
+                    "/security/security-hq",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "parameter-store-read-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "RemovePasswordExecutionFailureAlarm": Object {
       "Properties": Object {
         "AlarmActions": Array [
@@ -575,6 +1380,165 @@ dpkg -i /tmp/installer.deb
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RemovePasswordFailureAlarm68B6574A": Object {
+      "Properties": Object {
+        "ActionsEnabled": Object {
+          "Fn::FindInMap": Array [
+            "securityhq",
+            Object {
+              "Ref": "Stage",
+            },
+            "alarmActionsEnabled",
+          ],
+        },
+        "AlarmActions": Array [
+          Object {
+            "Fn::Join": Array [
+              "",
+              Array [
+                "arn:aws:sns:",
+                Object {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                Object {
+                  "Ref": "AWS::AccountId",
+                },
+                ":undefined",
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to remove a vulnerable password (new stack)",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": Array [
+          Object {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Failure",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "IamRemovePassword",
+        "Namespace": "SecurityHQ",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RestrictedIngressSecurityGroupSecurityhqCA18D247": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow restricted ingress from CIDR ranges",
+        "SecurityGroupIngress": Array [
+          Object {
+            "CidrIp": Object {
+              "Ref": "AccessRestrictionCidr",
+            },
+            "Description": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "Allow access on port 443 from ",
+                  Object {
+                    "Ref": "AccessRestrictionCidr",
+                  },
+                ],
+              ],
+            },
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
+    },
+    "RestrictedIngressSecurityGroupSecurityhqtosecurityhqGuHttpsEgressSecurityGroupSecurityhqFDD8E89C9000A501F165": Object {
+      "Properties": Object {
+        "Description": "Load balancer to target",
+        "DestinationSecurityGroupId": Object {
+          "Fn::GetAtt": Array [
+            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
+            "GroupId",
+          ],
+        },
+        "FromPort": 9000,
+        "GroupId": Object {
+          "Fn::GetAtt": Array [
+            "RestrictedIngressSecurityGroupSecurityhqCA18D247",
+            "GroupId",
+          ],
+        },
+        "IpProtocol": "tcp",
+        "ToPort": 9000,
+      },
+      "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "SSMRunCommandPolicy244E1613": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "ssm-run-command-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "SecurityHQAssumeRolePolicy": Object {
       "Properties": Object {
@@ -869,6 +1833,102 @@ dpkg -i /tmp/installer.deb
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "TargetGroupSecurityhq530DEDAA": Object {
+      "Properties": Object {
+        "HealthCheckIntervalSeconds": 10,
+        "HealthCheckPath": "/healthcheck",
+        "HealthCheckProtocol": "HTTP",
+        "HealthCheckTimeoutSeconds": 5,
+        "HealthyThresholdCount": 5,
+        "Port": 9000,
+        "Protocol": "HTTP",
+        "Tags": Array [
+          Object {
+            "Key": "App",
+            "Value": "security-hq",
+          },
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "TargetGroupAttributes": Array [
+          Object {
+            "Key": "deregistration_delay.timeout_seconds",
+            "Value": "30",
+          },
+          Object {
+            "Key": "stickiness.enabled",
+            "Value": "false",
+          },
+        ],
+        "TargetType": "instance",
+        "UnhealthyThresholdCount": 2,
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    },
+    "WazuhSecurityGroup": Object {
+      "Properties": Object {
+        "GroupDescription": "Allow outbound traffic from wazuh agent to manager",
+        "SecurityGroupEgress": Array [
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh event logging",
+            "FromPort": 1514,
+            "IpProtocol": "tcp",
+            "ToPort": 1514,
+          },
+          Object {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Wazuh agent registration",
+            "FromPort": 1515,
+            "IpProtocol": "tcp",
+            "ToPort": 1515,
+          },
+        ],
+        "Tags": Array [
+          Object {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          Object {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          Object {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          Object {
+            "Key": "Stage",
+            "Value": Object {
+              "Ref": "Stage",
+            },
+          },
+        ],
+        "VpcId": Object {
+          "Ref": "VpcId",
+        },
+      },
+      "Type": "AWS::EC2::SecurityGroup",
     },
     "securityhqgutoolscouk": Object {
       "Properties": Object {

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -228,6 +228,11 @@ Object {
             "Value": "guardian/security-hq",
           },
           Object {
+            "Key": "gu:riffraff:new-asg",
+            "PropagateAtLaunch": true,
+            "Value": "true",
+          },
+          Object {
             "Key": "Name",
             "PropagateAtLaunch": true,
             "Value": "security-hq/AutoScalingGroupSecurityhq",

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -160,6 +160,27 @@ Object {
     },
   },
   "Resources": Object {
+    "AssumeRole3910C09D": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AssumeRole3910C09D",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "AutoScalingGroupSecurityhqASG8DD277A5": Object {
       "Properties": Object {
         "HealthCheckGracePeriod": 120,
@@ -467,6 +488,27 @@ dpkg -i /tmp/installer.deb",
           "Version": "2012-10-17",
         },
         "PolicyName": "describe-ec2-policy",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "DescribeRegions9F63D96D": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "ec2:DescribeRegions",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "DescribeRegions9F63D96D",
         "Roles": Array [
           Object {
             "Ref": "InstanceRoleSecurityhq7C08CA33",
@@ -1829,6 +1871,42 @@ dpkg -i /tmp/installer.deb
         "Roles": Array [
           Object {
             "Ref": "SecurityHQInstanceRole",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "SsmCommands38E42C6A": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": Array [
+                "ec2messages:AcknowledgeMessage",
+                "ec2messages:DeleteMessage",
+                "ec2messages:FailMessage",
+                "ec2messages:GetEndpoint",
+                "ec2messages:GetMessages",
+                "ec2messages:SendReply",
+                "ssm:UpdateInstanceInformation",
+                "ssm:ListInstanceAssociations",
+                "ssm:DescribeInstanceProperties",
+                "ssm:DescribeDocumentParameters",
+                "ssmmessages:CreateControlChannel",
+                "ssmmessages:CreateDataChannel",
+                "ssmmessages:OpenControlChannel",
+                "ssmmessages:OpenDataChannel",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "SsmCommands38E42C6A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
           },
         ],
       },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -26,6 +26,7 @@ import {
 import type { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import {
+  GuAllowPolicy,
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
 } from '@guardian/cdk/lib/constructs/iam';
@@ -123,6 +124,35 @@ dpkg -i /tmp/installer.deb`,
           }),
           new GuDynamoDBWritePolicy(this, 'DynamoWrite', {
             tableName: cfnTable.tableName as string,
+          }),
+          new GuAllowPolicy(this, 'SsmCommands', {
+            resources: ['*'],
+            actions: [
+              'ec2messages:AcknowledgeMessage',
+              'ec2messages:DeleteMessage',
+              'ec2messages:FailMessage',
+              'ec2messages:GetEndpoint',
+              'ec2messages:GetMessages',
+              'ec2messages:SendReply',
+              'ssm:UpdateInstanceInformation',
+              'ssm:ListInstanceAssociations',
+              'ssm:DescribeInstanceProperties',
+              'ssm:DescribeDocumentParameters',
+              'ssmmessages:CreateControlChannel',
+              'ssmmessages:CreateDataChannel',
+              'ssmmessages:OpenControlChannel',
+              'ssmmessages:OpenDataChannel',
+            ],
+          }),
+          // Allow security HQ to assume roles in watched accounts.
+          new GuAllowPolicy(this, 'AssumeRole', {
+            resources: ['*'],
+            actions: ['sts:AssumeRole'],
+          }),
+          // Get the list of regions.
+          new GuAllowPolicy(this, 'DescribeRegions', {
+            resources: ['*'],
+            actions: ['ec2:DescribeRegions'],
           }),
         ],
       },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -1,34 +1,34 @@
-/* import {
+import {
   ComparisonOperator,
   Metric,
   TreatMissingData,
 } from '@aws-cdk/aws-cloudwatch';
-import type { CfnTable } from '@aws-cdk/aws-dynamodb'; */
-/* import {
+import type { CfnTable } from '@aws-cdk/aws-dynamodb';
+import {
   InstanceClass,
   InstanceSize,
   InstanceType,
   Peer,
-} from '@aws-cdk/aws-ec2'; */
+} from '@aws-cdk/aws-ec2';
 import type { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
-// import type { CfnTopic } from '@aws-cdk/aws-sns';
+import type { CfnTopic } from '@aws-cdk/aws-sns';
 import { CfnInclude } from '@aws-cdk/cloudformation-include';
 import { Duration } from '@aws-cdk/core';
 import type { App } from '@aws-cdk/core';
-//import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
+import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
 import { Stage } from '@guardian/cdk/lib/constants/stage';
-// import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
 import {
-  //GuDistributionBucketParameter,
+  GuDistributionBucketParameter,
   GuStack,
 } from '@guardian/cdk/lib/constructs/core';
 import type { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
-/* import {
+import {
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
-} from '@guardian/cdk/lib/constructs/iam'; */
+} from '@guardian/cdk/lib/constructs/iam';
 
 /**
  * Migration steps:
@@ -60,9 +60,9 @@ export class SecurityHQ extends GuStack {
     });
 
     // Import the existing Dynamo table.
-    /*     const cfnTable = template.getResource(
+    const cfnTable = template.getResource(
       'SecurityHqIamDynamoTable'
-    ) as CfnTable; */
+    ) as CfnTable;
 
     // TODO use below once old template is gone instead of importing above.
     /*     const table = new Table(this, 'DynamoTable', {
@@ -80,20 +80,20 @@ export class SecurityHQ extends GuStack {
 
     // The new stack below...
 
-    /*     const distBucket = GuDistributionBucketParameter.getInstance(this);
+    const distBucket = GuDistributionBucketParameter.getInstance(this);
 
     // TODO replace with config repo once token access for GHA is sorted
     // (https://trello.com/c/zhdgXpmk/903-allow-github-actions-to-clone-private-infrastructure-config).
     const accessRestrictionCidr = template.getParameter(
       'AccessRestrictionCidr'
-    ).valueAsString; */
+    ).valueAsString;
 
     const domainNames = {
       [Stage.CODE]: { domainName: 'security-hq.code.dev-gutools.co.uk' },
       [Stage.PROD]: { domainName: 'security-hq.gutools.co.uk' },
     };
 
-    /*     new GuEc2App(this, {
+    new GuEc2App(this, {
       access: {
         scope: AccessScope.RESTRICTED,
         cidrRanges: [Peer.ipv4(accessRestrictionCidr)],
@@ -126,7 +126,7 @@ dpkg -i /tmp/installer.deb`,
           }),
         ],
       },
-    }); */
+    });
 
     // TODO reduce TTL and point to new ALB after going live.
     const oldElb = template.getResource('LoadBalancer') as CfnLoadBalancer;
@@ -139,9 +139,9 @@ dpkg -i /tmp/installer.deb`,
     });
 
     // TODO replace once template deleted with commented code below.
-    /*     const notificationTopic = template.getResource(
+    const notificationTopic = template.getResource(
       'NotificationTopic'
-    ) as CfnTopic; */
+    ) as CfnTopic;
 
     /*     const notificationTopic = new GuSnsTopic(this, 'NotificationTopic', {
       displayName: 'Security HQ notifications',
@@ -153,7 +153,7 @@ dpkg -i /tmp/installer.deb`,
       new EmailSubscription(emailDest.valueAsString)
     ); */
 
-    /*     new GuAlarm(this, 'RemovePasswordFailureAlarm', {
+    new GuAlarm(this, 'RemovePasswordFailureAlarm', {
       app: SecurityHQ.app.app,
       alarmName:
         'Security HQ failed to remove a vulnerable password (new stack)',
@@ -195,6 +195,6 @@ dpkg -i /tmp/installer.deb`,
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
-    }); */
+    });
   }
 }

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -13,7 +13,7 @@ import {
 import type { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import type { CfnTopic } from '@aws-cdk/aws-sns';
 import { CfnInclude } from '@aws-cdk/cloudformation-include';
-import { Duration } from '@aws-cdk/core';
+import { Duration, Tags } from '@aws-cdk/core';
 import type { App } from '@aws-cdk/core';
 import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
 import { Stage } from '@guardian/cdk/lib/constants/stage';
@@ -94,7 +94,7 @@ export class SecurityHQ extends GuStack {
       [Stage.PROD]: { domainName: 'security-hq.gutools.co.uk' },
     };
 
-    new GuEc2App(this, {
+    const ec2App = new GuEc2App(this, {
       access: {
         scope: AccessScope.RESTRICTED,
         cidrRanges: [Peer.ipv4(accessRestrictionCidr)],
@@ -157,6 +157,9 @@ dpkg -i /tmp/installer.deb`,
         ],
       },
     });
+
+    // Required to support 2 ASGs at the same time in a RR deploy.
+    Tags.of(ec2App.autoScalingGroup).add('gu:riffraff:new-asg', 'true');
 
     // TODO reduce TTL and point to new ALB after going live.
     const oldElb = template.getResource('LoadBalancer') as CfnLoadBalancer;

--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -8,6 +8,7 @@ deployments:
     type: autoscaling
     parameters:
       bucket: security-dist
+      asgMigrationInProgress: true
     dependencies: [security-hq-cfn]
 
   security-vpc-cfn:


### PR DESCRIPTION
Step **4** of the VPC fix. Follows:

* 1 https://github.com/guardian/security-hq/pull/341
* 2 https://github.com/guardian/security-hq/pull/342
* 3 https://github.com/guardian/security-hq/pull/343
* 4 <-- THIS PR
* 5 https://github.com/guardian/security-hq/pull/350

Reverts guardian/security-hq#342

TODO: Also adds some missing policies which are required for the SHQ tasks. Thanks @jorgeazevedo for reporting the errors here.