### PR TITLE
Make scripts generic and document `-u` 

### DIFF
--- a/cdk/README.md
+++ b/cdk/README.md
@@ -9,16 +9,17 @@ We follow the
 find useful scripts within the [`script`](./script) directory for common tasks.
 
 - `./script/setup` to install dependencies
-- `./script/build [-w]` to compile the Typescript and check for errors
-- `./script/test [-w]` wrapper to lint, and run tests
-- `./script/lint [-fix]` to lint the code using ESLint
+- `./script/build [--watch]` to compile the Typescript and check for errors
+- `./script/test [-u] [--watch]` wrapper to lint, and run tests
+- `./script/lint [--fix]` to lint the code using ESLint
 - `./script/generate` to build a CDK stack into the `cdk.out` directory
 - `./script/ci` to lint and run tests, and generate templates of the CDK stacks
 - `./script/diff` to print the diff between a traditional CloudFormation
   template and a CDK stack
 
-`-w` is supported as an optional 'watch' flag for various commands.
-`-fix` is supported as 'fix' for linting.
+`-u` updates the snapshot tests, which is needed for any change in the cdk.
+`--watch` is supported as an optional 'watch' flag for various commands.
+`--fix` is supported as 'fix' for linting.
 
 ## Deployment
 

--- a/cdk/script/build
+++ b/cdk/script/build
@@ -2,10 +2,4 @@
 
 set -e
 
-if [ "$1" == '-w' ]
-then
-  yarn tsc -w
-else
-  yarn tsc
-fi
-
+yarn tsc "$@"

--- a/cdk/script/lint
+++ b/cdk/script/lint
@@ -2,9 +2,4 @@
 
 set -e
 
-if [ "$1" == '-fix' ]
-then
-  yarn lint --fix
-else
-  yarn lint
-fi
+yarn lint "$@"

--- a/cdk/script/test
+++ b/cdk/script/test
@@ -2,9 +2,4 @@
 
 set -e
 
-if [ "$1" == '-w' ]
-then
-  yarn test --watch
-else
-  yarn test
-fi
+yarn test "$@"


### PR DESCRIPTION
## What does this change?

This makes `build`, `lint` and `test` forward any argument passed to them to the underlying `yarn` call and updates the README accordingly.

Crucially, it mentions in the README that `./script/test -u` is how to update the snapshots, which always need to be ran when making changes to the cdk.

## What is the value of this?

I didn't know how to update the snapshots! The easier solution would be to add `yarn test -u` to the documentation, but I saw an opportunity here to consolidate our cdk actions under the `script` interface, as it were. It's weird that everything else is done with these scripts, except this one important action.

One downside is that it's `--watch` instead of the more brief `-w`.

Another is that it's not standard. Even if we update the [upstream version](https://github.com/guardian/cdk-cli/blob/main/src/template/script/test), every other cdk project in existence won't support it.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Nope

## Will this require changes to config?

Nope

## Any additional notes?

I'm open not to merge this and update the README instead, but I thought a proposed changed would be a good way to anchor the conversation.
