### PR TITLE
IamRemediationDb implementation

### DIFF
--- a/hq/app/db/IamRemediationDb.scala
+++ b/hq/app/db/IamRemediationDb.scala
@@ -17,14 +17,19 @@ class IamRemediationDb(client: AmazonDynamoDB, tableName: String) {
     * The application can then filter it down to relevant notifications.
     */
   def lookupIamUserNotifications(IAMUser: IAMUser, awsAccount: AwsAccount)(implicit ec: ExecutionContext): Attempt[List[IamRemediationActivity]] = {
-    ???
+    for {
+      result <- scan(lookupScanRequest(IAMUser.username, awsAccount.id, tableName))
+      activities <- Attempt.traverse(result)(deserialiseIamRemediationActivity)
+    } yield activities
   }
 
   /**
     * Writes this record to the database, returning the successful DynamoDB request ID or a failure.
     */
-  def writeRemediationActivity(iamRemediationActivity: IamRemediationActivity): Attempt[String] = {
-    ???
+  def writeRemediationActivity(iamRemediationActivity: IamRemediationActivity)(implicit ec: ExecutionContext): Attempt[String] = {
+    for {
+      result <- put(writePutRequest(iamRemediationActivity, tableName))
+    } yield result.getSdkResponseMetadata.getRequestId
   }
 
   private def scan(request: ScanRequest)(implicit ec: ExecutionContext): Attempt[List[Map[String, AttributeValue]]] = {

--- a/hq/app/db/IamRemediationDb.scala
+++ b/hq/app/db/IamRemediationDb.scala
@@ -71,8 +71,17 @@ class IamRemediationDb(client: AmazonDynamoDB, tableName: String) {
 }
 
 object IamRemediationDb {
+  private def S(str: String) = new AttributeValue().withS(str)
+  private def L(list: List[AttributeValue]) = new AttributeValue().withL(list.asJava)
+  private def N(number: Long) = new AttributeValue().withN(number.toString)
+  private def N(number: Double) = new AttributeValue().withN(number.toString)
+  private def B(boolean: Boolean) = new AttributeValue().withBOOL(boolean)
+  private def M(map: Map[String,  AttributeValue]) = new AttributeValue().withM(map.asJava)
+
   private[db] def lookupScanRequest(username: String, accountId: String, tableName: String): ScanRequest = {
-    ???
+    new ScanRequest().withTableName(tableName)
+      .withFilterExpression("id = :key")
+      .withExpressionAttributeValues(Map(":key" -> S(s"${username}/${accountId}")).asJava)
   }
 
   private[db] def writePutRequest(iamRemediationActivity: IamRemediationActivity, tableName: String): PutItemRequest = {

--- a/hq/app/db/IamRemediationDb.scala
+++ b/hq/app/db/IamRemediationDb.scala
@@ -97,7 +97,24 @@ object IamRemediationDb {
   }
 
   private[db] def writePutRequest(iamRemediationActivity: IamRemediationActivity, tableName: String): PutItemRequest = {
-    ???
+    val awsAcountId = iamRemediationActivity.awsAccountId
+    val username = iamRemediationActivity.username
+    val dateNotificationSent = iamRemediationActivity.dateNotificationSent
+    val iamRemediationActivityType = iamRemediationActivity.iamRemediationActivityType
+    val iamProblem = iamRemediationActivity.iamProblem
+    val problemCreationDate = iamRemediationActivity.problemCreationDate
+
+    val item = Map(
+      "id" -> S(s"${awsAcountId}/${username}"),
+      "awsAccountId" -> S(awsAcountId),
+      "username" -> S(username),
+      "dateNotificationSent" -> N(dateNotificationSent.getMillis),
+      "iamRemediationActivityType" -> S(iamRemediationActivityType.toString),
+      "iamProblem" -> S(iamProblem.toString),
+      "problemCreationDate" -> N(problemCreationDate.getMillis)
+    )
+
+    new PutItemRequest().withTableName(tableName).withItem(item.asJava)
   }
 
   /**

--- a/hq/app/db/IamRemediationDb.scala
+++ b/hq/app/db/IamRemediationDb.scala
@@ -156,7 +156,7 @@ object IamRemediationDb {
       dbData.get(key).flatMap(data => Option(f(data))),
       Failure(
         s"The item retrieved from the database with id ${dbData.get("id")} has an invalid attribute with key $key",
-        s"Failed to deserialise database item into a IamRemediationActivity object",
+        s"Failed to deserialise database item into an IamRemediationActivity object",
         500,
         None).attempt
     )

--- a/hq/app/db/IamRemediationDb.scala
+++ b/hq/app/db/IamRemediationDb.scala
@@ -87,7 +87,7 @@ object IamRemediationDb {
   private[db] def lookupScanRequest(username: String, accountId: String, tableName: String): ScanRequest = {
     new ScanRequest().withTableName(tableName)
       .withFilterExpression("id = :key")
-      .withExpressionAttributeValues(Map(":key" -> S(s"${username}/${accountId}")).asJava)
+      .withExpressionAttributeValues(Map(":key" -> S(s"${accountId}/${username}")).asJava)
   }
 
   private[db] def writePutRequest(iamRemediationActivity: IamRemediationActivity, tableName: String): PutItemRequest = {

--- a/hq/app/db/IamRemediationDb.scala
+++ b/hq/app/db/IamRemediationDb.scala
@@ -28,7 +28,19 @@ class IamRemediationDb(client: AmazonDynamoDB, tableName: String) {
   }
 
   private def scan(request: ScanRequest)(implicit ec: ExecutionContext): Attempt[List[Map[String, AttributeValue]]] = {
-    ???
+    try {
+      Attempt.Right(client.scan(request).getItems.asScala.toList.map(_.asScala.toMap))
+    } catch {
+      case NonFatal(e) =>
+        Attempt.Left(
+          Failure(
+            s"unable to scan dynamoDB table",
+            s"I haven't been able to scan the dynamo table for the vulnerable user job",
+            500,
+            throwable = Some(e)
+          )
+        )
+    }
   }
 
   private def get(request: GetItemRequest)(implicit ec: ExecutionContext): Attempt[Map[String, AttributeValue]] = {

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -25,6 +25,8 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
   val dateNotificationSentMillis = dateNotificationSent.getMillis
   val problemCreationDate = new DateTime(2021, 2, 2, 2, 2)
   val problemCreationDateMillis = problemCreationDate.getMillis
+  val activityType = "FinalWarning"
+  val problem = "PasswordMissingMFA"
 
   val iamRemediationActivity = IamRemediationActivity(
     accountId,
@@ -40,8 +42,8 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     "awsAccountId" -> S(accountId),
     "username" -> S(testUser),
     "dateNotificationSent" -> N(dateNotificationSentMillis),
-    "iamRemediationActivityType" -> S("FinalWarning"),
-    "iamProblem" -> S("PasswordMissingMFA"),
+    "iamRemediationActivityType" -> S(activityType),
+    "iamProblem" -> S(problem),
     "problemCreationDate" -> N(problemCreationDateMillis)
   )
 
@@ -49,8 +51,8 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     "id" -> S(hashKey),
     "username" -> S(testUser),
     "dateNotificationSent" -> N(dateNotificationSentMillis),
-    "iamRemediationActivityType" -> S("FinalWarning"),
-    "iamProblem" -> S("PasswordMissingMFA"),
+    "iamRemediationActivityType" -> S(activityType),
+    "iamProblem" -> S(problem),
     "problemCreationDate" -> N(problemCreationDateMillis)
   )
 
@@ -59,8 +61,8 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     "awsAccountId" -> S(accountId),
     "username" -> S(null),
     "dateNotificationSent" -> N(dateNotificationSentMillis),
-    "iamRemediationActivityType" -> S("FinalWarning"),
-    "iamProblem" -> S("PasswordMissingMFA"),
+    "iamRemediationActivityType" -> S(activityType),
+    "iamProblem" -> S(problem),
     "problemCreationDate" -> N(problemCreationDateMillis)
   )
 
@@ -69,7 +71,7 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     "awsAccountId" -> S(accountId),
     "username" -> S(testUser),
     "dateNotificationSent" -> N(dateNotificationSentMillis),
-    "iamRemediationActivityType" -> S("FinalWarning"),
+    "iamRemediationActivityType" -> S(activityType),
     "iamProblem" -> S("FailFast"),
     "problemCreationDate" -> N(problemCreationDateMillis)
   )

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -32,7 +32,25 @@ class IamRemediationDbTest extends FreeSpec with Matchers {
   }
 
   "writePutRequest" - {
-    "TODO" ignore {}
+    "creates put request for correct table name with correct attribute name and values" in {
+      val dateNotificationSent = new DateTime(2021, 1, 1, 1, 1)
+      val problemCreationDate = new DateTime(2021, 2, 2, 2, 2)
+      val dateNotificationSentMillis = dateNotificationSent.getMillis
+      val problemCreationDateMillis = problemCreationDate.getMillis
+      val tableName = "testTable"
+
+      val iamRemediationActivity = IamRemediationActivity("testAccount", "testUser", dateNotificationSent, FinalWarning, PasswordMissingMFA, problemCreationDate)
+      val putItemRequest = writePutRequest(iamRemediationActivity, tableName)
+
+      putItemRequest.getTableName shouldEqual tableName
+      putItemRequest.getItem.asScala("id") shouldEqual S("testAccount/testUser")
+      putItemRequest.getItem.asScala("awsAccountId") shouldEqual S("testAccount")
+      putItemRequest.getItem.asScala("username") shouldEqual S("testUser")
+      putItemRequest.getItem.asScala("dateNotificationSent") shouldEqual N(dateNotificationSentMillis)
+      putItemRequest.getItem.asScala("iamRemediationActivityType") shouldEqual S("FinalWarning")
+      putItemRequest.getItem.asScala("iamProblem") shouldEqual S("PasswordMissingMFA")
+      putItemRequest.getItem.asScala("problemCreationDate") shouldEqual N(problemCreationDateMillis)
+    }
   }
 
   "deserialiseIamRemediationActivity" - {

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -3,9 +3,10 @@ package db
 import org.scalatest.{FreeSpec, Matchers}
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest, PutItemRequest, PutItemResult, ScanRequest}
 import db.IamRemediationDb.{N, S, deserialiseIamRemediationActivity, lookupScanRequest, writePutRequest}
-import model.{FinalWarning, IamProblem, IamRemediationActivity, IamRemediationActivityType, MissingMfa, PasswordMissingMFA}
+import model.{AccessKey, AwsAccount, FinalWarning, Green, HumanUser, IamProblem, IamRemediationActivity, IamRemediationActivityType, MissingMfa, NoKey, PasswordMissingMFA}
 import org.joda.time.DateTime
 import utils.attempt.AttemptValues
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
 
@@ -30,7 +31,7 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     problemCreationDate
   )
 
-  val record = Map(
+  val iamRemediationActivityMap = Map(
     "id" -> S(hashKey),
     "awsAccountId" -> S(accountId),
     "username" -> S(testUser),
@@ -40,7 +41,7 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     "problemCreationDate" -> N(problemCreationDateMillis)
   )
 
-  val incompleteRecord = Map(
+  val incompleteMap = Map(
     "id" -> S(hashKey),
     "username" -> S(testUser),
     "dateNotificationSent" -> N(dateNotificationSentMillis),
@@ -63,18 +64,18 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     "creates put request for correct table name with correct attribute name and values" in {
       writePutRequest(iamRemediationActivity, tableName) should have(
         'tableName (tableName),
-        'getItem (record.asJava)
+        'getItem (iamRemediationActivityMap.asJava)
       )
     }
   }
 
   "deserialiseIamRemediationActivity" - {
     "Returns a right with a IamRemediationActivity object correctly instantiated from a database record" in {
-        deserialiseIamRemediationActivity(record).value shouldEqual iamRemediationActivity
+        deserialiseIamRemediationActivity(iamRemediationActivityMap).value shouldEqual iamRemediationActivity
     }
 
     "Returns left when database record is incomplete" in {
-      deserialiseIamRemediationActivity(incompleteRecord).isFailedAttempt shouldBe true
+      deserialiseIamRemediationActivity(incompleteMap).isFailedAttempt shouldBe true
     }
   }
 }

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -1,11 +1,34 @@
 package db
 
 import org.scalatest.{FreeSpec, Matchers}
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest, PutItemRequest, PutItemResult, ScanRequest}
+import db.IamRemediationDb.{lookupScanRequest, writePutRequest}
+import model.{FinalWarning, IamProblem, IamRemediationActivity, IamRemediationActivityType, MissingMfa, PasswordMissingMFA}
+import org.joda.time.DateTime
+
+import scala.collection.JavaConverters._
 
 
 class IamRemediationDbTest extends FreeSpec with Matchers {
+  def S(str: String) = new AttributeValue().withS(str)
+  def L(list: List[AttributeValue]) = new AttributeValue().withL(list.asJava)
+  def N(number: Long) = new AttributeValue().withN(number.toString)
+  def N(number: Double) = new AttributeValue().withN(number.toString)
+  def B(boolean: Boolean) = new AttributeValue().withBOOL(boolean)
+  def M(map: Map[String,  AttributeValue]) = new AttributeValue().withM(map.asJava)
+
   "lookupScanRequest" - {
-    "TODO" ignore {}
+    "creates scan request for correct table name with correct filter" in {
+      val username = "test.user"
+      val accountId = "account"
+      val tableName = "my table"
+      val hashKey = s"${username}/${accountId}"
+
+      val result = lookupScanRequest(username, accountId, tableName)
+      result.getTableName shouldEqual tableName
+      result.getFilterExpression shouldEqual "id = :key"
+      result.getExpressionAttributeValues shouldEqual Map(":key" -> new AttributeValue().withS(hashKey)).asJava
+    }
   }
 
   "writePutRequest" - {

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -69,31 +69,31 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues wit
   }
 
   "deserialiseIamRemediationActivity" - {
-    "Returns a right with a IamRemediationActivity object correctly instantiated from a database record" in {
+    "Returns a right with an IamRemediationActivity object correctly instantiated from a database record" in {
       deserialiseIamRemediationActivity(
         iamRemediationActivityDbRecord
       ).value shouldEqual iamRemediationActivity
     }
 
-    "Returns left when database record is incomplete" in {
+    "Returns a left when database record is incomplete" in {
       deserialiseIamRemediationActivity(
         iamRemediationActivityDbRecord - ("awsAccountId")
       ).isFailedAttempt shouldBe true
     }
 
-    "Returns left when database record is complete but one of the attributes is null" in {
+    "Returns a left when database record is complete but one of the attributes is null" in {
       deserialiseIamRemediationActivity(
         iamRemediationActivityDbRecord + ("username" -> S(null))
       ).isFailedAttempt shouldBe true
     }
 
-    "Returns left when database record is complete but iamProblem is an invalid string" in {
+    "Returns a left when database record is complete but iamProblem is an invalid string" in {
       deserialiseIamRemediationActivity(
         iamRemediationActivityDbRecord + ("iamProblem" -> S("FailFast"))
       ).isFailedAttempt shouldBe true
     }
 
-    "Returns left when database record is complete but one attribute is of the wrong type" in {
+    "Returns a left when database record is complete but one attribute is of the wrong type" in {
       deserialiseIamRemediationActivity(
         iamRemediationActivityDbRecord + ("username" -> N(0))
       ).isFailedAttempt shouldBe true

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -51,25 +51,20 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
 
   "lookupScanRequest" - {
     "creates scan request for correct table name with correct filter" in {
-      val result = lookupScanRequest(testUser, accountId, tableName)
-      result.getTableName shouldEqual tableName
-      result.getFilterExpression shouldEqual "id = :key"
-      result.getExpressionAttributeValues shouldEqual Map(":key" -> new AttributeValue().withS(hashKey)).asJava
+      lookupScanRequest(testUser, accountId, tableName) should have(
+        'tableName (tableName),
+        'filterExpression ("id = :key"),
+        'expressionAttributeValues (Map(":key" -> new AttributeValue().withS(hashKey)).asJava)
+      )
     }
   }
 
   "writePutRequest" - {
     "creates put request for correct table name with correct attribute name and values" in {
-      val putItemRequest = writePutRequest(iamRemediationActivity, tableName)
-
-      putItemRequest.getTableName shouldEqual tableName
-      putItemRequest.getItem.asScala("id") shouldEqual S(hashKey)
-      putItemRequest.getItem.asScala("awsAccountId") shouldEqual S(accountId)
-      putItemRequest.getItem.asScala("username") shouldEqual S(testUser)
-      putItemRequest.getItem.asScala("dateNotificationSent") shouldEqual N(dateNotificationSentMillis)
-      putItemRequest.getItem.asScala("iamRemediationActivityType") shouldEqual S("FinalWarning")
-      putItemRequest.getItem.asScala("iamProblem") shouldEqual S("PasswordMissingMFA")
-      putItemRequest.getItem.asScala("problemCreationDate") shouldEqual N(problemCreationDateMillis)
+      writePutRequest(iamRemediationActivity, tableName) should have(
+        'tableName (tableName),
+        'getItem (record.asJava)
+      )
     }
   }
 

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -7,22 +7,23 @@ import model.{FinalWarning, IamProblem, IamRemediationActivity, IamRemediationAc
 import org.joda.time.DateTime
 import utils.attempt.AttemptValues
 import scala.concurrent.ExecutionContext.Implicits.global
-
-
 import scala.collection.JavaConverters._
 
 
 class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
 
-  val dateNotificationSent = new DateTime(2021, 1, 1, 1, 1)
-  val problemCreationDate = new DateTime(2021, 2, 2, 2, 2)
-  val dateNotificationSentMillis = dateNotificationSent.getMillis
-  val problemCreationDateMillis = problemCreationDate.getMillis
   val tableName = "testTable"
+  val hashKey = "testAccountId/testUser"
+  val accountId = "testAccountId"
+  val testUser = "testUser"
+  val dateNotificationSent = new DateTime(2021, 1, 1, 1, 1)
+  val dateNotificationSentMillis = dateNotificationSent.getMillis
+  val problemCreationDate = new DateTime(2021, 2, 2, 2, 2)
+  val problemCreationDateMillis = problemCreationDate.getMillis
 
   val iamRemediationActivity = IamRemediationActivity(
-    "testAccount",
-    "testUser",
+    accountId,
+    testUser,
     dateNotificationSent,
     FinalWarning,
     PasswordMissingMFA,
@@ -30,9 +31,9 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
   )
 
   val record = Map(
-    "id" -> S("testAccount/testUser"),
-    "awsAccountId" -> S("testAccount"),
-    "username" -> S("testUser"),
+    "id" -> S(hashKey),
+    "awsAccountId" -> S(accountId),
+    "username" -> S(testUser),
     "dateNotificationSent" -> N(dateNotificationSentMillis),
     "iamRemediationActivityType" -> S("FinalWarning"),
     "iamProblem" -> S("PasswordMissingMFA"),
@@ -40,8 +41,8 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
   )
 
   val incompleteRecord = Map(
-    "id" -> S("testAccount/testUser"),
-    "username" -> S("testUser"),
+    "id" -> S(hashKey),
+    "username" -> S(testUser),
     "dateNotificationSent" -> N(dateNotificationSentMillis),
     "iamRemediationActivityType" -> S("FinalWarning"),
     "iamProblem" -> S("PasswordMissingMFA"),
@@ -50,12 +51,7 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
 
   "lookupScanRequest" - {
     "creates scan request for correct table name with correct filter" in {
-      val username = "test.user"
-      val accountId = "account"
-      val tableName = "my table"
-      val hashKey = s"${username}/${accountId}"
-
-      val result = lookupScanRequest(username, accountId, tableName)
+      val result = lookupScanRequest(testUser, accountId, tableName)
       result.getTableName shouldEqual tableName
       result.getFilterExpression shouldEqual "id = :key"
       result.getExpressionAttributeValues shouldEqual Map(":key" -> new AttributeValue().withS(hashKey)).asJava
@@ -67,9 +63,9 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
       val putItemRequest = writePutRequest(iamRemediationActivity, tableName)
 
       putItemRequest.getTableName shouldEqual tableName
-      putItemRequest.getItem.asScala("id") shouldEqual S("testAccount/testUser")
-      putItemRequest.getItem.asScala("awsAccountId") shouldEqual S("testAccount")
-      putItemRequest.getItem.asScala("username") shouldEqual S("testUser")
+      putItemRequest.getItem.asScala("id") shouldEqual S(hashKey)
+      putItemRequest.getItem.asScala("awsAccountId") shouldEqual S(accountId)
+      putItemRequest.getItem.asScala("username") shouldEqual S(testUser)
       putItemRequest.getItem.asScala("dateNotificationSent") shouldEqual N(dateNotificationSentMillis)
       putItemRequest.getItem.asScala("iamRemediationActivityType") shouldEqual S("FinalWarning")
       putItemRequest.getItem.asScala("iamProblem") shouldEqual S("PasswordMissingMFA")

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -1,5 +1,9 @@
 package db
 
+import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import org.scalatest.{FreeSpec, Matchers}
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest, PutItemRequest, PutItemResult, ScanRequest}
 import db.IamRemediationDb.{N, S, deserialiseIamRemediationActivity, lookupScanRequest, writePutRequest}
@@ -50,6 +54,27 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
     "problemCreationDate" -> N(problemCreationDateMillis)
   )
 
+  val nullMap = Map(
+    "id" -> S(hashKey),
+    "awsAccountId" -> S(accountId),
+    "username" -> S(null),
+    "dateNotificationSent" -> N(dateNotificationSentMillis),
+    "iamRemediationActivityType" -> S("FinalWarning"),
+    "iamProblem" -> S("PasswordMissingMFA"),
+    "problemCreationDate" -> N(problemCreationDateMillis)
+  )
+
+  val invalidIamProblemMap = Map(
+    "id" -> S(hashKey),
+    "awsAccountId" -> S(accountId),
+    "username" -> S(testUser),
+    "dateNotificationSent" -> N(dateNotificationSentMillis),
+    "iamRemediationActivityType" -> S("FinalWarning"),
+    "iamProblem" -> S("FailFast"),
+    "problemCreationDate" -> N(problemCreationDateMillis)
+  )
+
+
   "lookupScanRequest" - {
     "creates scan request for correct table name with correct filter" in {
       lookupScanRequest(testUser, accountId, tableName) should have(
@@ -76,6 +101,16 @@ class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues {
 
     "Returns left when database record is incomplete" in {
       deserialiseIamRemediationActivity(incompleteMap).isFailedAttempt shouldBe true
+    }
+
+    "Returns left when database record is complete but one of the attributes is null" in {
+      val ret = deserialiseIamRemediationActivity(nullMap)
+      ret.isFailedAttempt shouldBe true
+    }
+
+    "Returns left when database record is complete but iamProblem is an invalid string" in {
+      val ret = deserialiseIamRemediationActivity(invalidIamProblemMap)
+      ret.isFailedAttempt shouldBe true
     }
   }
 }

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -1,13 +1,9 @@
 package db
 
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder
 import org.scalatest.{FreeSpec, Matchers}
-import com.amazonaws.services.dynamodbv2.model.{AttributeValue, GetItemRequest, PutItemRequest, PutItemResult, ScanRequest}
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import db.IamRemediationDb.{N, S, deserialiseIamRemediationActivity, lookupScanRequest, writePutRequest}
-import model.{AccessKey, AwsAccount, FinalWarning, Green, HumanUser, IamProblem, IamRemediationActivity, IamRemediationActivityType, MissingMfa, NoKey, PasswordMissingMFA}
+import model.{FinalWarning, IamRemediationActivity, PasswordMissingMFA}
 import org.joda.time.DateTime
 import utils.attempt.AttemptValues
 


### PR DESCRIPTION
## What does this change?

This implements the outstanding methods in IamRemediationDb, namely
- lookupIamUserNotifications
- writeRemediationActivity
- lookupScanRequest
- writePutRequest
- deserialiseIamRemediationActivity
- scan

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Will this require changes to config?

No

## Any additional notes?
- method signatures were changed to include ExecutionContext when using attempts and for comps
- the suite of helped methods such as `S` and `L` were moved to the companion object, so they could be used both in the tests and across the implementation
<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
