### PR TITLE
IAM remediation lookupCredentialId implementation

### DIFF
--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -6,7 +6,7 @@ import db.IamRemediationDb
 import model._
 import org.joda.time.{DateTime, Days}
 import play.api.Logging
-import utils.attempt.{Attempt, FailedAttempt}
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.ExecutionContext
 
@@ -172,7 +172,26 @@ object IamRemediation extends Logging {
     * This might fail, because it may be that no matching key exists.
     */
   def lookupCredentialId(badKeyCreationDate: DateTime, userCredentials: List[CredentialMetadata]): Attempt[CredentialMetadata] = {
-    ???
+    val username = userCredentials.map(_.username).headOption.getOrElse("unknown username")
+    userCredentials.filter { credentialMetadata =>
+      credentialMetadata.creationDate.withMillisOfSecond(0) == badKeyCreationDate.withMillisOfSecond(0)
+    } match {
+      case singleMatchingKey :: Nil => Attempt.Right(singleMatchingKey)
+      case Nil =>
+        Attempt.Left(FailedAttempt(Failure(
+          "unable to identify matching access key in user's metadata",
+          s"I've made a list-access-keys AWS API call for $username, but I have not found a matching key in the response.",
+          500
+        )))
+      case _ =>
+        // This is an edge case where both the user's access keys both have the same creation date.
+        // This should be unlikely given the Credentials Reports creation dates are defined up to the second.
+        Attempt.Left(FailedAttempt(Failure(
+          s"both of $username's access keys have the exact same creation date - cannot decide which one to select for disablement",
+          s"I've hit an edge case for $username's access keys where both have the same creation date, please investigate as I can't decide which one to disable.",
+          500
+        )))
+    }
   }
 
   def formatRemediationOperation(remediationOperation: RemediationOperation): String = {


### PR DESCRIPTION
## What does this change?
Adds implementation for the lookupCredentialId function.

## What is the value of this?
This function attempts to find matching access key metadata from an AWS list-access-keys API call, with the problem access key that SHQ has identified.

If this fails, a FailedAttempt is returned, because this means that the access key cannot be disabled as an access key id has not been identified.

## Will this require CloudFormation and/or updates to the AWS StackSet?
No love.

## Will this require changes to config?
No.

## Any additional notes?
This change includes an important edge case.

Currently we differentiate access keys by date, but what if both a user's access keys were created on exactly the same date to the second?

Yes, this is unlikely, but an edge case nevertheless. I think this would be impossible if the keys were created in the console, but could potentially be possible if the CLI were used.

This has been accounted for by returning a FailedAttempt and logging this out as an error for developers to investigate. Having written this down, I realise that it would be helpful for Security developers to be alerted if this occurs. It would be good to get thoughts on this.

A potential solution to this problem, to be implemented in the future, would be to:
- enrich the credentials report with access key ids, similar to how tags are added to the report
- add access key id to the access key case class in the model
- add access key id to a field on the `OutdatedCredential` `IamProblem` type.
