### PR TITLE
Revert "Grant access for unrecognised user job to S3 bucket for Janus data"

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -38,38 +38,6 @@ Object {
       "Description": "CIDR block from which access to Security HQ should be allowed",
       "Type": "String",
     },
-    "AuditDataS3BucketName": Object {
-      "Default": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "/security/security-hq/",
-            Object {
-              "Ref": "Stage",
-            },
-            "/audit-data-s3-bucket/name",
-          ],
-        ],
-      },
-      "Description": "Name of the S3 bucket to fetch auditable data from (e.g. Janus data)",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "AuditDataS3BucketPath": Object {
-      "Default": Object {
-        "Fn::Join": Array [
-          "",
-          Array [
-            "/security/security-hq/",
-            Object {
-              "Ref": "Stage",
-            },
-            "/audit-data-s3-bucket/path",
-          ],
-        ],
-      },
-      "Description": "Path of the directory in S3 containing auditable data (e.g. Janus data)",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
     "CloudwatchAlarmEmailDestination": Object {
       "Description": "Send Security HQ cloudwatch alarms to this email address",
       "Type": "String",
@@ -1092,41 +1060,6 @@ dpkg -i /tmp/installer.deb",
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "S3AuditRead9DF4AE59": Object {
-      "Properties": Object {
-        "PolicyDocument": Object {
-          "Statement": Array [
-            Object {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Resource": Object {
-                "Fn::Join": Array [
-                  "",
-                  Array [
-                    "arn:aws:s3:::",
-                    Object {
-                      "Ref": "AuditDataS3BucketName",
-                    },
-                    "/",
-                    Object {
-                      "Ref": "AuditDataS3BucketPath",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "S3AuditRead9DF4AE59",
-        "Roles": Array [
-          Object {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "SSMRunCommandPolicy244E1613": Object {
       "Properties": Object {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -11,8 +11,8 @@ import {
   Peer,
 } from '@aws-cdk/aws-ec2';
 import { EmailSubscription } from '@aws-cdk/aws-sns-subscriptions';
-import type { App, CfnElement } from '@aws-cdk/core';
 import { Duration, RemovalPolicy } from '@aws-cdk/core';
+import type { App, CfnElement } from '@aws-cdk/core';
 import { AccessScope, GuApplicationPorts, GuEc2App } from '@guardian/cdk';
 import { Stage } from '@guardian/cdk/lib/constants/stage';
 import { GuAlarm } from '@guardian/cdk/lib/constructs/cloudwatch';
@@ -21,7 +21,6 @@ import {
   GuDistributionBucketParameter,
   GuParameter,
   GuStack,
-  GuStringParameter,
 } from '@guardian/cdk/lib/constructs/core';
 import type { AppIdentity } from '@guardian/cdk/lib/constructs/core/identity';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
@@ -29,7 +28,6 @@ import {
   GuAllowPolicy,
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
-  GuGetS3ObjectsPolicy,
   GuPutCloudwatchMetricsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
@@ -71,27 +69,6 @@ export class SecurityHQ extends GuStack {
       }
     );
 
-    const auditDataS3BucketName = new GuStringParameter(
-      this,
-      'AuditDataS3BucketName',
-      {
-        description:
-          'Name of the S3 bucket to fetch auditable data from (e.g. Janus data)',
-        default: `/${this.stack}/${SecurityHQ.app.app}/${this.stage}/audit-data-s3-bucket/name`,
-        fromSSM: true,
-      }
-    );
-    const auditDataS3BucketPath = new GuStringParameter(
-      this,
-      'AuditDataS3BucketPath',
-      {
-        description:
-          'Path of the directory in S3 containing auditable data (e.g. Janus data)',
-        default: `/${this.stack}/${SecurityHQ.app.app}/${this.stage}/audit-data-s3-bucket/path`,
-        fromSSM: true,
-      }
-    );
-
     const domainNames = {
       [Stage.CODE]: { domainName: 'security-hq.code.dev-gutools.co.uk' },
       [Stage.PROD]: { domainName: 'security-hq.gutools.co.uk' },
@@ -123,10 +100,6 @@ dpkg -i /tmp/installer.deb`,
       roleConfiguration: {
         additionalPolicies: [
           new GuPutCloudwatchMetricsPolicy(this),
-          new GuGetS3ObjectsPolicy(this, 'S3AuditRead', {
-            bucketName: auditDataS3BucketName.valueAsString,
-            paths: [auditDataS3BucketPath.valueAsString],
-          }),
           new GuDynamoDBReadPolicy(this, 'DynamoRead', {
             tableName: table.tableName,
           }),

--- a/hq/app/aws/s3/S3.scala
+++ b/hq/app/aws/s3/S3.scala
@@ -1,5 +1,6 @@
 package aws.s3
 
+import aws.AwsClient
 import com.amazonaws.services.s3.AmazonS3
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -7,11 +8,11 @@ import scala.io.BufferedSource
 import scala.util.control.NonFatal
 
 object S3 {
-  def getS3Object(s3Client: AmazonS3, bucket: String, key: String): Attempt[BufferedSource] = {
+  def getS3Object(s3Client: AwsClient[AmazonS3], bucket: String, key: String): Attempt[BufferedSource] = {
     try {
       Attempt.Right {
         scala.io.Source
-          .fromInputStream(s3Client.getObject(bucket, key).getObjectContent)
+          .fromInputStream(s3Client.client.getObject(bucket, key).getObjectContent)
       }
     } catch {
       case NonFatal(e) =>

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -1,15 +1,16 @@
 package config
 
+import java.io.FileInputStream
 import com.amazonaws.regions.Regions
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
 import model._
+import org.apache.commons.lang3.exception.ExceptionContext
 import play.api.Configuration
 import play.api.http.HttpConfiguration
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
-import java.io.FileInputStream
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -129,9 +130,10 @@ object Config {
       accounts <- getAllowedAccountsForStage(config)
       key <- getJanusDataFileKey(config)
       bucket <- getIamUnrecognisedUserBucket(config)
+      region <- getIamUnrecognisedUserBucketRegion(config)
       securityAccount <- getSecurityAccount(config)
       anghammaradSnsTopicArn <- getAnghammaradSNSTopicArn(config)
-    } yield UnrecognisedJobConfigProperties(accounts, key, bucket, securityAccount, anghammaradSnsTopicArn)
+    } yield UnrecognisedJobConfigProperties(accounts, key, bucket, Regions.fromName(region), securityAccount, anghammaradSnsTopicArn)
   }
 
   def getAnghammaradSNSTopicArn(config: Configuration): Attempt[String] = {

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -1,6 +1,6 @@
 package model
 
-import com.amazonaws.regions.Region
+import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.identitymanagement.model.AccessKeyMetadata
 import com.google.cloud.securitycenter.v1.Finding.Severity
 import com.gu.anghammarad.models.{App, Notification, Stack, Target, Stage => AnghammaradStage}
@@ -361,6 +361,7 @@ case class UnrecognisedJobConfigProperties(
   allowedAccounts: List[String],
   janusDataFileKey: String,
   janusUserBucket: String,
+  janusUserBucketRegion: Regions,
   securityAccount: AwsAccount,
   anghammaradSnsTopicArn: String
 )

--- a/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
+++ b/hq/app/schedule/unrecognised/IamUnrecognisedUserJob.scala
@@ -7,7 +7,7 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sns.AmazonSNSAsync
 import com.gu.anghammarad.models.{AwsAccount => TargetAccount}
 import com.gu.janus.JanusConfig
-import config.Config.getIamUnrecognisedUserConfig
+import config.Config.{getAnghammaradSNSTopicArn, getIamUnrecognisedUserConfig}
 import model.{AccessKeyEnabled, CronSchedule, VulnerableUser, AwsAccount => Account}
 import play.api.{Configuration, Logging}
 import schedule.IamMessages.FormerStaff.disabledUsersMessage
@@ -26,7 +26,7 @@ import scala.util.control.NonFatal
 class IamUnrecognisedUserJob(
   cacheService: CacheService,
   snsClient: AmazonSNSAsync,
-  s3Client: AmazonS3,
+  s3Clients: AwsClients[AmazonS3],
   iamClients: AwsClients[AmazonIdentityManagementAsync],
   config: Configuration
 )(implicit executionContext: ExecutionContext) extends JobRunner with Logging {
@@ -44,7 +44,8 @@ class IamUnrecognisedUserJob(
 
     val result = for {
       config <- getIamUnrecognisedUserConfig(config)
-      s3Object <- getS3Object(s3Client, config.janusUserBucket, config.janusDataFileKey)
+      client <- s3Clients.get(config.securityAccount, config.janusUserBucketRegion)
+      s3Object <- getS3Object(client, config.janusUserBucket, config.janusDataFileKey)
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
       accountCredsReports = getCredsReportDisplayForAccount(allCredsReports)

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -63,6 +63,7 @@ alert {
     iamDynamoTableName = ${IAM_DYNAMO_TABLE_NAME}
     iamUnrecognisedUserS3Bucket = ${IAM_UNRECOGNISED_USER_S3_BUCKET}
     iamUnrecognisedUserS3Key = ${IAM_UNRECOGNISED_USER_S3_KEY}
+    iamUnrecognisedUserS3BucketRegion = ${IAM_USER_S3_BUCKET_REGION}
     allowedAccountIds = ${ALLOWED_ACCOUNT_IDS}
 }
 


### PR DESCRIPTION
Reverts guardian/security-hq#359

The parameter's default value uses Stage, which isn't available at this location. The actual error isn't super helpful for pointing at this, but we suspect it just means we get a `token` instead of a `String`, here.