### PR TITLE
IAM Remediation: calculateOutstandingOperations

### DIFF
--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -18,8 +18,7 @@ import scala.util.Try
 object Config {
   val iamHumanUserRotationCadence: Long = 90
   val iamMachineUserRotationCadence: Long = 365
-  val iamAlertCadence: Int = 21
-  val daysBetweenWarningAndFinalNotification = 21
+  val daysBetweenWarningAndFinalNotification = 7
   val daysBetweenFinalNotificationAndRemediation = 7
 
   // TODO fetch the region dynamically from the instance

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -1,16 +1,30 @@
 package logic
 
 import config.Config
-import logic.IamRemediation.{formatRemediationOperation, getCredsReportDisplayForAccount, identifyAllUsersWithOutdatedCredentials, identifyUsersWithOutdatedCredentials, partitionOperationsByAllowedAccounts}
-import model.{FinalWarning, IamUserRemediationHistory, OutdatedCredential, PasswordMissingMFA, Remediation, RemediationOperation}
-import model.{AccessKey, AccessKeyDisabled, AccessKeyEnabled, AwsAccount, CredentialReportDisplay, Green, HumanUser, MachineUser, NoKey}
-import model.{IamUserRemediationHistory, OutdatedCredential, RemediationOperation, Warning}
+import config.Config.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
+import logic.IamRemediation._
+import model._
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.Inside.inside
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
 import utils.attempt.{FailedAttempt, Failure}
 
 
-class IamRemediationTest extends FreeSpec with Matchers {
+class IamRemediationTest extends FreeSpec with Matchers with OptionValues {
+  val date = new DateTime(2021, 1, 1, 1, 1)
+  val humanAccessKeyOldAndEnabled1 = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))
+  val humanAccessKeyOldAndEnabled2 = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))
+  val machineAccessKeyOldAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(13)))
+  val machineAccessKeyOldAndEnabledOnTimeThreshold = AccessKey(AccessKeyEnabled, Some(date.minusDays(Config.iamMachineUserRotationCadence.toInt)))
+  val humanAccessKeyHealthAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(1)))
+  val noAccessKey = AccessKey(NoKey, None)
+  val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
+  val humanWithOneOldEnabledAccessKey = HumanUser("amina.adewusi", true, humanAccessKeyOldAndEnabled1, noAccessKey, Green, None, None, Nil)
+  val humanWithTwoOldEnabledAccessKeys = HumanUser("nic.long", true, humanAccessKeyOldAndEnabled1, humanAccessKeyOldAndEnabled2, Green, None, None, Nil)
+  val humanWithHealthyKey = HumanUser("jon.soul", true, noAccessKey, humanAccessKeyHealthAndEnabled, Green, None, None, Nil)
+  val machineWithOneOldEnabledAccessKey = MachineUser("machine1", machineAccessKeyOldAndEnabled, noAccessKey, Green, None, None, Nil)
+  val machineWithOneOldEnabledAccessKey2 = MachineUser("machine2", machineAccessKeyOldAndEnabledOnTimeThreshold, noAccessKey, Green, None, None, Nil)
+
   "getCredsReportDisplayForAccount" - {
     val failedAttempt: FailedAttempt = FailedAttempt(Failure("error", "error", 500))
 
@@ -36,25 +50,6 @@ class IamRemediationTest extends FreeSpec with Matchers {
   }
 
   "identifyUsersWithOutdatedCredentials" - {
-    val date = new DateTime(2021, 1, 1, 1, 1)
-    val humanAccessKeyOldAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))
-    val humanAccessKeyOldAndDisabled = AccessKey(AccessKeyDisabled, Some(date.minusMonths(4)))
-    val machineAccessKeyOldAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(13)))
-    val machineAccessKeyOldAndEnabledOnTimeThreshold = AccessKey(AccessKeyEnabled, Some(date.minusDays(Config.iamMachineUserRotationCadence.toInt)))
-    val machineAccessKeyOldAndDisabled = AccessKey(AccessKeyDisabled, Some(date.minusMonths(13)))
-    val humanEnabledAccessKeyHealthy = AccessKey(AccessKeyEnabled, Some(date.minusMonths(1)))
-    val machineEnabledAccessKeyHealthy = AccessKey(AccessKeyEnabled, Some(date.minusMonths(11)))
-    val noAccessKey = AccessKey(NoKey, None)
-    val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
-    val humanWithOneOldEnabledAccessKey = HumanUser("amina.adewusi", true, humanAccessKeyOldAndEnabled, noAccessKey, Green, None, None, Nil)
-    val humanWithOneOldDisabledAccessKey = HumanUser("adam.fisher", true, noAccessKey, humanAccessKeyOldAndDisabled, Green, None, None, Nil)
-    val humanWithNoKeys = HumanUser("jorge.azevedo", true, noAccessKey, noAccessKey, Green, None, None, Nil)
-    val humanWithHealthyKey = HumanUser("jon.soul", true, noAccessKey, humanEnabledAccessKeyHealthy, Green, None, None, Nil)
-    val machineWithOneOldEnabledAccessKey = MachineUser("machine1", machineAccessKeyOldAndEnabled, noAccessKey, Green, None, None, Nil)
-    val machineWithOneOldEnabledAccessKey2 = MachineUser("machine2", machineAccessKeyOldAndEnabledOnTimeThreshold, noAccessKey, Green, None, None, Nil)
-    val machineWithOneOldDisabledAccessKey = MachineUser("machine3", noAccessKey, machineAccessKeyOldAndDisabled, Green, None, None, Nil)
-    val machineWithHealthyKey = MachineUser("machine4", noAccessKey, machineEnabledAccessKeyHealthy, Green, None, None, Nil)
-
     "given a vulnerable human user, return that user" in {
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanWithOneOldEnabledAccessKey))
       identifyUsersWithOutdatedCredentials(account, credsReport, date).map(_.username) shouldEqual List("amina.adewusi")
