### PR TITLE
Update riffraff artifact plugin to avoid warning on sbt startup

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.17")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 


### PR DESCRIPTION
## What does this change?
Updates to the latest version of the riffraff artifact plugin, which avoids making a network request (and generating a warning) on sbt startup.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Avoids unnecessary network request and warning on sbt startup.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
