### PR TITLE
Unrecognised user notification handling improvements

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -34,6 +34,11 @@ Object {
       "Description": "Amazon Machine Image ID for the app security-hq. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
     },
+    "AnghammaradSnsArn": Object {
+      "Default": "/account/services/anghammarad.topic.arn",
+      "Description": "SSM parameter containing the ARN of the Anghammarad SNS topic",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
     "AuditDataS3BucketName": Object {
       "Default": "/security/security-hq/audit-data-s3-bucket/name",
       "Description": "Name of the S3 bucket to fetch auditable data from (e.g. Janus data)",
@@ -515,6 +520,29 @@ dpkg -i /tmp/installer.deb",
           "Version": "2012-10-17",
         },
         "PolicyName": "GetDistributablePolicySecurityhqC6808A6A",
+        "Roles": Array [
+          Object {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuAnghammaradSenderPolicy674A3874": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "sns:Publish",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Ref": "AnghammaradSnsArn",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuAnghammaradSenderPolicy674A3874",
         "Roles": Array [
           Object {
             "Ref": "InstanceRoleSecurityhq7C08CA33",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -32,6 +32,7 @@ import {
   GuGetS3ObjectsPolicy,
   GuPutCloudwatchMetricsPolicy,
 } from '@guardian/cdk/lib/constructs/iam';
+import { GuAnghammaradSenderPolicy } from '@guardian/cdk/lib/constructs/iam/policies/anghammarad';
 import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
 import { GuardianPublicNetworks } from '@guardian/private-infrastructure-config';
 
@@ -102,6 +103,7 @@ aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.st
 dpkg -i /tmp/installer.deb`,
       roleConfiguration: {
         additionalPolicies: [
+          GuAnghammaradSenderPolicy.getInstance(this),
           new GuPutCloudwatchMetricsPolicy(this),
           new GuGetS3ObjectsPolicy(this, 'S3AuditRead', {
             bucketName: auditDataS3BucketName.valueAsString,


### PR DESCRIPTION
## What does this change?
On testing of the unrecognised user notification in production, 2 things became apparent:
1) The notification was not being sent. The logs indicated an attempt was made by the program to put a message on the necessary Anghammarad SNS topic, but the lambda was not invoked, indicating the topic was not published to.
2) There was no indication in the SHQ logs that this failure happened.

To address these this PR does the following:
1) Adds the necessary Anghammarad SNS publish policy to the instance role via CDK. It looks like this was omitted when we migrated to CDK, but it wasn't important until now.
2) Updates the error handling in the part of the job that interprets the result of a notification `send`. We were previously `fold`ing an `Attempt` (to a `Future`) and then transforming back to an `Attempt`. If I understand correctly the `fold` is transforming the `Left` of our attempted notification send into a `None`, and `None` is not treated as a failure case, so the error is swallowed. Instead we let the `Attempt` from the notification sending bubble up to the edge of the program. 

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Notifications from this job (and others in the future) will send successfully (or fail with a visible error log)

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
CDK update included

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
