### PR TITLE
Implement formatRemediationOperation

### DIFF
--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -110,6 +110,10 @@ object IamRemediation extends Logging {
   }
 
   def formatRemediationOperation(remediationOperation: RemediationOperation): String = {
-    ???
+    val problem = remediationOperation.iamProblem
+    val activity = remediationOperation.iamRemediationActivityType
+    val username = remediationOperation.vulnerableCandidate.iamUser.username
+    val accountId = remediationOperation.vulnerableCandidate.awsAccount.id
+    s"$problem $activity for user $username from account $accountId"
   }
 }

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -2,7 +2,7 @@ package logic
 
 import config.Config
 import logic.IamRemediation.{formatRemediationOperation, getCredsReportDisplayForAccount, identifyAllUsersWithOutdatedCredentials, identifyUsersWithOutdatedCredentials, partitionOperationsByAllowedAccounts}
-import model.iamremediation.{FinalWarning, IamUserRemediationHistory, OutdatedCredential, PasswordMissingMFA, Remediation, RemediationOperation}
+import model.{FinalWarning, IamUserRemediationHistory, OutdatedCredential, PasswordMissingMFA, Remediation, RemediationOperation}
 import model.{AccessKey, AccessKeyDisabled, AccessKeyEnabled, AwsAccount, CredentialReportDisplay, Green, HumanUser, MachineUser, NoKey}
 import model.{IamUserRemediationHistory, OutdatedCredential, RemediationOperation, Warning}
 import org.joda.time.DateTime

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -1,7 +1,8 @@
 package logic
 
 import config.Config
-import logic.IamRemediation.{getCredsReportDisplayForAccount, identifyAllUsersWithOutdatedCredentials, identifyUsersWithOutdatedCredentials, partitionOperationsByAllowedAccounts}
+import logic.IamRemediation.{formatRemediationOperation, getCredsReportDisplayForAccount, identifyAllUsersWithOutdatedCredentials, identifyUsersWithOutdatedCredentials, partitionOperationsByAllowedAccounts}
+import model.iamremediation.{FinalWarning, IamUserRemediationHistory, OutdatedCredential, PasswordMissingMFA, Remediation, RemediationOperation}
 import model.{AccessKey, AccessKeyDisabled, AccessKeyEnabled, AwsAccount, CredentialReportDisplay, Green, HumanUser, MachineUser, NoKey}
 import model.{IamUserRemediationHistory, OutdatedCredential, RemediationOperation, Warning}
 import org.joda.time.DateTime
@@ -148,7 +149,23 @@ class IamRemediationTest extends FreeSpec with Matchers {
   }
 
   "formatRemediationOperation" - {
-    "TODO" ignore {}
+    val date = new DateTime(2021, 1, 1, 1, 1)
+    val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
+    val user = HumanUser("jorge.azevedo", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
+    val iamUserRemediationHistory = IamUserRemediationHistory(account, user, Nil)
+
+    "should return a readable message for PasswordMissingMFA" in {
+      val operation = RemediationOperation(iamUserRemediationHistory, Remediation, PasswordMissingMFA, date)
+      val expectedString = "PasswordMissingMFA Remediation for user jorge.azevedo from account testAccountId"
+      formatRemediationOperation(operation) shouldEqual expectedString
+    }
+
+    "should return a readable message for OutdatedCredentials" in {
+      val operation = RemediationOperation(iamUserRemediationHistory, FinalWarning, OutdatedCredential, date)
+      val expectedString = "OutdatedCredential FinalWarning for user jorge.azevedo from account testAccountId"
+      formatRemediationOperation(operation) shouldEqual expectedString
+
+    }
   }
 
   def operationForAccountId(id: String, username: String): RemediationOperation = {

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -151,20 +151,19 @@ class IamRemediationTest extends FreeSpec with Matchers {
   "formatRemediationOperation" - {
     val date = new DateTime(2021, 1, 1, 1, 1)
     val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
-    val user = HumanUser("jorge.azevedo", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
-    val iamUserRemediationHistory = IamUserRemediationHistory(account, user, Nil)
+    val humanUser = HumanUser("human.user", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
+    val machineUser = MachineUser("machine.user", AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
 
     "should return a readable message for PasswordMissingMFA" in {
+      val iamUserRemediationHistory = IamUserRemediationHistory(account, humanUser, Nil)
       val operation = RemediationOperation(iamUserRemediationHistory, Remediation, PasswordMissingMFA, date)
-      val expectedString = "PasswordMissingMFA Remediation for user jorge.azevedo from account testAccountId"
-      formatRemediationOperation(operation) shouldEqual expectedString
+      formatRemediationOperation(operation) shouldEqual "PasswordMissingMFA Remediation for user human.user from account testAccountId"
     }
 
     "should return a readable message for OutdatedCredentials" in {
+      val iamUserRemediationHistory = IamUserRemediationHistory(account, machineUser, Nil)
       val operation = RemediationOperation(iamUserRemediationHistory, FinalWarning, OutdatedCredential, date)
-      val expectedString = "OutdatedCredential FinalWarning for user jorge.azevedo from account testAccountId"
-      formatRemediationOperation(operation) shouldEqual expectedString
-
+      formatRemediationOperation(operation) shouldEqual "OutdatedCredential FinalWarning for user machine.user from account testAccountId"
     }
   }
 


### PR DESCRIPTION
## What does this change?

This implements `formatRemediationOperation`, which is called by `dummyOperation` to log what it would have done. In context, dummyOperation will produce 2 logs lines that look like this

```
Remediation operation skipped because testAccountId is not configured for remediation
Skipping remediation action: OutdatedCredential FinalWarning for user machine.user from account testAccountId
```

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?

Depending on the purpose of the `dummyOperation` log this might be insufficient. For example, it doesn't say which key it's referring to, and doesn't shed any light on why it's doing this particular operation.