### PR TITLE
Use region provided by trusted advisor for S3 client to check encryption status

### DIFF
--- a/hq/app/aws/s3/S3.scala
+++ b/hq/app/aws/s3/S3.scala
@@ -1,8 +1,10 @@
 package aws.s3
 
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{AmazonS3Exception, GetBucketEncryptionResult}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
+import scala.concurrent.ExecutionContext
 import scala.io.BufferedSource
 import scala.util.control.NonFatal
 
@@ -19,6 +21,27 @@ object S3 {
           "unable to get S3 object for the unrecognised user job",
           "I haven't been able to get the S3 object for the unrecognised user job, which contains the Janus data",
           500,
+          throwable = Some(e)
+        )))
+    }
+  }
+
+  def getBucketEncryption(client: AmazonS3, bucketName: String)(implicit ec: ExecutionContext): Attempt[Option[GetBucketEncryptionResult]] = {
+    try {
+      Attempt.Right {
+        Some(client.getBucketEncryption(bucketName))
+      }
+    } catch {
+      // If there is no bucket encryption, AWS returns an error...
+      // Assume bucket is not encrypted if we receive the specific error
+      case e: AmazonS3Exception if e.getMessage.contains("ServerSideEncryptionConfigurationNotFoundError") =>
+        Attempt.Right(None)
+      case NonFatal(e) =>
+        Attempt.Left(FailedAttempt(Failure(
+          s"unable to get S3 bucket encryption status for bucket $bucketName",
+          "Encryption status for this bucket was not found.",
+          500,
+          context = Some(e.getMessage),
           throwable = Some(e)
         )))
     }

--- a/hq/app/aws/s3/S3.scala
+++ b/hq/app/aws/s3/S3.scala
@@ -18,8 +18,8 @@ object S3 {
     } catch {
       case NonFatal(e) =>
         Attempt.Left(FailedAttempt(Failure(
-          "unable to get S3 object for the unrecognised user job",
-          "I haven't been able to get the S3 object for the unrecognised user job, which contains the Janus data",
+          s"Unable to get S3 object for bucket $bucket and key $key",
+          "Failed to fetch an S3 object",
           500,
           throwable = Some(e)
         )))


### PR DESCRIPTION
## What does this change?
This attempts to use an AWS S3 client with the region provided by the Trusted Advisor report. We are only using `US-EAST-1` for all S3 requests, which meant that any buckets outside that region would be assumed to have no encryption (even though they might).

You can see this with the following bucket which has default encryption turned on and is in `EU-WEST-1`:
![image](https://user-images.githubusercontent.com/8754692/142643204-e6492bf2-8674-45b7-8d4f-27efb72ac61f.png)

As it turns out, there also appears to be a limitation with the regions provided by Trusted Advisor - they don't seem to be provided unless the bucket is public, so this change will not fix that. I've opened a support ticket to find out more.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
The S3 report should more often show the correct default encryption status for buckets outside `US-EAST-1`. As it happens, for buckets in `US-EAST-1` whose region is not provided by Trusted Advisor, we will now be less accurate, but I'm assuming that a lot of our buckets will be `EU-WEST-1`.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
Related to #340 from which I spotted the issue.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
