### PR TITLE
Update DB schema for IAM Remediation jobs

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1158,11 +1158,19 @@ dpkg -i /tmp/installer.deb",
             "AttributeName": "id",
             "AttributeType": "S",
           },
+          Object {
+            "AttributeName": "dateNotificationSent",
+            "AttributeType": "N",
+          },
         ],
         "KeySchema": Array [
           Object {
             "AttributeName": "id",
             "KeyType": "HASH",
+          },
+          Object {
+            "AttributeName": "dateNotificationSent",
+            "KeyType": "RANGE",
           },
         ],
         "ProvisionedThroughput": Object {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -55,6 +55,10 @@ export class SecurityHQ extends GuStack {
         name: 'id',
         type: AttributeType.STRING,
       },
+      sortKey: {
+        name: 'dateNotificationSent',
+        type: AttributeType.NUMBER,
+      },
     });
     const defaultChild = table.node.defaultChild as unknown as CfnElement;
     defaultChild.overrideLogicalId('SecurityHqIamDynamoTable');


### PR DESCRIPTION
## What does this change?
The refactor of the outdated credentials job has changed the database structure. It now includes a range key as well as a primary key, which this PR adds.

## What is the value of this?
The database is now up to date with the refactored IAM remediation job.

## Will this require CloudFormation and/or updates to the AWS StackSet?
Yes. 

## Will this require changes to config?
No.

## Any additional notes?
Before this PR is deployed, the current db table should be deleted. This should be safe as the data in it has only been used for test purposes only and it's not a problem if we send another email about the same credential if one has already been sent in the past.
