### PR TITLE
Add permissions to put metrics in cloudwatch

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -648,6 +648,27 @@ dpkg -i /tmp/installer.deb",
       },
       "Type": "AWS::IAM::Policy",
     },
+    "GuPutCloudwatchMetricsPolicyC5BCE402": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "InstanceRoleSecurityhq7C08CA33": Object {
       "Properties": Object {
         "AssumeRolePolicyDocument": Object {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -28,6 +28,7 @@ import {
   GuAllowPolicy,
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
+  GuPutCloudwatchMetricsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
 

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -133,6 +133,11 @@ dpkg -i /tmp/installer.deb`,
             resources: ['*'],
             actions: ['ec2:DescribeRegions'],
           }),
+          // Allow security HQ to post metrics to cloudwatch
+          new GuAllowPolicy(this, 'CloudwatchPutMetric', {
+            resources: ['*'],
+            actions: ['cloudwatch:PutMetricData'],
+          }),
         ],
       },
     });

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -133,7 +133,7 @@ dpkg -i /tmp/installer.deb`,
           new GuAllowPolicy(this, 'DescribeRegions', {
             resources: ['*'],
             actions: ['ec2:DescribeRegions'],
-          })
+          }),
         ],
       },
     });

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -98,6 +98,7 @@ aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.st
 dpkg -i /tmp/installer.deb`,
       roleConfiguration: {
         additionalPolicies: [
+          new GuPutCloudwatchMetricsPolicy(this),
           new GuDynamoDBReadPolicy(this, 'DynamoRead', {
             tableName: table.tableName,
           }),
@@ -132,12 +133,7 @@ dpkg -i /tmp/installer.deb`,
           new GuAllowPolicy(this, 'DescribeRegions', {
             resources: ['*'],
             actions: ['ec2:DescribeRegions'],
-          }),
-          // Allow security HQ to post metrics to cloudwatch
-          new GuAllowPolicy(this, 'CloudwatchPutMetric', {
-            resources: ['*'],
-            actions: ['cloudwatch:PutMetricData'],
-          }),
+          })
         ],
       },
     });


### PR DESCRIPTION
## What does this change?

Add permissions to put metrics in cloudwatch


## What is the value of this?

Allows sec hq to log data to cloudwatch

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yep!

## Will this require changes to config?

No