### PR TITLE
Add Notification Message logic for iam-remediation

### DIFF
--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -20,6 +20,8 @@ object Config {
   val iamHumanUserRotationCadence: Long = 90
   val iamMachineUserRotationCadence: Long = 365
   val iamAlertCadence: Int = 21
+  val daysBetweenWarningAndFinalNotification = 21
+  val daysBetweenFinalNotificationAndRemediation = 7
 
   // TODO fetch the region dynamically from the instance
   val region: Regions = Regions.EU_WEST_1

--- a/hq/app/logic/DateUtils.scala
+++ b/hq/app/logic/DateUtils.scala
@@ -1,7 +1,7 @@
 package logic
 
 import org.joda.time.{DateTime, DateTimeZone, Duration}
-import org.joda.time.format.ISODateTimeFormat
+import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 
 object DateUtils {
   val formatter = ISODateTimeFormat.dateTimeParser()
@@ -17,4 +17,6 @@ object DateUtils {
   def dayDiff(date: DateTime): Long =  new Duration(date, DateTime.now(DateTimeZone.UTC)).getStandardDays
 
   def printTime(date: DateTime): String = date.toString("HH:mm")
+
+  def printDay(day: DateTime): String = DateTimeFormat.forPattern("dd/MM/yyyy").print(day)
 }

--- a/hq/app/notifications/AnghammaradNotifications.scala
+++ b/hq/app/notifications/AnghammaradNotifications.scala
@@ -2,7 +2,9 @@ package notifications
 
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.gu.anghammarad.Anghammarad
-import com.gu.anghammarad.models.{Email, Notification, Preferred}
+import com.gu.anghammarad.models.{Email, Notification, Preferred, AwsAccount => Account}
+import config.Config.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
+import logic.DateUtils.printDay
 import model.{AwsAccount, IAMUser}
 import org.joda.time.DateTime
 import play.api.Logging
@@ -34,17 +36,34 @@ object AnghammaradNotifications extends Logging {
   }
 
   val channel = Preferred(Email)
+  val sourceSystem = "Security HQ Credentials Notifier"
 
-  def outdatedCredentialWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime): Notification = {
-    ???
+  def outdatedCredentialWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime, now: DateTime): Notification = {
+    val message =
+      s"""
+         |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
+         |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
+         |(if you're already planning on doing this, please ignore this message).
+         |If this is not rectified before ${printDay(now.plusDays(daysBetweenWarningAndFinalNotification))}, Security HQ will automatically disable this user."
+         |""".stripMargin
+    val subject = s"Action ${awsAccount.name}: Vulnerable credential"
+    Notification(subject, message + genericOutdatedCredentialText, Nil, List(Account(awsAccount.accountNumber)), channel, sourceSystem)
   }
 
   def passwordWithoutMfaWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime): Notification = {
     ???
   }
 
-  def outdatedCredentialFinalWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime): Notification = {
-    ???
+  def outdatedCredentialFinalWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime, now: DateTime): Notification = {
+    val message =
+      s"""
+         |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
+         |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
+         |(if you're already planning on doing this, please ignore this message).
+         |If this is not rectified before ${printDay(now.plusDays(daysBetweenFinalNotificationAndRemediation))}, Security HQ will automatically disable this user."
+         |""".stripMargin
+    val subject = s"Action ${awsAccount.name}: Vulnerable credential will be disabled soon"
+    Notification(subject, message + genericOutdatedCredentialText, Nil, List(Account(awsAccount.accountNumber)), channel, sourceSystem)
   }
 
   def passwordWithoutMfaFinalWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime): Notification = {
@@ -52,10 +71,27 @@ object AnghammaradNotifications extends Logging {
   }
 
   def outdatedCredentialRemediation(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime): Notification = {
-    ???
+    val message =
+      s"""
+         |The permanent credential, ${iamUser.username}, in ${awsAccount.name} was disabled today,
+         |because it was last rotated on ${printDay(problemCreationDate)}.
+         |If you still require the disabled user, add new access keys(s) and rotate regularly. Otherwise, delete them.
+         |""".stripMargin
+    val subject = s"DISABLED Vulnerable credential in ${awsAccount.name}"
+    Notification(subject, message + genericOutdatedCredentialText, Nil, List(Account(awsAccount.accountNumber)), channel, sourceSystem)
   }
 
   def passwordWithoutMfaRemediation(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime): Notification = {
     ???
+  }
+
+  private val genericOutdatedCredentialText = {
+    s"""
+       |To find out how to rectify this, see Security HQ (https://security-hq.gutools.co.uk/iam).
+       |Here is some helpful documentation on:
+       |rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,
+       |deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_console,
+       |If you have any questions, please contact the Developer Experience team: devx@theguardian.com.
+       |""".stripMargin
   }
 }

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -120,14 +120,14 @@ class IamRemediationService(
     (remediationOperation.iamRemediationActivityType, remediationOperation.iamProblem) match {
     // Outdated credentials
       case (Warning, OutdatedCredential) =>
-        val notification = AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate)
+        val notification = AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
         for {
           snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity)
         } yield snsId
 
       case (FinalWarning, OutdatedCredential) =>
-        val notification = AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate)
+        val notification = AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
         for {
           snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity)


### PR DESCRIPTION
## What does this change?
This PR adds the text for the notification messages that will be sent when an old credentials requires a warning, final and remediation notification.

## What is the value of this?
SHQ sends notifications when a credential has been identified as requiring rotation so that developers are reminded to rotate the credential's access key(s). If this does not happen, SHQ will disable the credential and a notification will be sent once this has happened. This PR crafts the text for those notification messages.

## Will this require changes to config?
No.

## Any additional notes?
No.
