### PR TITLE
Revert dns change

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -2028,7 +2028,7 @@ dpkg -i /tmp/installer.deb
         "ResourceRecords": Array [
           Object {
             "Fn::GetAtt": Array [
-              "LoadBalancer",
+              "LoadBalancerSecurityhqF59D9B82",
               "DNSName",
             ],
           },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -10,7 +10,6 @@ import {
   InstanceType,
   Peer,
 } from '@aws-cdk/aws-ec2';
-import type { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import type { CfnTopic } from '@aws-cdk/aws-sns';
 import { CfnInclude } from '@aws-cdk/cloudformation-include';
 import { Duration, Tags } from '@aws-cdk/core';
@@ -161,14 +160,11 @@ dpkg -i /tmp/installer.deb`,
     // Required to support 2 ASGs at the same time in a RR deploy.
     Tags.of(ec2App.autoScalingGroup).add('gu:riffraff:new-asg', 'true');
 
-    // TODO reduce TTL and point to new ALB after going live.
-    const oldElb = template.getResource('LoadBalancer') as CfnLoadBalancer;
-
     new GuCname(this, 'security-hq.gutools.co.uk', {
       app: SecurityHQ.app.app,
       domainNameProps: domainNames,
       ttl: Duration.minutes(1), // Temporarily low during DNS migration.
-      resourceRecord: oldElb.attrDnsName,
+      resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
     });
 
     // TODO replace once template deleted with commented code below.


### PR DESCRIPTION
Step **5** of the VPC fix. Follows:

* 1 https://github.com/guardian/security-hq/pull/341
* 2 https://github.com/guardian/security-hq/pull/342
* 3 https://github.com/guardian/security-hq/pull/343
* 4 https://github.com/guardian/security-hq/pull/347
* 5 <-- THIS PR

A direct revert wasn't possible because of conflicts.