### PR TITLE
Use new action to simplify workflow

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -44,16 +44,9 @@ jobs:
           cache: 'yarn'
 
       - name: Add SSH key for accessing @guardian/private-infrastructure-config
-        run: |
-          mkdir -m 700 ~/.ssh
-          
-          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
-
-          echo '${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}' > ~/.ssh/id_ed25519
-          chmod 400 ~/.ssh/id_ed25519
-          
-          eval "$(ssh-agent)"
-          ssh-add
+        uses: guardian/actions-read-private-repos@v0.1.0
+        with:
+          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
 
       # 1. Seed the build number with last number from TeamCity.
       #    Update `LAST_TEAMCITY_BUILD` as needed or remove entirely if changing Riff-Raff project name.


### PR DESCRIPTION
## What + why

Use the new https://github.com/guardian/actions-read-private-repos action to simplify private repo access in the Github actions CI workflow.
