### PR TITLE
POC to use private config repo via Deploy Key

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -43,6 +43,18 @@ jobs:
         with:
           cache: 'yarn'
 
+      - name: Add SSH key for accessing @guardian/private-infrastructure-config
+        run: |
+          mkdir -m 700 ~/.ssh
+          
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+          echo '${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}' > ~/.ssh/id_ed25519
+          chmod 400 ~/.ssh/id_ed25519
+          
+          eval "$(ssh-agent)"
+          ssh-add
+
       # 1. Seed the build number with last number from TeamCity.
       #    Update `LAST_TEAMCITY_BUILD` as needed or remove entirely if changing Riff-Raff project name.
       # 2. Execute `script/ci`, a script that will compile, run tests etc.

--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,1 +1,2 @@
 jest.mock('@guardian/cdk/lib/constants/tracking-tag');
+jest.mock('@guardian/private-infrastructure-config');

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -34,10 +34,6 @@ Object {
       "Description": "Amazon Machine Image ID for the app security-hq. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
     },
-    "AccessRestrictionCidr": Object {
-      "Description": "CIDR block from which access to Security HQ should be allowed",
-      "Type": "String",
-    },
     "AuditDataS3BucketName": Object {
       "Default": Object {
         "Fn::Join": Array [
@@ -1023,20 +1019,8 @@ dpkg -i /tmp/installer.deb",
         "GroupDescription": "Allow restricted ingress from CIDR ranges",
         "SecurityGroupIngress": Array [
           Object {
-            "CidrIp": Object {
-              "Ref": "AccessRestrictionCidr",
-            },
-            "Description": Object {
-              "Fn::Join": Array [
-                "",
-                Array [
-                  "Allow access on port 443 from ",
-                  Object {
-                    "Ref": "AccessRestrictionCidr",
-                  },
-                ],
-              ],
-            },
+            "CidrIp": "192.168.1.1/22",
+            "Description": "Allow access on port 443 from 192.168.1.1/22",
             "FromPort": 443,
             "IpProtocol": "tcp",
             "ToPort": 443,

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -33,6 +33,7 @@ import {
   GuPutCloudwatchMetricsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
+import { GuardianPublicNetworks } from '@guardian/private-infrastructure-config';
 
 export class SecurityHQ extends GuStack {
   private static app: AppIdentity = {
@@ -58,18 +59,6 @@ export class SecurityHQ extends GuStack {
     defaultChild.overrideLogicalId('SecurityHqIamDynamoTable');
 
     const distBucket = GuDistributionBucketParameter.getInstance(this);
-
-    // TODO replace with config repo once token access for GHA is sorted
-    // (https://trello.com/c/zhdgXpmk/903-allow-github-actions-to-clone-private-infrastructure-config).
-    const accessRestrictionCidr = new GuParameter(
-      this,
-      'AccessRestrictionCidr',
-      {
-        description:
-          'CIDR block from which access to Security HQ should be allowed',
-        type: 'String',
-      }
-    );
 
     const auditDataS3BucketName = new GuStringParameter(
       this,
@@ -100,7 +89,7 @@ export class SecurityHQ extends GuStack {
     const ec2App = new GuEc2App(this, {
       access: {
         scope: AccessScope.RESTRICTED,
-        cidrRanges: [Peer.ipv4(accessRestrictionCidr.valueAsString)],
+        cidrRanges: [Peer.ipv4(GuardianPublicNetworks.London)],
       },
       app: 'security-hq',
       applicationPort: GuApplicationPorts.Play,

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@aws-cdk/assert": "1.132.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
-    "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git",
+    "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.0",
     "@types/jest": "^26.0.20",
     "@types/node": "14.14.37",
     "aws-cdk": "1.132.0",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@aws-cdk/assert": "1.132.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
+    "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git",
     "@types/jest": "^26.0.20",
     "@types/node": "14.14.37",
     "aws-cdk": "1.132.0",
@@ -26,8 +27,8 @@
     "typescript": "~4.2.2"
   },
   "dependencies": {
-    "@aws-cdk/aws-ec2": "1.132.0",
     "@aws-cdk/aws-cloudwatch": "1.132.0",
+    "@aws-cdk/aws-ec2": "1.132.0",
     "@aws-cdk/aws-events-targets": "1.132.0",
     "@aws-cdk/aws-iam": "1.132.0",
     "@aws-cdk/aws-lambda": "1.132.0",

--- a/cdk/script/generate
+++ b/cdk/script/generate
@@ -14,5 +14,5 @@ if [[ -z $APP ]]; then
 fi
 
 pushd "${ROOT_DIR}" > /dev/null || exit
-yarn --silent cdk synth --profile security --app="ts-node ${ROOT_DIR}/bin/${APP}.ts"  -o "${OUTPUT_DIR}" --path-metadata false --version-reporting false "*"
+yarn --silent cdk synth --quiet --profile security --app="ts-node ${ROOT_DIR}/bin/${APP}.ts"  -o "${OUTPUT_DIR}" --path-metadata false --version-reporting false "*"
 popd > /dev/null

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2554,6 +2554,10 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
+"@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git":
+  version "1.2.0"
+  resolved "git+ssh://git@github.com:guardian/private-infrastructure-config.git#3a6a1d88c0b7e195b8888b38520e7953e931a494"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -2554,9 +2554,9 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
-"@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git":
-  version "1.2.0"
-  resolved "git+ssh://git@github.com:guardian/private-infrastructure-config.git#3a6a1d88c0b7e195b8888b38520e7953e931a494"
+"@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.0":
+  version "1.1.3"
+  resolved "git+ssh://git@github.com:guardian/private-infrastructure-config.git#c1789051594a2dc5a21fd49f1bd571613131403b"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## What does this change?

POC of using a Github [Deploy Key](https://docs.github.com/en/developers/overview/managing-deploy-keys) (really an SSH key) for read access to the @guardian/private-infrastructure-config repo.

## What is the value of this?

Illustrate the concept before we decide whether to do further work.

The nice thing about Deploy Keys is that they provide read-only access to a specific repo. PATs, the alternative here, cannot be tightly scoped in this way.

Ultimately, the suggestion is we store the deploy key as an organisation secret but to test things here I've just added it as a repository secret.
