### PR TITLE
IAM Remediation: calculateOutstandingOperations

### DIFF
--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -1,16 +1,15 @@
 package config
 
-import java.io.FileInputStream
 import com.amazonaws.regions.Regions
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
 import model._
-import org.apache.commons.lang3.exception.ExceptionContext
 import play.api.Configuration
 import play.api.http.HttpConfiguration
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
+import java.io.FileInputStream
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -19,7 +18,6 @@ import scala.util.Try
 object Config {
   val iamHumanUserRotationCadence: Long = 90
   val iamMachineUserRotationCadence: Long = 365
-  val iamAlertCadence: Int = 21
   val daysBetweenWarningAndFinalNotification = 21
   val daysBetweenFinalNotificationAndRemediation = 7
 

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -18,7 +18,7 @@ import scala.util.Try
 object Config {
   val iamHumanUserRotationCadence: Long = 90
   val iamMachineUserRotationCadence: Long = 365
-  val daysBetweenWarningAndFinalNotification = 21
+  val daysBetweenWarningAndFinalNotification = 7
   val daysBetweenFinalNotificationAndRemediation = 7
 
   // TODO fetch the region dynamically from the instance

--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -1,10 +1,11 @@
 package logic
 
 import config.Config
+import config.Config.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
 import db.IamRemediationDb
-import model.iamremediation.{CredentialMetadata, IamUserRemediationHistory, PartitionedRemediationOperations, RemediationOperation}
-import model.{AccessKey, AccessKeyEnabled, AwsAccount, CredentialReportDisplay, IAMUser}
-import org.joda.time.DateTime
+import model._
+import model.iamremediation._
+import org.joda.time.{DateTime, Days}
 import play.api.Logging
 import utils.attempt.{Attempt, FailedAttempt}
 
@@ -45,19 +46,23 @@ object IamRemediation extends Logging {
       credentialReportDisplay.humanUsers.filter(user => hasOutdatedHumanKey(List(user.key1, user.key2), now))
   }
 
-  private def hasOutdatedHumanKey(keys: List[AccessKey], now: DateTime): Boolean = keys.exists { key =>
-      key.lastRotated.exists { date =>
-        // using minus 1 so that we return true if the last rotated date is exactly on the cadence date
-        date.isBefore(now.minusDays(Config.iamHumanUserRotationCadence.toInt - 1))
-      } && key.keyStatus == AccessKeyEnabled
-    }
+  private def hasOutdatedHumanKey(keys: List[AccessKey], now: DateTime): Boolean = keys.exists(isOutdatedHumanKey(_, now))
 
-  private def hasOutdatedMachineKey(keys: List[AccessKey], now: DateTime): Boolean = keys.exists { key =>
-      key.lastRotated.exists { date =>
-        // using minus 1 so that we return true if the last rotated date is exactly on the cadence date
-        date.isBefore(now.minusDays(Config.iamMachineUserRotationCadence.toInt - 1))
-      } && key.keyStatus == AccessKeyEnabled
-    }
+  private def hasOutdatedMachineKey(keys: List[AccessKey], now: DateTime): Boolean = keys.exists(isOutdatedMachineKey(_, now))
+
+  private def isOutdatedHumanKey(key: AccessKey, now: DateTime): Boolean = {
+    key.lastRotated.exists { date =>
+      // using minus 1 so that we return true if the last rotated date is exactly on the cadence date
+      date.isBefore(now.minusDays(Config.iamHumanUserRotationCadence.toInt - 1))
+    } && key.keyStatus == AccessKeyEnabled
+  }
+
+  private def isOutdatedMachineKey(key: AccessKey, now: DateTime): Boolean = {
+    key.lastRotated.exists { date =>
+      // using minus 1 so that we return true if the last rotated date is exactly on the cadence date
+      date.isBefore(now.minusDays(Config.iamMachineUserRotationCadence.toInt - 1))
+    } && key.keyStatus == AccessKeyEnabled
+  }
 
   /**
     * Given an IAMUser (in an AWS account), look up that user's activity history form the Database.
@@ -79,13 +84,72 @@ object IamRemediation extends Logging {
   }
 
   /**
-    * Looks through the candidates with their remediation history to decide what work needs to be done.
-    *
-    * By comparing the current date with
+    * Looks through the candidate's remediation history and outputs the work to be done per access key.
+    * This means that the same user could appear in the output list twice, because both of their keys may require an operation.
+    * By comparing the current date with the date of the last alert, we know which operation to perform next.
     */
-  def calculateOutstandingOperations(remediationHistory: List[IamUserRemediationHistory], now: DateTime): List[RemediationOperation] = {
-    ???
+  def calculateOutstandingOperations(remediationHistories: List[IamUserRemediationHistory], now: DateTime): List[RemediationOperation] = {
+    for {
+      userRemediationHistory <- remediationHistories
+      vulnerableKey <- identifyVulnerableKeys(userRemediationHistory, now)
+      keyPreviousAlert = identifyMostRecentActivity(userRemediationHistory, vulnerableKey)
+      keyNextActivity <- identifyRemediationOperation(keyPreviousAlert, now, userRemediationHistory)
+    } yield keyNextActivity
   }
+
+  private[logic] def identifyVulnerableKeys(remediationHistory: IamUserRemediationHistory, now: DateTime): List[AccessKey] = {
+    val user = remediationHistory.iamUser
+    if (user.isHuman) List(user.key1, user.key2).filter(isOutdatedHumanKey(_, now))
+    else List(user.key1, user.key2).filter(isOutdatedMachineKey(_, now))
+  }
+
+  private[logic] def identifyMostRecentActivity(remediationHistory: IamUserRemediationHistory, vulnerableKey: AccessKey): Option[IamRemediationActivity] = {
+    //TODO lastRotatedDate should not be an Option, because every IAM access key has a last rotated date. Change SHQ's model.
+    vulnerableKey.lastRotated match {
+      case Some(lastRotatedDate) =>
+        // filter activity list to find matching db records for given access key
+        val keyPreviousActivities = remediationHistory.activityHistory.filter { activity =>
+          activity.problemCreationDate.withTimeAtStartOfDay == lastRotatedDate.withTimeAtStartOfDay()
+        }
+        keyPreviousActivities match {
+          case Nil =>
+            // there is no recent activity for the given access key, so return None.
+            None
+          case remediationActivities =>
+            // get the most recent remediation activity
+            Some(remediationActivities.maxBy { activity =>
+              Days.daysBetween(activity.problemCreationDate.withTimeAtStartOfDay(), activity.dateNotificationSent.withTimeAtStartOfDay()).getDays
+            })
+        }
+      case None =>
+        // we do not expect this case, because every IAM access key has a lastRotatedDate. SHQ's model needs to be changed to reflect this.
+        None
+    }
+  }
+
+  private[logic] def identifyRemediationOperation(mostRecentRemediationActivity: Option[IamRemediationActivity], now: DateTime,
+    userRemediationHistory: IamUserRemediationHistory): Option[RemediationOperation] =
+    mostRecentRemediationActivity match {
+      case None =>
+        // if there is no recent activity, then the required operation must be a Warning
+        Some(RemediationOperation(userRemediationHistory, Warning, OutdatedCredential, problemCreationDate = now))
+      case Some(mostRecentActivity) =>
+        mostRecentActivity.iamRemediationActivityType match {
+        case Warning if now.isAfter(mostRecentActivity.dateNotificationSent.plusDays(daysBetweenWarningAndFinalNotification - 1)) =>
+          // if the most recent activity is a Warning and the last notification was sent at least `Config.daysBetweenWarningAndFinalNotification` ago,
+          // the required operation is a FinalWarning
+          Some(RemediationOperation(userRemediationHistory, FinalWarning, mostRecentActivity.iamProblem, mostRecentActivity.problemCreationDate))
+        case FinalWarning if now.isAfter(mostRecentActivity.dateNotificationSent.plusDays(daysBetweenFinalNotificationAndRemediation - 1)) =>
+          // if the most recent activity is a FinalWarning and the last notification was sent at least `Config.daysBetweenFinalNotificationAndRemediation` ago,
+          // the required operation is Remediation
+          Some(RemediationOperation(userRemediationHistory, Remediation, mostRecentActivity.iamProblem, mostRecentActivity.problemCreationDate))
+        case Remediation =>
+          // if the most recent activity is Remediation, then we have entered into an edge case.
+          // The operation should still be Remediation, because the access key must not have been successfully disabled last time it was marked as Remediation.
+          Some(RemediationOperation(userRemediationHistory, Remediation, mostRecentActivity.iamProblem, mostRecentActivity.problemCreationDate))
+        case _ => None
+      }
+    }
 
   /**
     * To prevent non-PROD application instances from making changes to production AWS accounts, SHQ is

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -1,15 +1,30 @@
 package logic
 
 import config.Config
-import logic.IamRemediation.{getCredsReportDisplayForAccount, identifyAllUsersWithOutdatedCredentials, identifyUsersWithOutdatedCredentials}
-import model.{AccessKey, AccessKeyDisabled, AccessKeyEnabled, AwsAccount, CredentialReportDisplay, Green, HumanUser, MachineUser, NoKey}
-import model.iamremediation.{IamUserRemediationHistory, OutdatedCredential, RemediationOperation, Warning}
+import config.Config.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
+import logic.IamRemediation._
+import model.iamremediation._
+import model._
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.{FailedAttempt, Failure}
 
 
 class IamRemediationTest extends FreeSpec with Matchers {
+  val date = new DateTime(2021, 1, 1, 1, 1)
+  val humanAccessKeyOldAndEnabled1 = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))
+  val humanAccessKeyOldAndEnabled2 = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))
+  val machineAccessKeyOldAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(13)))
+  val machineAccessKeyOldAndEnabledOnTimeThreshold = AccessKey(AccessKeyEnabled, Some(date.minusDays(Config.iamMachineUserRotationCadence.toInt)))
+  val humanAccessKeyHealthAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(1)))
+  val noAccessKey = AccessKey(NoKey, None)
+  val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
+  val humanWithOneOldEnabledAccessKey = HumanUser("amina.adewusi", true, humanAccessKeyOldAndEnabled1, noAccessKey, Green, None, None, Nil)
+  val humanWithTwoOldEnabledAccessKeys = HumanUser("nic.long", true, humanAccessKeyOldAndEnabled1, humanAccessKeyOldAndEnabled2, Green, None, None, Nil)
+  val humanWithHealthyKey = HumanUser("jon.soul", true, noAccessKey, humanAccessKeyHealthAndEnabled, Green, None, None, Nil)
+  val machineWithOneOldEnabledAccessKey = MachineUser("machine1", machineAccessKeyOldAndEnabled, noAccessKey, Green, None, None, Nil)
+  val machineWithOneOldEnabledAccessKey2 = MachineUser("machine2", machineAccessKeyOldAndEnabledOnTimeThreshold, noAccessKey, Green, None, None, Nil)
+
   "getCredsReportDisplayForAccount" - {
     val failedAttempt: FailedAttempt = FailedAttempt(Failure("error", "error", 500))
 
@@ -35,25 +50,6 @@ class IamRemediationTest extends FreeSpec with Matchers {
   }
 
   "identifyUsersWithOutdatedCredentials" - {
-    val date = new DateTime(2021, 1, 1, 1, 1)
-    val humanAccessKeyOldAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))
-    val humanAccessKeyOldAndDisabled = AccessKey(AccessKeyDisabled, Some(date.minusMonths(4)))
-    val machineAccessKeyOldAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(13)))
-    val machineAccessKeyOldAndEnabledOnTimeThreshold = AccessKey(AccessKeyEnabled, Some(date.minusDays(Config.iamMachineUserRotationCadence.toInt)))
-    val machineAccessKeyOldAndDisabled = AccessKey(AccessKeyDisabled, Some(date.minusMonths(13)))
-    val humanEnabledAccessKeyHealthy = AccessKey(AccessKeyEnabled, Some(date.minusMonths(1)))
-    val machineEnabledAccessKeyHealthy = AccessKey(AccessKeyEnabled, Some(date.minusMonths(11)))
-    val noAccessKey = AccessKey(NoKey, None)
-    val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
-    val humanWithOneOldEnabledAccessKey = HumanUser("amina.adewusi", true, humanAccessKeyOldAndEnabled, noAccessKey, Green, None, None, Nil)
-    val humanWithOneOldDisabledAccessKey = HumanUser("adam.fisher", true, noAccessKey, humanAccessKeyOldAndDisabled, Green, None, None, Nil)
-    val humanWithNoKeys = HumanUser("jorge.azevedo", true, noAccessKey, noAccessKey, Green, None, None, Nil)
-    val humanWithHealthyKey = HumanUser("jon.soul", true, noAccessKey, humanEnabledAccessKeyHealthy, Green, None, None, Nil)
-    val machineWithOneOldEnabledAccessKey = MachineUser("machine1", machineAccessKeyOldAndEnabled, noAccessKey, Green, None, None, Nil)
-    val machineWithOneOldEnabledAccessKey2 = MachineUser("machine2", machineAccessKeyOldAndEnabledOnTimeThreshold, noAccessKey, Green, None, None, Nil)
-    val machineWithOneOldDisabledAccessKey = MachineUser("machine3", noAccessKey, machineAccessKeyOldAndDisabled, Green, None, None, Nil)
-    val machineWithHealthyKey = MachineUser("machine4", noAccessKey, machineEnabledAccessKeyHealthy, Green, None, None, Nil)
-
     "given a vulnerable human user, return that user" in {
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanWithOneOldEnabledAccessKey))
       identifyUsersWithOutdatedCredentials(account, credsReport, date).map(_.username) shouldEqual List("amina.adewusi")
@@ -67,14 +63,20 @@ class IamRemediationTest extends FreeSpec with Matchers {
       identifyUsersWithOutdatedCredentials(account, credsReport, date).map(_.username) should contain allOf ("amina.adewusi", "machine1")
     }
     "given users with old disabled keys, return an empty list" in {
+      val humanWithOneOldDisabledAccessKey = HumanUser("adam.fisher", true, noAccessKey, AccessKey(AccessKeyDisabled, Some(date.minusMonths(4))), Green, None, None, Nil)
+      val machineAccessKeyOldAndDisabled = AccessKey(AccessKeyDisabled, Some(date.minusMonths(13)))
+      val machineWithOneOldDisabledAccessKey = MachineUser("machine3", noAccessKey, machineAccessKeyOldAndDisabled, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldDisabledAccessKey), Seq(humanWithOneOldDisabledAccessKey))
       identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
     }
     "given no users with access keys, return an empty list" in {
+      val humanWithNoKeys = HumanUser("jorge.azevedo", true, noAccessKey, noAccessKey, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanWithNoKeys))
       identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
     }
     "given no vulnerable access keys, return an empty list" in {
+      val machineAccessKeyHealthyAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(11)))
+      val machineWithHealthyKey = MachineUser("machine4", noAccessKey, machineAccessKeyHealthyAndEnabled, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(machineWithHealthyKey), Seq(humanWithHealthyKey))
       identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
     }
@@ -85,7 +87,138 @@ class IamRemediationTest extends FreeSpec with Matchers {
   }
 
   "calculateOutstandingOperations" - {
-    "TODO" ignore {}
+    // human activities - warning
+    val humanActivityWarningLastNotificationGreaterThanCadence = IamRemediationActivity(account.id, humanWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenWarningAndFinalNotification + 1), Warning, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    val humanActivityWarningLastNotificationEqualToCadence = IamRemediationActivity(account.id, humanWithTwoOldEnabledAccessKeys.username, date.minusDays(daysBetweenWarningAndFinalNotification), Warning, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    // human activities - final
+    val humanActivityFinalLastNotificationGreaterThanCadence = IamRemediationActivity(account.id, humanWithTwoOldEnabledAccessKeys.username, date.minusDays(daysBetweenFinalNotificationAndRemediation + 1), FinalWarning, OutdatedCredential, humanAccessKeyOldAndEnabled2.lastRotated.get)
+    val humanActivityFinalLastNotificationEqualToCadence = IamRemediationActivity(account.id, humanWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenFinalNotificationAndRemediation), FinalWarning, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    // human activities - remediation
+    val humanActivityRemediationUnhealthy = IamRemediationActivity(account.id, humanWithOneOldEnabledAccessKey.username, date, Remediation, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    // human users
+    val humanBothKeysRequireAction = IamUserRemediationHistory(account, humanWithTwoOldEnabledAccessKeys, List(humanActivityFinalLastNotificationGreaterThanCadence, humanActivityWarningLastNotificationEqualToCadence))
+    val humanOneKeyRequiresAction = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(humanActivityWarningLastNotificationGreaterThanCadence))
+    val humanOneKeyFinalWarning = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(humanActivityWarningLastNotificationEqualToCadence, humanActivityFinalLastNotificationEqualToCadence))
+    val humanOneKeyRemediation = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(humanActivityWarningLastNotificationEqualToCadence, humanActivityFinalLastNotificationEqualToCadence, humanActivityRemediationUnhealthy))
+    // machine activities - warning
+    val machineActivityWarningLastNotificationEqualToCadence = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenWarningAndFinalNotification), Warning, OutdatedCredential, machineAccessKeyOldAndEnabled.lastRotated.get)
+    val machineActivityWarningKeyLastRotatedEqualCadenceThreshold = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusWeeks(3), Warning, OutdatedCredential, machineAccessKeyOldAndEnabledOnTimeThreshold.lastRotated.get)
+    // machine access keys
+    val machineWithTwoOldEnabledAccessKeys = MachineUser("machine5", machineAccessKeyOldAndEnabledOnTimeThreshold, machineAccessKeyOldAndEnabled, Green, None, None, Nil)
+    // machine users
+    val machineOneKeyWarning = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(machineActivityWarningLastNotificationEqualToCadence))
+    val machineTwoKeysRequireAction = IamUserRemediationHistory(account, machineWithTwoOldEnabledAccessKeys, List(machineActivityWarningLastNotificationEqualToCadence, machineActivityWarningKeyLastRotatedEqualCadenceThreshold))
+
+
+    "given two users, each with 2 keys that require operations, output a list of size 4" in {
+      calculateOutstandingOperations(List(humanBothKeysRequireAction, machineTwoKeysRequireAction), date) should have length 4
+    }
+    "given two users, each with 1 key that requires an operation, output a list of size 2" in {
+      calculateOutstandingOperations(List(humanOneKeyRequiresAction,  machineOneKeyWarning), date) should have length 2
+    }
+    "given one user with 2 keys that require an operation, output a list of size 2" in {
+      calculateOutstandingOperations(List(machineTwoKeysRequireAction), date) should have length 2
+    }
+    "given one user with 1 key that requires an operation, output a list of size 1" in {
+      calculateOutstandingOperations(List(humanOneKeyRequiresAction), date) should have length 1
+    }
+    // this scenario should never happen, keeping this test here to note this.
+    "given an empty input list, return an empty output list" in {
+      calculateOutstandingOperations(Nil, date) shouldEqual Nil
+    }
+
+    "identifyRemediationOperation" - {
+      "given IamRemediationActivity is a None, return Warning operation" in {
+        val result = identifyRemediationOperation(mostRecentRemediationActivity = None, now = date, humanBothKeysRequireAction).map(_.iamRemediationActivityType)
+        result shouldBe Some(Warning)
+      }
+      "if the most recent activity is a Warning with a date more than `Config.daysBetweenWarningAndFinalNotification` days ago, return a Final operation" in {
+        val input = activity(daysBetweenWarningAndFinalNotification + 1, Warning, humanAccessKeyOldAndEnabled1)
+        val result = identifyRemediationOperation(Some(input), date, humanOneKeyRequiresAction).map(_.iamRemediationActivityType)
+        result shouldBe Some(FinalWarning)
+      }
+      "if the most recent activity is a Warning with a date exactly `Config.daysBetweenWarningAndFinalNotification` days ago, return a Final operation" in {
+        val input = activity(daysBetweenWarningAndFinalNotification, Warning, machineAccessKeyOldAndEnabled)
+        val result = identifyRemediationOperation(Some(input), date, machineOneKeyWarning).map(_.iamRemediationActivityType)
+        result shouldBe Some(FinalWarning)
+      }
+      "if the most recent activity is a Warning with a date less than `Config.daysBetweenWarningAndFinalNotification` days ago, return a None" in {
+        val machineActivityWarningHealthy = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenWarningAndFinalNotification - 1), Warning, OutdatedCredential, machineAccessKeyOldAndEnabled.lastRotated.get)
+        val machineOneWarningKeyDoesNotRequireAction = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(machineActivityWarningHealthy))
+        val input = activity(daysBetweenWarningAndFinalNotification - 1, Warning, machineAccessKeyOldAndEnabled)
+        val result = identifyRemediationOperation(Some(input), date, machineOneWarningKeyDoesNotRequireAction).map(_.iamRemediationActivityType)
+        result shouldBe empty
+      }
+      "if the most recent activity is a Final with a date more than `Config.daysBetweenFinalNotificationAndRemediation` days ago, return a Remediation operation" in {
+        val input = activity(daysBetweenFinalNotificationAndRemediation + 1, FinalWarning, humanAccessKeyOldAndEnabled1)
+        val result = identifyRemediationOperation(Some(input), date, humanBothKeysRequireAction).map(_.iamRemediationActivityType)
+        result shouldBe Some(Remediation)
+      }
+      "if the most recent activity is a Final with a date exactly `Config.daysBetweenFinalNotificationAndRemediation` days ago, return a Remediation operation" in {
+        val input = activity(daysBetweenFinalNotificationAndRemediation, FinalWarning, humanAccessKeyOldAndEnabled1)
+        val result = identifyRemediationOperation(Some(input), date, humanOneKeyFinalWarning).map(_.iamRemediationActivityType)
+        result shouldBe Some(Remediation)
+      }
+      "if the most recent activity is a Final with a date less than `Config.daysBetweenFinalNotificationAndRemediation` days ago, return a None" in {
+        val machineActivityFinalNotificationLessThanCadence = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenFinalNotificationAndRemediation - 1), FinalWarning, OutdatedCredential, machineAccessKeyOldAndEnabled.lastRotated.get)
+        val machineOneFinalKeyDoesNotRequireAction = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(machineActivityFinalNotificationLessThanCadence))
+        val input = activity(daysBetweenFinalNotificationAndRemediation - 1, FinalWarning, machineAccessKeyOldAndEnabled)
+        val result = identifyRemediationOperation(Some(input), date, machineOneFinalKeyDoesNotRequireAction).map(_.iamRemediationActivityType)
+        result shouldBe empty
+      }
+      // The most recent activity being a Remediation is an edge case, because it means that the access key has not been successfully disabled.
+      // In this edge case, set the operation to Remediation so that Security HQ can try to disable the key again.
+      "if the most recent activity is a Remediation, return a Remediation" in {
+        val input = activity(1, Remediation, humanAccessKeyOldAndEnabled1)
+        val result = identifyRemediationOperation(Some(input), date, humanOneKeyRemediation).map(_.iamRemediationActivityType)
+        result shouldBe Some(Remediation)
+      }
+    }
+    "identifyMostRecentIamRemediationActivity" - {
+      "if the key's most recent activity is Warning, return Warning" in {
+        val key = machineAccessKeyOldAndEnabled
+        val recentActivity = activity(daysBetweenWarningAndFinalNotification, Warning, key)
+        val history = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(recentActivity))
+        val result = identifyMostRecentActivity(history, key)
+        result.map(_.iamRemediationActivityType) shouldBe Some(Warning)
+      }
+      "if the key's most recent activity is Final, return Final" in {
+        val key = humanAccessKeyOldAndEnabled1
+        val recentActivity = activity(daysBetweenFinalNotificationAndRemediation, FinalWarning, key)
+        val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(recentActivity))
+        val result = identifyMostRecentActivity(history, key)
+        result.map(_.iamRemediationActivityType) shouldBe Some(FinalWarning)
+      }
+      "if the key's most recent activity is Remediation, return Remediation" in {
+        val key = humanAccessKeyOldAndEnabled1
+        val recentActivity = activity(1, Remediation, key)
+        val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(recentActivity))
+        val result = identifyMostRecentActivity(history, key)
+        result.map(_.iamRemediationActivityType) shouldBe Some(Remediation)
+      }
+      "given a key does not have any activity, return None" in {
+        val recentActivity = Nil
+        val machineNoActivity = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey2, recentActivity)
+        identifyMostRecentActivity(machineNoActivity, machineAccessKeyOldAndEnabledOnTimeThreshold) shouldBe empty
+      }
+    }
+    "identifyVulnerableKeys" - {
+      "given a human user with 1 vulnerable access key, return that key" in {
+        identifyVulnerableKeys(humanOneKeyRequiresAction, date).map(_.lastRotated) shouldEqual List(humanAccessKeyOldAndEnabled1.lastRotated)
+      }
+      "given a machine user with 1 vulnerable access key, return that key" in {
+        identifyVulnerableKeys(machineOneKeyWarning, date).map(_.lastRotated) shouldEqual List(machineAccessKeyOldAndEnabled.lastRotated)
+      }
+      "given 2 vulnerable access keys, return both keys" in {
+        identifyVulnerableKeys(humanBothKeysRequireAction, date).map(_.lastRotated) shouldEqual List(humanAccessKeyOldAndEnabled1.lastRotated, humanAccessKeyOldAndEnabled2.lastRotated)
+      }
+      // this scenario should never happen, becuase this function should only be called if there is at least one problem access key.
+      "given no vulnerable access keys, return an empty list" in {
+        val humanActivityRemediationHealthy = IamRemediationActivity(account.id, humanWithHealthyKey.username, date.minusMonths(2), Remediation, OutdatedCredential, humanAccessKeyHealthAndEnabled.lastRotated.get)
+        val humanHealthy = IamUserRemediationHistory(account, humanWithHealthyKey, List(humanActivityRemediationHealthy))
+        identifyVulnerableKeys(humanHealthy, date) shouldBe empty
+      }
+    }
   }
 
   "partitionOperationsByAllowedAccounts" - {
@@ -157,4 +290,6 @@ class IamRemediationTest extends FreeSpec with Matchers {
       machineUser
       , Nil), Warning, OutdatedCredential, new DateTime())
   }
+  def activity(dayOffset: Int, activityType: IamRemediationActivityType, accessKey: AccessKey) =
+    IamRemediationActivity(account.id, "username", date.minusDays(dayOffset), activityType, OutdatedCredential, accessKey.lastRotated.get)
 }


### PR DESCRIPTION
## What does this change?
Adds tests and implementations for the logic required by the IAM Remediation job to determine which operations, if any,
are required for old credentials.

## What is the value of this?
Determines which work SHQ should do on vulnerable access keys.

## Will this require changes to config?
No.

## Any additional notes?
I have made some changes to the alert cadence and I would like to check that everyone in the team is happy with this. 

Also, I want to check what we would like to do in the case that an access key is enabled, vulnerable and its most recent operation type is `Remediation`. 

Ideally this case should never happen because all vulnerable credentials would be disabled if denoted as ready for Remediation, but in the case that it does I suggest the key is flagged for remediation again so that SHQ can attempt to disable it again in case something has gone wrong with the automated process when the CRON runs. This means that hopefully the next time the CRON runs the key would be disabled. It would be great to get thoughts on this.
