### PR TITLE
Grant access for unrecognised user job to S3 bucket for Janus data

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -38,6 +38,38 @@ Object {
       "Description": "CIDR block from which access to Security HQ should be allowed",
       "Type": "String",
     },
+    "AuditDataS3BucketName": Object {
+      "Default": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "/security/security-hq/",
+            Object {
+              "Ref": "Stage",
+            },
+            "/audit-data-s3-bucket/name",
+          ],
+        ],
+      },
+      "Description": "Name of the S3 bucket to fetch auditable data from (e.g. Janus data)",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+    "AuditDataS3BucketPath": Object {
+      "Default": Object {
+        "Fn::Join": Array [
+          "",
+          Array [
+            "/security/security-hq/",
+            Object {
+              "Ref": "Stage",
+            },
+            "/audit-data-s3-bucket/path",
+          ],
+        ],
+      },
+      "Description": "Path of the directory in S3 containing auditable data (e.g. Janus data)",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "CloudwatchAlarmEmailDestination": Object {
       "Description": "Send Security HQ cloudwatch alarms to this email address",
       "Type": "String",
@@ -1060,6 +1092,41 @@ dpkg -i /tmp/installer.deb",
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "S3AuditRead9DF4AE59": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:aws:s3:::",
+                    Object {
+                      "Ref": "AuditDataS3BucketName",
+                    },
+                    "/",
+                    Object {
+                      "Ref": "AuditDataS3BucketPath",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3AuditRead9DF4AE59",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "SSMRunCommandPolicy244E1613": Object {
       "Properties": Object {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -11,8 +11,8 @@ import {
   Peer,
 } from '@aws-cdk/aws-ec2';
 import { EmailSubscription } from '@aws-cdk/aws-sns-subscriptions';
-import { Duration, RemovalPolicy } from '@aws-cdk/core';
 import type { App, CfnElement } from '@aws-cdk/core';
+import { Duration, RemovalPolicy } from '@aws-cdk/core';
 import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
 import { Stage } from '@guardian/cdk/lib/constants/stage';
 import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
@@ -21,6 +21,7 @@ import {
   GuDistributionBucketParameter,
   GuParameter,
   GuStack,
+  GuStringParameter,
 } from '@guardian/cdk/lib/constructs/core';
 import type { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
@@ -28,6 +29,7 @@ import {
   GuAllowPolicy,
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
+  GuGetS3ObjectsPolicy,
   GuPutCloudwatchMetricsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
@@ -69,6 +71,27 @@ export class SecurityHQ extends GuStack {
       }
     );
 
+    const auditDataS3BucketName = new GuStringParameter(
+      this,
+      'AuditDataS3BucketName',
+      {
+        description:
+          'Name of the S3 bucket to fetch auditable data from (e.g. Janus data)',
+        default: `/${this.stack}/${SecurityHQ.app.app}/${this.stage}/audit-data-s3-bucket/name`,
+        fromSSM: true,
+      }
+    );
+    const auditDataS3BucketPath = new GuStringParameter(
+      this,
+      'AuditDataS3BucketPath',
+      {
+        description:
+          'Path of the directory in S3 containing auditable data (e.g. Janus data)',
+        default: `/${this.stack}/${SecurityHQ.app.app}/${this.stage}/audit-data-s3-bucket/path`,
+        fromSSM: true,
+      }
+    );
+
     const domainNames = {
       [Stage.CODE]: { domainName: 'security-hq.code.dev-gutools.co.uk' },
       [Stage.PROD]: { domainName: 'security-hq.gutools.co.uk' },
@@ -100,6 +123,10 @@ dpkg -i /tmp/installer.deb`,
       roleConfiguration: {
         additionalPolicies: [
           new GuPutCloudwatchMetricsPolicy(this),
+          new GuGetS3ObjectsPolicy(this, 'S3AuditRead', {
+            bucketName: auditDataS3BucketName.valueAsString,
+            paths: [auditDataS3BucketPath.valueAsString],
+          }),
           new GuDynamoDBReadPolicy(this, 'DynamoRead', {
             tableName: table.tableName,
           }),

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -6,13 +6,13 @@ import com.amazonaws.auth.{AWSCredentialsProviderChain, DefaultAWSCredentialsPro
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import com.amazonaws.services.ec2.AmazonEC2AsyncClientBuilder
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder
 import com.google.cloud.securitycenter.v1.{SecurityCenterClient, SecurityCenterSettings}
 import config.Config
 import controllers._
 import filters.HstsFilter
 import model.AwsAccount
-import org.quartz.impl.StdSchedulerFactory
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -22,8 +22,6 @@ import play.api.{BuiltInComponentsFromContext, Logging}
 import play.filters.csrf.CSRFComponents
 import router.Routes
 import schedule.unrecognised.IamUnrecognisedUserJob
-import schedule.vulnerable.IamVulnerableUserJob
-import schedule.{AwsDynamoAlertService, JobScheduler}
 import services.{CacheService, MetricService}
 import utils.attempt.Attempt
 
@@ -91,7 +89,11 @@ class AppComponents(context: Context)
   private val securityCenterClient = SecurityCenterClient.create(securityCenterSettings)
   private val dynamoDbClient = AmazonDynamoDBClientBuilder.standard()
     .withCredentials(securityCredentialsProvider)
-    .withRegion(Config.region.getName)
+    .withRegion(Config.region)
+    .build()
+  private val securityS3Client = AmazonS3ClientBuilder.standard()
+    .withCredentials(securityCredentialsProvider)
+    .withRegion(Config.region)
     .build()
 
   private val cacheService = new CacheService(
@@ -116,6 +118,8 @@ class AppComponents(context: Context)
     environment,
     cacheService
   )
+
+  val unrecognisedUserJob = new IamUnrecognisedUserJob(cacheService, securitySnsClient, securityS3Client, iamClients, configuration)(executionContext)
 
   override def router: Router = new Routes(
     httpErrorHandler,

--- a/hq/app/aws/s3/S3.scala
+++ b/hq/app/aws/s3/S3.scala
@@ -1,6 +1,5 @@
 package aws.s3
 
-import aws.AwsClient
 import com.amazonaws.services.s3.AmazonS3
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -8,11 +7,11 @@ import scala.io.BufferedSource
 import scala.util.control.NonFatal
 
 object S3 {
-  def getS3Object(s3Client: AwsClient[AmazonS3], bucket: String, key: String): Attempt[BufferedSource] = {
+  def getS3Object(s3Client: AmazonS3, bucket: String, key: String): Attempt[BufferedSource] = {
     try {
       Attempt.Right {
         scala.io.Source
-          .fromInputStream(s3Client.client.getObject(bucket, key).getObjectContent)
+          .fromInputStream(s3Client.getObject(bucket, key).getObjectContent)
       }
     } catch {
       case NonFatal(e) =>

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -1,16 +1,15 @@
 package config
 
-import java.io.FileInputStream
 import com.amazonaws.regions.Regions
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
 import model._
-import org.apache.commons.lang3.exception.ExceptionContext
 import play.api.Configuration
 import play.api.http.HttpConfiguration
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
+import java.io.FileInputStream
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -130,10 +129,9 @@ object Config {
       accounts <- getAllowedAccountsForStage(config)
       key <- getJanusDataFileKey(config)
       bucket <- getIamUnrecognisedUserBucket(config)
-      region <- getIamUnrecognisedUserBucketRegion(config)
       securityAccount <- getSecurityAccount(config)
       anghammaradSnsTopicArn <- getAnghammaradSNSTopicArn(config)
-    } yield UnrecognisedJobConfigProperties(accounts, key, bucket, Regions.fromName(region), securityAccount, anghammaradSnsTopicArn)
+    } yield UnrecognisedJobConfigProperties(accounts, key, bucket, securityAccount, anghammaradSnsTopicArn)
   }
 
   def getAnghammaradSNSTopicArn(config: Configuration): Attempt[String] = {

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.regions.Region
 import com.amazonaws.services.identitymanagement.model.AccessKeyMetadata
 import com.google.cloud.securitycenter.v1.Finding.Severity
 import com.gu.anghammarad.models.{App, Notification, Stack, Target, Stage => AnghammaradStage}
@@ -361,7 +361,6 @@ case class UnrecognisedJobConfigProperties(
   allowedAccounts: List[String],
   janusDataFileKey: String,
   janusUserBucket: String,
-  janusUserBucketRegion: Regions,
   securityAccount: AwsAccount,
   anghammaradSnsTopicArn: String
 )

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.gu.anghammarad.models.{AwsAccount => TargetAccount}
 import com.gu.janus.JanusConfig
-import config.Config.{getAnghammaradSNSTopicArn, getIamUnrecognisedUserConfig}
+import config.Config.getIamUnrecognisedUserConfig
 import model.{AccessKeyEnabled, CronSchedule, VulnerableUser, AwsAccount => Account}
 import play.api.{Configuration, Logging}
 import schedule.IamMessages.FormerStaff.disabledUsersMessage
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 class IamUnrecognisedUserJob(
   cacheService: CacheService,
   snsClient: AmazonSNSAsync,
-  s3Clients: AwsClients[AmazonS3],
+  s3Client: AmazonS3,
   iamClients: AwsClients[AmazonIdentityManagementAsync],
   config: Configuration
 )(implicit executionContext: ExecutionContext) extends JobRunner with Logging {
@@ -44,8 +44,7 @@ class IamUnrecognisedUserJob(
 
     val result = for {
       config <- getIamUnrecognisedUserConfig(config)
-      client <- s3Clients.get(config.securityAccount, config.janusUserBucketRegion)
-      s3Object <- getS3Object(client, config.janusUserBucket, config.janusDataFileKey)
+      s3Object <- getS3Object(s3Client, config.janusUserBucket, config.janusDataFileKey)
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
       accountCredsReports = getCredsReportDisplayForAccount(allCredsReports)

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -63,7 +63,6 @@ alert {
     iamDynamoTableName = ${IAM_DYNAMO_TABLE_NAME}
     iamUnrecognisedUserS3Bucket = ${IAM_UNRECOGNISED_USER_S3_BUCKET}
     iamUnrecognisedUserS3Key = ${IAM_UNRECOGNISED_USER_S3_KEY}
-    iamUnrecognisedUserS3BucketRegion = ${IAM_USER_S3_BUCKET_REGION}
     allowedAccountIds = ${ALLOWED_ACCOUNT_IDS}
 }
 


### PR DESCRIPTION
## What does this change?
This addresses a couple of issues identified while testing the unrecognised user job in the dev-playground account.

- The instance did not have access to the S3 bucket containing the Janus data, that has now been added in a42b20b38856c63c0315ca39c996d47b5cb17d76
- The S3 client used to fetch the data was from the set of clients we use to monitor watched accounts. In this case, we are trying to perform an action specific to security-hq and the security account, so we have switched to using a specific S3 client for that. This allows the app to make a successful get-object request to the resource because the credentials chain is appropriate for the task. d551d1e5da3b27daa1a97fcaf0eba867041fec6e

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Allows the job to perform its task by accessing S3

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
Yes, cdk updates included. I've already added the necessary SSM parameters.

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
We could remove the region parameter that's no longer used.

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
