### PR TITLE
Remove unused import from cdk

### DIFF
--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -11,7 +11,7 @@ import {
   Peer,
 } from '@aws-cdk/aws-ec2';
 import { EmailSubscription } from '@aws-cdk/aws-sns-subscriptions';
-import { Duration, RemovalPolicy, Tags } from '@aws-cdk/core';
+import { Duration, RemovalPolicy } from '@aws-cdk/core';
 import type { App, CfnElement } from '@aws-cdk/core';
 import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
 import { Stage } from '@guardian/cdk/lib/constants/stage';


### PR DESCRIPTION
## What does this change?

Removes the tags import

## What is the value of this?

eslint flags it as a warning and it shows up in every PR


![Add_permissions_to_put_metrics_in_cloudwatch_by_jorgeazevedo_·_Pull_Request__353_·_guardian_security-hq](https://user-images.githubusercontent.com/1672034/142882064-e714b509-754c-4b38-920b-1d8855a5c020.png)

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope! This does not make a diff on the cloudformation yaml

## Will this require changes to config?

Nope