### PR TITLE
ci: Attempt to improve build time

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -49,6 +49,9 @@ jobs:
         uses: guardian/actions-setup-node@v2.4.1
         with:
           cache: 'yarn'
+          cache-dependency-path: |
+            yarn.lock
+            cdk/yarn.lock
 
       - name: Add SSH key for accessing @guardian/private-infrastructure-config
         run: |

--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -42,7 +42,7 @@ jobs:
             ~/.ivy2/cache
             ~/.sbt
             ~/.coursier
-          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
+          key: sbt
 
       # (Respects .nvmrc)
       - name: Setup Node

--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           java-version: '8'
           distribution: 'adopt'
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.coursier
+          key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
       # (Respects .nvmrc)
       - name: Setup Node

--- a/script/ci
+++ b/script/ci
@@ -7,4 +7,4 @@ set -e
     ./script/ci
 )
 
-./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'
+sbt "project hq" "; clean; compile; riffRaffUpload"


### PR DESCRIPTION
## What does this change?

A couple of updates to the GitHub Actions CI build:
  - Cache more aggressively
  - Use native `sbt` rather than the script in the repo. The [repo's script](https://github.com/guardian/security-hq/blob/d2ddeeddb1a987cdaf9f5799d37dfa806693faa5/sbt#L39-L40) sets some memory options for the JVM which won't use all the [available memory](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) (7GB)

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

A reduction in build times means we can ship that much faster. These changes appear to bring the build time below 3 minutes (from ~5 mins). Not quite on the same level as it was in TeamCity, but an improvement nonetheless.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?

No.
<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?

No.
<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