@@ -68,14 +63,20 @@ class IamRemediationTest extends FreeSpec with Matchers {
       identifyUsersWithOutdatedCredentials(account, credsReport, date).map(_.username) should contain allOf ("amina.adewusi", "machine1")
     }
     "given users with old disabled keys, return an empty list" in {
+      val humanWithOneOldDisabledAccessKey = HumanUser("adam.fisher", true, noAccessKey, AccessKey(AccessKeyDisabled, Some(date.minusMonths(4))), Green, None, None, Nil)
+      val machineAccessKeyOldAndDisabled = AccessKey(AccessKeyDisabled, Some(date.minusMonths(13)))
+      val machineWithOneOldDisabledAccessKey = MachineUser("machine3", noAccessKey, machineAccessKeyOldAndDisabled, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldDisabledAccessKey), Seq(humanWithOneOldDisabledAccessKey))
       identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
     }
     "given no users with access keys, return an empty list" in {
+      val humanWithNoKeys = HumanUser("jorge.azevedo", true, noAccessKey, noAccessKey, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanWithNoKeys))
       identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
     }
     "given no vulnerable access keys, return an empty list" in {
+      val machineAccessKeyHealthyAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(11)))
+      val machineWithHealthyKey = MachineUser("machine4", noAccessKey, machineAccessKeyHealthyAndEnabled, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(machineWithHealthyKey), Seq(humanWithHealthyKey))
       identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
     }
