### PR TITLE
Turn on unrecognised user job in allowed accounts

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1068,7 +1068,7 @@ dpkg -i /tmp/installer.deb",
             Object {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::gu-security-hq-audit/security/PROD/janus-data-export/janusData.conf",
+              "Resource": "arn:aws:s3:::gu-security-hq-audit/security/PROD/*",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1061,6 +1061,27 @@ dpkg -i /tmp/installer.deb",
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
+    "S3AuditRead9DF4AE59": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::gu-security-hq-audit/security/PROD/janus-data-export/janusData.conf",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3AuditRead9DF4AE59",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "SSMRunCommandPolicy244E1613": Object {
       "Properties": Object {
         "PolicyDocument": Object {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -100,7 +100,6 @@ aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.st
 dpkg -i /tmp/installer.deb`,
       roleConfiguration: {
         additionalPolicies: [
-          new GuPutCloudwatchMetricsPolicy(this),
           new GuDynamoDBReadPolicy(this, 'DynamoRead', {
             tableName: table.tableName,
           }),

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -29,6 +29,7 @@ import {
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
   GuPutCloudwatchMetricsPolicy,
+  GuGetS3ObjectsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
 
@@ -105,6 +106,10 @@ dpkg -i /tmp/installer.deb`,
           }),
           new GuDynamoDBWritePolicy(this, 'DynamoWrite', {
             tableName: table.tableName,
+          }),
+          new GuGetS3ObjectsPolicy(this, 'S3AuditRead', {
+            bucketName: 'gu-security-hq-audit',
+            paths: ['security/PROD/*'],
           }),
           // Allow security HQ to assume roles in watched accounts.
           new GuAllowPolicy(this, 'AssumeRole', {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -1,37 +1,24 @@
-import {
-  ComparisonOperator,
-  Metric,
-  TreatMissingData,
-} from '@aws-cdk/aws-cloudwatch';
-import { AttributeType, Table } from '@aws-cdk/aws-dynamodb';
-import {
-  InstanceClass,
-  InstanceSize,
-  InstanceType,
-  Peer,
-} from '@aws-cdk/aws-ec2';
-import { EmailSubscription } from '@aws-cdk/aws-sns-subscriptions';
-import { Duration, RemovalPolicy } from '@aws-cdk/core';
-import type { App, CfnElement } from '@aws-cdk/core';
-import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
-import { Stage } from '@guardian/cdk/lib/constants/stage';
-import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
-import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import {
-  GuDistributionBucketParameter,
-  GuParameter,
-  GuStack,
-} from '@guardian/cdk/lib/constructs/core';
-import type { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import {ComparisonOperator, Metric, TreatMissingData,} from '@aws-cdk/aws-cloudwatch';
+import {AttributeType, Table} from '@aws-cdk/aws-dynamodb';
+import {InstanceClass, InstanceSize, InstanceType, Peer,} from '@aws-cdk/aws-ec2';
+import {EmailSubscription} from '@aws-cdk/aws-sns-subscriptions';
+import type {App, CfnElement} from '@aws-cdk/core';
+import {Duration, RemovalPolicy} from '@aws-cdk/core';
+import {AccessScope, GuApplicationPorts, GuEc2App} from '@guardian/cdk';
+import {Stage} from '@guardian/cdk/lib/constants/stage';
+import {GuAlarm} from '@guardian/cdk/lib/constructs/cloudwatch';
+import type {GuStackProps} from '@guardian/cdk/lib/constructs/core';
+import {GuDistributionBucketParameter, GuParameter, GuStack,} from '@guardian/cdk/lib/constructs/core';
+import type {AppIdentity} from '@guardian/cdk/lib/constructs/core/identity';
+import {GuCname} from '@guardian/cdk/lib/constructs/dns';
 import {
   GuAllowPolicy,
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
-  GuPutCloudwatchMetricsPolicy,
   GuGetS3ObjectsPolicy,
+  GuPutCloudwatchMetricsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
-import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
+import {GuSnsTopic} from '@guardian/cdk/lib/constructs/sns';
 
 export class SecurityHQ extends GuStack {
   private static app: AppIdentity = {
@@ -100,6 +87,7 @@ aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.st
 dpkg -i /tmp/installer.deb`,
       roleConfiguration: {
         additionalPolicies: [
+          new GuPutCloudwatchMetricsPolicy(this),
           new GuDynamoDBReadPolicy(this, 'DynamoRead', {
             tableName: table.tableName,
           }),

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -1,16 +1,29 @@
-import {ComparisonOperator, Metric, TreatMissingData,} from '@aws-cdk/aws-cloudwatch';
-import {AttributeType, Table} from '@aws-cdk/aws-dynamodb';
-import {InstanceClass, InstanceSize, InstanceType, Peer,} from '@aws-cdk/aws-ec2';
-import {EmailSubscription} from '@aws-cdk/aws-sns-subscriptions';
-import type {App, CfnElement} from '@aws-cdk/core';
-import {Duration, RemovalPolicy} from '@aws-cdk/core';
-import {AccessScope, GuApplicationPorts, GuEc2App} from '@guardian/cdk';
-import {Stage} from '@guardian/cdk/lib/constants/stage';
-import {GuAlarm} from '@guardian/cdk/lib/constructs/cloudwatch';
-import type {GuStackProps} from '@guardian/cdk/lib/constructs/core';
-import {GuDistributionBucketParameter, GuParameter, GuStack,} from '@guardian/cdk/lib/constructs/core';
-import type {AppIdentity} from '@guardian/cdk/lib/constructs/core/identity';
-import {GuCname} from '@guardian/cdk/lib/constructs/dns';
+import {
+  ComparisonOperator,
+  Metric,
+  TreatMissingData,
+} from '@aws-cdk/aws-cloudwatch';
+import { AttributeType, Table } from '@aws-cdk/aws-dynamodb';
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  Peer,
+} from '@aws-cdk/aws-ec2';
+import { EmailSubscription } from '@aws-cdk/aws-sns-subscriptions';
+import type { App, CfnElement } from '@aws-cdk/core';
+import { Duration, RemovalPolicy } from '@aws-cdk/core';
+import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
+import { Stage } from '@guardian/cdk/lib/constants/stage';
+import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import {
+  GuDistributionBucketParameter,
+  GuParameter,
+  GuStack,
+} from '@guardian/cdk/lib/constructs/core';
+import type { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import {
   GuAllowPolicy,
   GuDynamoDBReadPolicy,
@@ -18,7 +31,7 @@ import {
   GuGetS3ObjectsPolicy,
   GuPutCloudwatchMetricsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
-import {GuSnsTopic} from '@guardian/cdk/lib/constructs/sns';
+import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
 
 export class SecurityHQ extends GuStack {
   private static app: AppIdentity = {

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -116,7 +116,7 @@ class AppComponents(context: Context)
     cacheService
   )
 
-  val unrecognisedUserJob = new IamUnrecognisedUserJob(cacheService, securitySnsClient, s3Clients, iamClients, configuration)
+  val unrecognisedUserJob = new IamUnrecognisedUserJob(cacheService, securitySnsClient, s3Clients, iamClients, configuration)(executionContext)
 
   val quartzScheduler = StdSchedulerFactory.getDefaultScheduler
   val jobScheduler = new JobScheduler(quartzScheduler, List(unrecognisedUserJob))

--- a/hq/app/AppLoader.scala
+++ b/hq/app/AppLoader.scala
@@ -19,6 +19,12 @@ class AppLoader extends ApplicationLoader {
 
     val components = new AppComponents(context)
 
+    components.quartzScheduler.start()
+
+    components.applicationLifecycle.addStopHook { () =>
+      Future.successful(components.quartzScheduler.shutdown())
+    }
+
     components.application
   }
 }

--- a/hq/app/aws/s3/S3.scala
+++ b/hq/app/aws/s3/S3.scala
@@ -2,14 +2,16 @@ package aws.s3
 
 import aws.AwsClient
 import com.amazonaws.services.s3.AmazonS3
+import play.api.Logging
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.io.BufferedSource
 import scala.util.control.NonFatal
 
-object S3 {
+object S3 extends Logging {
   def getS3Object(s3Client: AwsClient[AmazonS3], bucket: String, key: String): Attempt[BufferedSource] = {
     try {
+      logger.info(s"Making get-object request to S3 for bucket $bucket and key $key using region ${s3Client.region} and account ${s3Client.account}")
       Attempt.Right {
         scala.io.Source
           .fromInputStream(s3Client.client.getObject(bucket, key).getObjectContent)

--- a/hq/app/aws/s3/S3.scala
+++ b/hq/app/aws/s3/S3.scala
@@ -1,6 +1,5 @@
 package aws.s3
 
-import aws.AwsClient
 import com.amazonaws.services.s3.AmazonS3
 import play.api.Logging
 import utils.attempt.{Attempt, FailedAttempt, Failure}
@@ -9,12 +8,11 @@ import scala.io.BufferedSource
 import scala.util.control.NonFatal
 
 object S3 extends Logging {
-  def getS3Object(s3Client: AwsClient[AmazonS3], bucket: String, key: String): Attempt[BufferedSource] = {
+  def getS3Object(s3Client: AmazonS3, bucket: String, key: String): Attempt[BufferedSource] = {
     try {
-      logger.info(s"Making get-object request to S3 for bucket $bucket and key $key using region ${s3Client.region} and account ${s3Client.account}")
       Attempt.Right {
         scala.io.Source
-          .fromInputStream(s3Client.client.getObject(bucket, key).getObjectContent)
+          .fromInputStream(s3Client.getObject(bucket, key).getObjectContent)
       }
     } catch {
       case NonFatal(e) =>

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -33,7 +33,7 @@ class IamUnrecognisedUserJob(
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  override val cronSchedule: CronSchedule = CronSchedule("0 50/5 13 ? * MON *", "(for testing only)")
+  override val cronSchedule: CronSchedule = CronSchedule("0 45/5 16 ? * MON *", "(for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 class IamUnrecognisedUserJob(
   cacheService: CacheService,
   snsClient: AmazonSNSAsync,
-  s3Clients: AwsClients[AmazonS3],
+  s3Client: AmazonS3,
   iamClients: AwsClients[AmazonIdentityManagementAsync],
   config: Configuration
 )(implicit executionContext: ExecutionContext) extends JobRunner with Logging {
@@ -45,8 +45,7 @@ class IamUnrecognisedUserJob(
 
     val result = for {
       config <- getIamUnrecognisedUserConfig(config)
-      client <- s3Clients.get(config.securityAccount, config.janusUserBucketRegion)
-      s3Object <- getS3Object(client, config.janusUserBucket, config.janusDataFileKey)
+      s3Object <- getS3Object(s3Client, config.janusUserBucket, config.janusDataFileKey)
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
       accountCredsReports = getCredsReportDisplayForAccount(allCredsReports)

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -33,7 +33,7 @@ class IamUnrecognisedUserJob(
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  override val cronSchedule: CronSchedule = CronSchedule("0 0/15 10 ? * MON *", "Every 15 minutes from 10am until 11am, on Monday (for testing only)")
+  override val cronSchedule: CronSchedule = CronSchedule("0 35 10 ? * MON *", "(for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -7,16 +7,16 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.gu.anghammarad.models.{AwsAccount => TargetAccount}
 import com.gu.janus.JanusConfig
-import config.Config.{getAnghammaradSNSTopicArn, getIamUnrecognisedUserConfig}
+import config.Config.getIamUnrecognisedUserConfig
 import model.{AccessKeyEnabled, CronSchedule, VulnerableUser, AwsAccount => Account}
 import play.api.{Configuration, Logging}
 import schedule.IamMessages.FormerStaff.disabledUsersMessage
 import schedule.IamMessages.disabledUsersSubject
+import schedule.JobRunner
 import schedule.Notifier.{notification, send}
 import schedule.unrecognised.IamUnrecognisedUsers.{getCredsReportDisplayForAccount, getJanusUsernames, makeFile, unrecognisedUsersForAllowedAccounts}
 import schedule.vulnerable.IamDisableAccessKeys.disableAccessKeys
 import schedule.vulnerable.IamRemovePassword.removePasswords
-import schedule.{CronSchedules, JobRunner}
 import services.CacheService
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -32,7 +32,8 @@ class IamUnrecognisedUserJob(
 )(implicit executionContext: ExecutionContext) extends JobRunner with Logging {
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
-  override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
+  //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
+  override val cronSchedule: CronSchedule = CronSchedule("0 0/15 10 ? * MON *", "Every 15 minutes from 10am until 11am, on Monday (for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -34,7 +34,6 @@ class IamUnrecognisedUserJob(
   override val description: String = "Check for and remove unrecognised human IAM users"
   //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
   override val cronSchedule: CronSchedule = CronSchedule("0 0/10 * ? * * *", "(for testing only)")
-  private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {
     if (testMode) {
@@ -48,7 +47,7 @@ class IamUnrecognisedUserJob(
       s3Object <- getS3Object(s3Client, config.janusUserBucket, config.janusDataFileKey)
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
-      accountCredsReports = getCredsReportDisplayForAccount(allCredsReports)
+      accountCredsReports = getCredsReportDisplayForAccount(cacheService.getAllCredentials)
       allowedAccountsUnrecognisedUsers = unrecognisedUsersForAllowedAccounts(accountCredsReports, janusUsernames, config.allowedAccounts)
       _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(disableUser)
       notificationIds <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(sendNotification(_, testMode, config.anghammaradSnsTopicArn))

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -33,7 +33,7 @@ class IamUnrecognisedUserJob(
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  override val cronSchedule: CronSchedule = CronSchedule("0 35/5 11 ? * MON *", "(for testing only)")
+  override val cronSchedule: CronSchedule = CronSchedule("0 50/5 13 ? * MON *", "(for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -33,7 +33,7 @@ class IamUnrecognisedUserJob(
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  override val cronSchedule: CronSchedule = CronSchedule("0 0/15 10 ? * MON *", "(for testing only)")
+  override val cronSchedule: CronSchedule = CronSchedule("0 35/5 11 ? * MON *", "(for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -33,7 +33,7 @@ class IamUnrecognisedUserJob(
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  override val cronSchedule: CronSchedule = CronSchedule("0 35 10 ? * MON *", "(for testing only)")
+  override val cronSchedule: CronSchedule = CronSchedule("0 0/15 10 ? * MON *", "(for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -33,7 +33,7 @@ class IamUnrecognisedUserJob(
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  override val cronSchedule: CronSchedule = CronSchedule("0 45/5 16 ? * MON *", "(for testing only)")
+  override val cronSchedule: CronSchedule = CronSchedule("0 0/10 * ? * * *", "(for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {


### PR DESCRIPTION
## What does this change?
This is a WIP PR for enabling the unrecognised user job in production. We will only initially be turning it on in the Dev Playground account (controlled by config), but in order to reduce the feedback cycle I'll adjust the cron schedule accordingly on this branch and deploy it to PROD (after rebasing). Once we've observed a successful run we can switch back to a more sensible schedule and merge.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Trial run of the unrecognised IAM user job in a safer environment before wider rollout.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
Yes! I will do this before deploying this branch or merging.

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
