### PR TITLE
Implement IamRemediation/partitionOperationsByAllowedAccounts

### DIFF
--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -92,7 +92,8 @@ object IamRemediation extends Logging {
     * configured with a list of the AWS accounts that this instance is allowed to affect.
     */
   def partitionOperationsByAllowedAccounts(operations: List[RemediationOperation], allowedAwsAccountIds: List[String]): PartitionedRemediationOperations = {
-    ???
+    val (allowed, forbidden) = operations.partition(remediationOperation => allowedAwsAccountIds.contains(remediationOperation.vulnerableCandidate.awsAccount.id))
+    PartitionedRemediationOperations(allowed, forbidden)
   }
 
   /**

--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -92,7 +92,9 @@ object IamRemediation extends Logging {
     * configured with a list of the AWS accounts that this instance is allowed to affect.
     */
   def partitionOperationsByAllowedAccounts(operations: List[RemediationOperation], allowedAwsAccountIds: List[String]): PartitionedRemediationOperations = {
-    val (allowed, forbidden) = operations.partition(remediationOperation => allowedAwsAccountIds.contains(remediationOperation.vulnerableCandidate.awsAccount.id))
+    val (allowed, forbidden) = operations.partition { remediationOperation =>
+      allowedAwsAccountIds.contains(remediationOperation.vulnerableCandidate.awsAccount.id)
+    }
     PartitionedRemediationOperations(allowed, forbidden)
   }
 

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -15,6 +15,7 @@ import utils.attempt.Attempt
 
 import scala.concurrent.ExecutionContext
 
+
 /**
   * A collection of jobs for automatically fixing IAM problems in our AWS accounts.
   *

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -15,7 +15,6 @@ import utils.attempt.Attempt
 
 import scala.concurrent.ExecutionContext
 
-
 /**
   * A collection of jobs for automatically fixing IAM problems in our AWS accounts.
   *

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -1,6 +1,5 @@
 package logic
 
-<<<<<<< HEAD
 import config.Config
 import logic.IamRemediation.{getCredsReportDisplayForAccount, identifyAllUsersWithOutdatedCredentials, identifyUsersWithOutdatedCredentials}
 import model.{AccessKey, AccessKeyDisabled, AccessKeyEnabled, AwsAccount, CredentialReportDisplay, Green, HumanUser, MachineUser, NoKey}

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -98,36 +98,37 @@ class IamRemediationTest extends FreeSpec with Matchers {
     "if allowedAccounts is empty" - {
       val allowedAccounts = Nil
       "then all operations are not allowed" in {
-        val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
-        result shouldEqual operations
+        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        forbidden shouldEqual operations
       }
       "then allowed operations is empty" in {
-        val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
-        result shouldEqual Nil
+        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+        allowed shouldEqual Nil
       }
 
       "if there is one allowed account provided" - {
         val allowedAccounts = List("a")
-        "allowed operations matches provided allowed account" in {
-          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
-          result shouldEqual List(operationsForAccountA)
+        "then all operations that don't match provided allowed account are forbidden" in {
+          val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+          forbidden shouldEqual List(operationsForAccountB, operationsForAccountC)
         }
-        "operationsOnAccountsThatAreNotAllowed contains all operations that do not match provided allowed account" in {
-          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
-          result shouldEqual List(operationsForAccountB, operationsForAccountC)
+        "then allowed operations matches provided allowed account" in {
+          val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+          allowed shouldEqual List(operationsForAccountA)
         }
       }
 
       "if multiple allowed accounts are provided" - {
         val allowedAccounts = List("a", "b")
-        "matching operations are allowed" in {
-          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
-          result shouldEqual List(operationsForAccountA, operationsForAccountB)
+        "then all operations that don't match any allowed accounts are forbidden" in {
+          val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+          forbidden shouldEqual List(operationsForAccountC)
         }
-        "operations that don't match any account are forbidden" in {
-          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
-          result shouldEqual List(operationsForAccountC)
+        "then matching operations are allowed" in {
+          val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+          allowed shouldEqual List(operationsForAccountA, operationsForAccountB)
         }
+
       }
 
     }

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -130,6 +130,18 @@ class IamRemediationTest extends FreeSpec with Matchers {
         allowed shouldEqual List(operationsForAccountA, operationsForAccountB)
       }
     }
+
+    "if operations to partition is empty" - {
+      val allowedAccounts = List("a", "b")
+      "then forbidden operations should also be empty" in {
+        val forbidden = partitionOperationsByAllowedAccounts(Nil, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        forbidden shouldEqual Nil
+      }
+      "then allowed operations should also be empty" in {
+        val allowed = partitionOperationsByAllowedAccounts(Nil, allowedAccounts).allowedOperations
+        allowed shouldEqual Nil
+      }
+    }
   }
 
   "lookupCredentialId" - {

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -105,32 +105,30 @@ class IamRemediationTest extends FreeSpec with Matchers {
         val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
         allowed shouldEqual Nil
       }
+    }
 
-      "if there is one allowed account provided" - {
-        val allowedAccounts = List("a")
-        "then all operations that don't match provided allowed account are forbidden" in {
-          val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
-          forbidden shouldEqual List(operationsForAccountB, operationsForAccountC)
-        }
-        "then allowed operations matches provided allowed account" in {
-          val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
-          allowed shouldEqual List(operationsForAccountA)
-        }
+    "if there is one allowed account provided" - {
+      val allowedAccounts = List("a")
+      "then all operations that don't match provided allowed account are forbidden" in {
+        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        forbidden shouldEqual List(operationsForAccountB, operationsForAccountC)
       }
-
-      "if multiple allowed accounts are provided" - {
-        val allowedAccounts = List("a", "b")
-        "then all operations that don't match any allowed accounts are forbidden" in {
-          val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
-          forbidden shouldEqual List(operationsForAccountC)
-        }
-        "then matching operations are allowed" in {
-          val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
-          allowed shouldEqual List(operationsForAccountA, operationsForAccountB)
-        }
-
+      "then allowed operations matches provided allowed account" in {
+        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+        allowed shouldEqual List(operationsForAccountA)
       }
+    }
 
+    "if multiple allowed accounts are provided" - {
+      val allowedAccounts = List("a", "b")
+      "then all operations that don't match any allowed accounts are forbidden" in {
+        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        forbidden shouldEqual List(operationsForAccountC)
+      }
+      "then matching operations are allowed" in {
+        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+        allowed shouldEqual List(operationsForAccountA, operationsForAccountB)
+      }
     }
   }
 

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -1,8 +1,10 @@
 package logic
 
+<<<<<<< HEAD
 import config.Config
 import logic.IamRemediation.{getCredsReportDisplayForAccount, identifyAllUsersWithOutdatedCredentials, identifyUsersWithOutdatedCredentials}
 import model.{AccessKey, AccessKeyDisabled, AccessKeyEnabled, AwsAccount, CredentialReportDisplay, Green, HumanUser, MachineUser, NoKey}
+import model.iamremediation.{IamUserRemediationHistory, OutdatedCredential, RemediationOperation, Warning}
 import org.joda.time.DateTime
 import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.{FailedAttempt, Failure}
@@ -88,7 +90,47 @@ class IamRemediationTest extends FreeSpec with Matchers {
   }
 
   "partitionOperationsByAllowedAccounts" - {
-    "TODO" ignore {}
+    val operationsForAccountA = operationForAccountId("a", "machineUser1")
+    val operationsForAccountB = operationForAccountId("b", "machineUser2")
+    val operationsForAccountC = operationForAccountId("c", "machineUser3")
+    val operations = List(operationsForAccountA, operationsForAccountB, operationsForAccountC)
+
+    "if allowedAccounts is empty" - {
+      val allowedAccounts = Nil
+      "then all operations are not allowed" in {
+        val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        result shouldEqual operations
+      }
+      "then allowed operations is empty" in {
+        val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+        result shouldEqual Nil
+      }
+
+      "if there is one allowed account provided" - {
+        val allowedAccounts = List("a")
+        "allowed operations matches provided allowed account" in {
+          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+          result shouldEqual List(operationsForAccountA)
+        }
+        "operationsOnAccountsThatAreNotAllowed contains all operations that do not match provided allowed account" in {
+          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+          result shouldEqual List(operationsForAccountB, operationsForAccountC)
+        }
+      }
+
+      "if multiple allowed accounts are provided" - {
+        val allowedAccounts = List("a", "b")
+        "matching operations are allowed" in {
+          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+          result shouldEqual List(operationsForAccountA, operationsForAccountB)
+        }
+        "operations that don't match any account are forbidden" in {
+          val result = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+          result shouldEqual List(operationsForAccountC)
+        }
+      }
+
+    }
   }
 
   "lookupCredentialId" - {
@@ -97,5 +139,12 @@ class IamRemediationTest extends FreeSpec with Matchers {
 
   "formatRemediationOperation" - {
     "TODO" ignore {}
+  }
+
+  def operationForAccountId(id: String, username: String): RemediationOperation = {
+    val machineUser = MachineUser(username, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
+    RemediationOperation(IamUserRemediationHistory(AwsAccount(id, "", "", ""),
+      machineUser
+      , Nil), Warning, OutdatedCredential, new DateTime())
   }
 }


### PR DESCRIPTION
## What does this change?


This takes a list of RemedationOperations and splits it in 2, according to list of accounts we are allowed to perform remediation operations in

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?

No
<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
