### PR TITLE
Remove migration flag

### DIFF
--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -26,6 +26,7 @@ deployments:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: security-hq
       templatePath: cfn.json
+      amiParameter: AMISecurityhq
       amiEncrypted: true
       amiTags:
         Recipe: security-java-lts-arm64

--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -8,7 +8,6 @@ deployments:
     type: autoscaling
     parameters:
       bucket: security-dist
-      asgMigrationInProgress: true
     dependencies: [security-hq-cfn]
 
   security-vpc-cfn:


### PR DESCRIPTION
Follows https://github.com/guardian/security-hq/pull/351 to fix the deploy - this flag currently fails the RR deploy as there are no longer 2 ASGs.

https://riffraff.gutools.co.uk/deployment/view/c4ee8bfa-4f48-46d1-98b8-a2f3babf5333