@@ -86,7 +87,163 @@ class IamRemediationTest extends FreeSpec with Matchers {
   }
 
   "calculateOutstandingOperations" - {
-    "TODO" ignore {}
+    // human activities - warning
+    val humanActivityWarningLastNotificationGreaterThanCadence = IamRemediationActivity(account.id, humanWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenWarningAndFinalNotification + 1), Warning, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    val humanActivityWarningLastNotificationEqualToCadence = IamRemediationActivity(account.id, humanWithTwoOldEnabledAccessKeys.username, date.minusDays(daysBetweenWarningAndFinalNotification), Warning, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    // human activities - final
+    val humanActivityFinalLastNotificationGreaterThanCadence = IamRemediationActivity(account.id, humanWithTwoOldEnabledAccessKeys.username, date.minusDays(daysBetweenFinalNotificationAndRemediation + 1), FinalWarning, OutdatedCredential, humanAccessKeyOldAndEnabled2.lastRotated.get)
+    val humanActivityFinalLastNotificationEqualToCadence = IamRemediationActivity(account.id, humanWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenFinalNotificationAndRemediation), FinalWarning, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    // human activities - remediation
+    val humanActivityRemediationUnhealthy = IamRemediationActivity(account.id, humanWithOneOldEnabledAccessKey.username, date, Remediation, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)
+    // human users
+    val humanBothKeysRequireAction = IamUserRemediationHistory(account, humanWithTwoOldEnabledAccessKeys, List(humanActivityFinalLastNotificationGreaterThanCadence, humanActivityWarningLastNotificationEqualToCadence))
+    val humanOneKeyRequiresAction = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(humanActivityWarningLastNotificationGreaterThanCadence))
+    val humanOneKeyFinalWarning = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(humanActivityWarningLastNotificationEqualToCadence, humanActivityFinalLastNotificationEqualToCadence))
+    val humanOneKeyRemediation = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(humanActivityWarningLastNotificationEqualToCadence, humanActivityFinalLastNotificationEqualToCadence, humanActivityRemediationUnhealthy))
+    // machine activities - warning
+    val machineActivityWarningLastNotificationEqualToCadence = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenWarningAndFinalNotification), Warning, OutdatedCredential, machineAccessKeyOldAndEnabled.lastRotated.get)
+    val machineActivityWarningKeyLastRotatedEqualCadenceThreshold = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusWeeks(3), Warning, OutdatedCredential, machineAccessKeyOldAndEnabledOnTimeThreshold.lastRotated.get)
+    // machine access keys
+    val machineWithTwoOldEnabledAccessKeys = MachineUser("machine5", machineAccessKeyOldAndEnabledOnTimeThreshold, machineAccessKeyOldAndEnabled, Green, None, None, Nil)
+    // machine users
+    val machineOneKeyWarning = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(machineActivityWarningLastNotificationEqualToCadence))
+    val machineTwoKeysRequireAction = IamUserRemediationHistory(account, machineWithTwoOldEnabledAccessKeys, List(machineActivityWarningLastNotificationEqualToCadence, machineActivityWarningKeyLastRotatedEqualCadenceThreshold))
+
+    "given two users, each with 2 keys that require operations, output a list of size 4" in {
+      calculateOutstandingOperations(List(humanBothKeysRequireAction, machineTwoKeysRequireAction), date) should have length 4
+    }
+    "given two users, each with 1 key that requires an operation, output a list of size 2" in {
+      calculateOutstandingOperations(List(humanOneKeyRequiresAction,  machineOneKeyWarning), date) should have length 2
+    }
+    "given one user with 2 keys that require an operation, output a list of size 2" in {
+      calculateOutstandingOperations(List(machineTwoKeysRequireAction), date) should have length 2
+    }
+    "given one user with 1 key that requires an operation, output a list of size 1" in {
+      calculateOutstandingOperations(List(humanOneKeyRequiresAction), date) should have length 1
+    }
+    // this scenario should never happen, keeping this test here to note this.
+    "given an empty input list, return an empty output list" in {
+      calculateOutstandingOperations(Nil, date) shouldEqual Nil
+    }
+
+    "identifyRemediationOperation" - {
+      "if there is no previous activity for this key, return a Warning operation" in {
+        identifyRemediationOperation(mostRecentRemediationActivity = None, now = date, humanBothKeysRequireAction).map(_.iamRemediationActivityType) shouldEqual Some(Warning)
+      }
+      "if the most recent activity is a Warning with a date more than `Config.daysBetweenWarningAndFinalNotification` days ago, return a Final operation" in {
+        val activity = remediationActivity(daysBetweenWarningAndFinalNotification + 1, Warning, humanAccessKeyOldAndEnabled1, humanWithOneOldEnabledAccessKey.username)
+        identifyRemediationOperation(Some(activity), date, humanOneKeyRequiresAction).map(_.iamRemediationActivityType) shouldEqual Some(FinalWarning)
+      }
+      "if the most recent activity is a Warning with a date exactly `Config.daysBetweenWarningAndFinalNotification` days ago, return a Final operation" in {
+        val activity = remediationActivity(daysBetweenWarningAndFinalNotification, Warning, machineAccessKeyOldAndEnabled, machineWithOneOldEnabledAccessKey.username)
+        identifyRemediationOperation(Some(activity), date, machineOneKeyWarning).map(_.iamRemediationActivityType) shouldEqual Some(FinalWarning)
+      }
+      "if the most recent activity is a Warning with a date less than `Config.daysBetweenWarningAndFinalNotification` days ago, return a None, because no operation is required" in {
+        val machineActivityWarningHealthy = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenWarningAndFinalNotification - 1), Warning, OutdatedCredential, machineAccessKeyOldAndEnabled.lastRotated.get)
+        val machineOneWarningKeyDoesNotRequireAction = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(machineActivityWarningHealthy))
+        val activity = remediationActivity(daysBetweenWarningAndFinalNotification - 1, Warning, machineAccessKeyOldAndEnabled, machineWithOneOldEnabledAccessKey.username)
+        identifyRemediationOperation(Some(activity), date, machineOneWarningKeyDoesNotRequireAction).map(_.iamRemediationActivityType) shouldBe empty
+      }
+      "if the most recent activity is a Final with a date more than `Config.daysBetweenFinalNotificationAndRemediation` days ago, return a Remediation operation" in {
+        val activity = remediationActivity(daysBetweenFinalNotificationAndRemediation + 1, FinalWarning, humanAccessKeyOldAndEnabled1, humanWithTwoOldEnabledAccessKeys.username)
+        identifyRemediationOperation(Some(activity), date, humanBothKeysRequireAction).map(_.iamRemediationActivityType) shouldEqual Some(Remediation)
+      }
+      "if the most recent activity is a Final with a date exactly `Config.daysBetweenFinalNotificationAndRemediation` days ago, return a Remediation operation" in {
+        val activity = remediationActivity(daysBetweenFinalNotificationAndRemediation, FinalWarning, humanAccessKeyOldAndEnabled1, humanWithOneOldEnabledAccessKey.username)
+        identifyRemediationOperation(Some(activity), date, humanOneKeyFinalWarning).map(_.iamRemediationActivityType) shouldEqual Some(Remediation)
+      }
+      "if the most recent activity is a Final with a date less than `Config.daysBetweenFinalNotificationAndRemediation` days ago, return a None, because no operation is required" in {
+        val machineActivityFinalNotificationLessThanCadence = IamRemediationActivity(account.id, machineWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenFinalNotificationAndRemediation - 1), FinalWarning, OutdatedCredential, machineAccessKeyOldAndEnabled.lastRotated.get)
+        val machineOneFinalKeyDoesNotRequireAction = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(machineActivityFinalNotificationLessThanCadence))
+        val activity = remediationActivity(daysBetweenFinalNotificationAndRemediation - 1, FinalWarning, machineAccessKeyOldAndEnabled, machineWithOneOldEnabledAccessKey.username)
+        identifyRemediationOperation(Some(activity), date, machineOneFinalKeyDoesNotRequireAction).map(_.iamRemediationActivityType) shouldBe empty
+      }
+      // The most recent activity being a Remediation is an edge case, because it means that the access key has not been successfully disabled.
+      // In this edge case, set the operation to Remediation so that Security HQ can try to disable the key again.
+      "if the most recent activity is a Remediation, return a Remediation" in {
+        val activity = remediationActivity(1, Remediation, humanAccessKeyOldAndEnabled1, humanWithOneOldEnabledAccessKey.username)
+        identifyRemediationOperation(Some(activity), date, humanOneKeyRemediation).map(_.iamRemediationActivityType) shouldEqual Some(Remediation)
+      }
+      "if the most recent activity is a Warning with a date more than `Config.daysBetweenWarningAndFinalNotification` days ago, return the correct output" in {
+        val activity = remediationActivity(daysBetweenWarningAndFinalNotification + 1, Warning, humanAccessKeyOldAndEnabled1, humanWithOneOldEnabledAccessKey.username)
+        val result = identifyRemediationOperation(Some(activity), date, humanOneKeyRequiresAction)
+        inside (result.value) { case RemediationOperation(candidate, activityType, problem, _) =>
+          inside (candidate) { case IamUserRemediationHistory(account, user, _) =>
+            account.name shouldEqual "testAccount"
+            user.username shouldEqual "amina.adewusi"
+          }
+          activityType shouldEqual FinalWarning
+          problem shouldEqual OutdatedCredential
+        }
+      }
+      "if the most recent activity is a Warning with a date exactly `Config.daysBetweenWarningAndFinalNotification` days ago, return the correct problem creation date" in {
+        val activity = remediationActivity(daysBetweenWarningAndFinalNotification, Warning, machineAccessKeyOldAndEnabled, machineWithOneOldEnabledAccessKey.username)
+        val result = identifyRemediationOperation(Some(activity), date, machineOneKeyWarning)
+        result.map(_.problemCreationDate) shouldEqual Some(machineAccessKeyOldAndEnabled.lastRotated.get)
+      }
+    }
+
+    "identifyMostRecentIamRemediationActivity" - {
+      "if the key's most recent activity is Warning, return Warning" in {
+        val key = machineAccessKeyOldAndEnabled
+        val activity = remediationActivity(daysBetweenWarningAndFinalNotification, Warning, key, machineWithOneOldEnabledAccessKey.username)
+        val history = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(activity))
+        identifyMostRecentActivity(history, key).map(_.iamRemediationActivityType) shouldEqual Some(Warning)
+      }
+      "if the key's most recent activity is Final, return Final" in {
+        val key = humanAccessKeyOldAndEnabled1
+        val activity = remediationActivity(daysBetweenFinalNotificationAndRemediation, FinalWarning, key, humanWithOneOldEnabledAccessKey.username)
+        val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(activity))
+        identifyMostRecentActivity(history, key).map(_.iamRemediationActivityType) shouldEqual Some(FinalWarning)
+      }
+      "if the key's most recent activity is Remediation, return Remediation" in {
+        val key = humanAccessKeyOldAndEnabled1
+        val activity = remediationActivity(1, Remediation, key, humanWithOneOldEnabledAccessKey.username)
+        val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(activity))
+        identifyMostRecentActivity(history, key).map(_.iamRemediationActivityType) shouldEqual Some(Remediation)
+      }
+      "given a key does not have any activity, return None" in {
+        val activity = Nil
+        val machineNoActivity = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey2, activity)
+        identifyMostRecentActivity(machineNoActivity, machineAccessKeyOldAndEnabledOnTimeThreshold) shouldBe empty
+      }
+      "if the key's most recent activity is Warning, return the correct output" in {
+        val key = machineAccessKeyOldAndEnabled
+        val activity = remediationActivity(daysBetweenWarningAndFinalNotification, Warning, key, machineWithOneOldEnabledAccessKey.username)
+        val history = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(activity))
+        val result = identifyMostRecentActivity(history, key)
+        inside (result.value) { case IamRemediationActivity(awsAccountId, username, _, iamRemediationActivityType, iamProblem, problemCreationDate) =>
+          awsAccountId shouldEqual "testAccountId"
+          username shouldEqual "machine1"
+          iamRemediationActivityType shouldEqual Warning
+          iamProblem shouldEqual OutdatedCredential
+        }
+      }
+      "if the key's most recent activity is Final, return the correct date the last notification was sent" in {
+        val key = humanAccessKeyOldAndEnabled1
+        val activity = remediationActivity(daysBetweenFinalNotificationAndRemediation, FinalWarning, key, humanWithOneOldEnabledAccessKey.username)
+        val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(activity))
+        identifyMostRecentActivity(history, key).map(_.dateNotificationSent) shouldEqual Some(date.minusDays(daysBetweenFinalNotificationAndRemediation))
+      }
+    }
+
+    "identifyVulnerableKeys" - {
+      "given a human user with 1 vulnerable access key, return that key" in {
+        identifyVulnerableKeys(humanOneKeyRequiresAction, date).map(_.lastRotated) shouldEqual List(humanAccessKeyOldAndEnabled1.lastRotated)
+      }
+      "given a machine user with 1 vulnerable access key, return that key" in {
+        identifyVulnerableKeys(machineOneKeyWarning, date).map(_.lastRotated) shouldEqual List(machineAccessKeyOldAndEnabled.lastRotated)
+      }
+      "given 2 vulnerable access keys, return both keys" in {
+        identifyVulnerableKeys(humanBothKeysRequireAction, date).map(_.lastRotated) shouldEqual List(humanAccessKeyOldAndEnabled1.lastRotated, humanAccessKeyOldAndEnabled2.lastRotated)
+      }
+      // this scenario should never happen, becuase this function should only be called if there is at least one problem access key.
+      "given no vulnerable access keys, return an empty list" in {
+        val humanActivityRemediationHealthy = IamRemediationActivity(account.id, humanWithHealthyKey.username, date.minusMonths(2), Remediation, OutdatedCredential, humanAccessKeyHealthAndEnabled.lastRotated.get)
+        val humanHealthy = IamUserRemediationHistory(account, humanWithHealthyKey, List(humanActivityRemediationHealthy))
+        identifyVulnerableKeys(humanHealthy, date) shouldBe empty
+      }
+    }
   }
 
   "partitionOperationsByAllowedAccounts" - {
@@ -173,4 +330,6 @@ class IamRemediationTest extends FreeSpec with Matchers {
       machineUser
       , Nil), Warning, OutdatedCredential, new DateTime())
   }
+  def remediationActivity(dayOffset: Int, activityType: IamRemediationActivityType, accessKey: AccessKey, username: String) =
+    IamRemediationActivity(account.id, username, date.minusDays(dayOffset), activityType, OutdatedCredential, accessKey.lastRotated.get)
 }


### PR DESCRIPTION
## What does this change?
Adds tests and implementations for the logic required by the IAM Remediation job to determine which operations, if any,
are required for old credentials.

## What is the value of this?
Determines which work SHQ should do on vulnerable access keys.

## Will this require changes to config?
No.

## Any additional notes?
I have made some changes to the alert cadence and I would like to check that everyone in the team is happy with this. 

Also, I want to check what we would like to do in the case that an access key is enabled, vulnerable and its most recent operation type is `Remediation`. 

Ideally this case should never happen because all vulnerable credentials would be disabled if denoted as ready for Remediation, but in the case that it does I suggest the key is flagged for remediation again so that SHQ can attempt to disable it again in case something has gone wrong with the automated process when the CRON runs. This means that hopefully the next time the CRON runs the key would be disabled. It would be great to get thoughts on this.
