### PR TITLE
Turn on unrecognised user job for allowed accounts

### DIFF
--- a/hq/app/AppLoader.scala
+++ b/hq/app/AppLoader.scala
@@ -1,7 +1,7 @@
 import config.LoggingConfig
 import logging.LogConfig
 import play.api.ApplicationLoader.Context
-import play.api.{Application, ApplicationLoader}
+import play.api.{Application, ApplicationLoader, Mode}
 
 import scala.concurrent.Future
 
@@ -19,10 +19,12 @@ class AppLoader extends ApplicationLoader {
 
     val components = new AppComponents(context)
 
-    components.quartzScheduler.start()
+    if (context.environment.mode != Mode.Test) {
+      components.quartzScheduler.start()
 
-    components.applicationLifecycle.addStopHook { () =>
-      Future.successful(components.quartzScheduler.shutdown())
+      components.applicationLifecycle.addStopHook { () =>
+        Future.successful(components.quartzScheduler.shutdown())
+      }
     }
 
     components.application

--- a/hq/app/AppLoader.scala
+++ b/hq/app/AppLoader.scala
@@ -19,6 +19,12 @@ class AppLoader extends ApplicationLoader {
 
     val components = new AppComponents(context)
 
+    components.quartzScheduler.start()
+
+    components.applicationLifecycle.addStopHook { () =>
+      Future.successful(components.quartzScheduler.shutdown())
+    }
+
     components.application
   }
 }

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -33,7 +33,6 @@ class IamUnrecognisedUserJob(
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
   override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {
     if (testMode) {
@@ -47,7 +46,7 @@ class IamUnrecognisedUserJob(
       s3Object <- getS3Object(s3Client, config.janusUserBucket, config.janusDataFileKey)
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
-      accountCredsReports = getCredsReportDisplayForAccount(allCredsReports)
+      accountCredsReports = getCredsReportDisplayForAccount(cacheService.getAllCredentials)
       allowedAccountsUnrecognisedUsers = unrecognisedUsersForAllowedAccounts(accountCredsReports, janusUsernames, config.allowedAccounts)
       _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(disableUser)
       notificationIds <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(sendNotification(_, testMode, config.anghammaradSnsTopicArn))

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -12,11 +12,11 @@ import model.{AccessKeyEnabled, CronSchedule, VulnerableUser, AwsAccount => Acco
 import play.api.{Configuration, Logging}
 import schedule.IamMessages.FormerStaff.disabledUsersMessage
 import schedule.IamMessages.disabledUsersSubject
+import schedule.JobRunner
 import schedule.Notifier.{notification, send}
 import schedule.unrecognised.IamUnrecognisedUsers.{getCredsReportDisplayForAccount, getJanusUsernames, makeFile, unrecognisedUsersForAllowedAccounts}
 import schedule.vulnerable.IamDisableAccessKeys.disableAccessKeys
 import schedule.vulnerable.IamRemovePassword.removePasswords
-import schedule.{CronSchedules, JobRunner}
 import services.CacheService
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -32,7 +32,8 @@ class IamUnrecognisedUserJob(
 )(implicit executionContext: ExecutionContext) extends JobRunner with Logging {
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
-  override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
+  //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
+  override val cronSchedule: CronSchedule = CronSchedule("0 0/15 10 ? * MON *", "Every 15 minutes from 10am until 11am, on Monday (for testing only)")
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -12,11 +12,11 @@ import model.{AccessKeyEnabled, CronSchedule, VulnerableUser, AwsAccount => Acco
 import play.api.{Configuration, Logging}
 import schedule.IamMessages.FormerStaff.disabledUsersMessage
 import schedule.IamMessages.disabledUsersSubject
-import schedule.JobRunner
 import schedule.Notifier.{notification, send}
 import schedule.unrecognised.IamUnrecognisedUsers.{getCredsReportDisplayForAccount, getJanusUsernames, makeFile, unrecognisedUsersForAllowedAccounts}
 import schedule.vulnerable.IamDisableAccessKeys.disableAccessKeys
 import schedule.vulnerable.IamRemovePassword.removePasswords
+import schedule.{CronSchedules, JobRunner}
 import services.CacheService
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -32,8 +32,7 @@ class IamUnrecognisedUserJob(
 )(implicit executionContext: ExecutionContext) extends JobRunner with Logging {
   override val id: String = "unrecognised-iam-users"
   override val description: String = "Check for and remove unrecognised human IAM users"
-  //override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
-  override val cronSchedule: CronSchedule = CronSchedule("0 0/15 10 ? * MON *", "Every 15 minutes from 10am until 11am, on Monday (for testing only)")
+  override val cronSchedule: CronSchedule = CronSchedules.everyWeekDay
   private val allCredsReports = cacheService.getAllCredentials
 
   def run(testMode: Boolean): Unit = {


### PR DESCRIPTION
## What does this change?
This turns on the unrecognised user job for allowed accounts. The job checks all human IAM users against Janus credentials using a `GoogleUsername` tag. Any users for which the tag exists, but there is no Janus access linked to that username, will have their access keys and password disabled.

For now, the only configured allowed account in production is dev-playground.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Releasing the feature which will increase the likelihood that the IAM access of leavers is removed in a timely fashion.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
Already made

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
While testing this, there were a couple of things to note that still haven't been addressed:
- The job is not entirely idempotent if run more regularly than the current schedule. This is because there is an assumption that the credentials report is up to date in identifying which users are human (and therefore when a password exists that needs disabling). In fact the credentials report may be up to 4 hours out of date, however we are currently only running the job daily. If we were to run the job more often then the consequence not major: unnecessary API calls to AWS, and failure messages in the logs/alerts.
- I was unable to view the notification, as there doesn't seem to be a target configured in anghammarad for the dev-playground account. If there are issues with the notification upon further testing in the deploy-tools account then I suggest we fix forward at that point rather than hold this up.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
