### PR TITLE
Remove duplicate SSM policy included in GuEc2App

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1130,42 +1130,6 @@ dpkg -i /tmp/installer.deb",
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
     },
-    "SsmCommands38E42C6A": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": Array [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "SsmCommands38E42C6A",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "TargetGroupSecurityhq530DEDAA": Object {
       "Properties": Object {
         "HealthCheckIntervalSeconds": 10,

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -104,25 +104,6 @@ dpkg -i /tmp/installer.deb`,
           new GuDynamoDBWritePolicy(this, 'DynamoWrite', {
             tableName: table.tableName,
           }),
-          new GuAllowPolicy(this, 'SsmCommands', {
-            resources: ['*'],
-            actions: [
-              'ec2messages:AcknowledgeMessage',
-              'ec2messages:DeleteMessage',
-              'ec2messages:FailMessage',
-              'ec2messages:GetEndpoint',
-              'ec2messages:GetMessages',
-              'ec2messages:SendReply',
-              'ssm:UpdateInstanceInformation',
-              'ssm:ListInstanceAssociations',
-              'ssm:DescribeInstanceProperties',
-              'ssm:DescribeDocumentParameters',
-              'ssmmessages:CreateControlChannel',
-              'ssmmessages:CreateDataChannel',
-              'ssmmessages:OpenControlChannel',
-              'ssmmessages:OpenDataChannel',
-            ],
-          }),
           // Allow security HQ to assume roles in watched accounts.
           new GuAllowPolicy(this, 'AssumeRole', {
             resources: ['*'],


### PR DESCRIPTION
## What does this change?


This removes the custom SSM policy as the exact same policy is built-in to GuEc2App

## What is the value of this?

No duplicate roles in IAM

![IAM_Management_Console](https://user-images.githubusercontent.com/1672034/142882760-42faee1c-c5d0-4963-a03c-f13b94cb98c3.png)


## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes!


## Will this require changes to config?

No!