### PR TITLE
Use DynamoDbLocal for local application development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ hq/test/jars
 .vscode
 project/metals.sbt
 project/project
+
+# DynamoDB local
+.dynamodb-local

--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ There are two other files that you will need to run security HQ locally. These a
 1.  `~/.gu/security-hq.local.conf` (Please update the value of key `GOOGLE_SERVICE_ACCOUNT_CERT_PATH`)
 1. `~/.gu/security-hq-service-account-cert.json`
 
-Both of these files can be found in the Security AWS account in S3 here `s3://security-dist/security/PROD/security-hq/`.
+Both of these files can be found in the Security AWS account in S3 here `s3://security-dist/security/DEV/security-hq/`.
 
 To access the Security AWS account you will need to raise a PR in [Janus](https://github.com/guardian/janus/blob/main/guData/src/main/scala/com/gu/janus/data/Access.scala) 
 to get access to the Security account (`Security.dev` should be appropriate).
 
 Once you have Janus credentials for the AWS Security account, you can copy the files from S3 by using the following:
 ```
- aws s3 cp s3://security-dist/security/PROD/security-hq/security-hq.local.conf ~/.gu --profile security
+ aws s3 cp s3://security-dist/security/DEV/security-hq/security-hq.local.conf ~/.gu --profile security
+ aws s3 cp s3://security-dist/security/DEV/security-hq/security-hq-service-account-cert.json ~/.gu --profile security
 ```
 
 ### Adding additional AWS accounts for local development

--- a/README.md
+++ b/README.md
@@ -140,11 +140,18 @@ Once the sever has started, the webapp is accessible at [https://security-hq.loc
 
 ### DynamoDB local setup
 
-The application requires DynamoDB to be running locally. It will start automatically upon `run`, but the table itself needs to be initialised separately by running
+
+Running Security HQ locally requires a local instance of DynamoDb to connect
+to. The `run` tasks handles most of the work automatically by starting and
+stopping `DynamoDBLocal` as appropriate. It does not, however, create a table
+for the application to use.
+
+To do that, the following script needs to be executed _while_ the application
+is running. This only needs to be done once, as the database is stored on disk
+and persistent between application runs.
 
 1. `$ ./script/setup`
 
-This scripts need to be run _while_ the application is running so that the database (which is automatically started and stopped while security hq is running) is available.
 
 ### Working with CSS and JS
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Once the sever has started, the webapp is accessible at [https://security-hq.loc
 
 ### DynamoDB local setup
 
-
 Running Security HQ locally requires a local instance of DynamoDb to connect
 to. The `run` tasks handles most of the work automatically by starting and
 stopping `DynamoDBLocal` as appropriate. It does not, however, create a table
@@ -151,7 +150,6 @@ is running. This only needs to be done once, as the database is stored on disk
 and persistent between application runs.
 
 1. `$ ./script/setup`
-
 
 ### Working with CSS and JS
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ From the root of the project:
 
 Once the sever has started, the webapp is accessible at [https://security-hq.local.dev-gutools.co.uk/](https://security-hq.local.dev-gutools.co.uk/)
 
+### DynamoDB local setup
+
+The application requires DynamoDB to be running locally. It will start automatically upon `run`, but the table itself needs to be initialised separately by running
+
+1. `$ ./script/setup`
+
+This scripts need to be run _while_ the application is running so that the database (which is automatically started and stopped while security hq is running) is available.
+
 ### Working with CSS and JS
 
 Security HQ uses [Prettier](https://prettier.io) and [ESLint](https://eslint.org/docs/about/) to provide opinionated code formatting and linting. As part of the automated build, all CSS and JS will be validated using the rules of Prettier and ESLint.

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
 import play.sbt.PlayImport.PlayKeys._
 import sbt.Keys.libraryDependencies
 
+import scala.concurrent.duration.DurationInt
+
 // common settings (apply to all projects)
 organization in ThisBuild := "com.gu"
 version in ThisBuild := "0.2.0"
@@ -78,6 +80,16 @@ lazy val hq = (project in file("hq"))
     unmanagedSourceDirectories in Test += baseDirectory.value / "test" / "jars",
     parallelExecution in Test := false,
     fork in Test := false,
+
+    // start DynamoDB on run
+    dynamoDBLocalDownloadDir := file(".dynamodb-local"),
+    dynamoDBLocalPort := 8000,
+    dynamoDBLocalDownloadIfOlderThan := 14.days,
+    startDynamoDBLocal := startDynamoDBLocal.dependsOn(compile in Compile).value,
+    run in Compile := (run in Compile).dependsOn(startDynamoDBLocal).evaluated,
+    dynamoDBLocalSharedDB := true,
+    dynamoDBLocalInMemory := false,
+    dynamoDBLocalDBPath := Some(System.getProperty("user.home") ++ "/.gu/security-hq"),
 
     serverLoading in Debian := Some(Systemd),
     debianPackageDependencies := Seq("openjdk-8-jre-headless"),

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -46,6 +46,7 @@ class AppComponents(context: Context)
   )
 
   private val stack = configuration.get[String]("stack")
+  private val stage = Config.getStage(configuration)
 
   // the aim of this is to get a list of available regions that we are able to access
   // note that:
@@ -89,10 +90,7 @@ class AppComponents(context: Context)
     .build()
   private val securityCenterSettings = SecurityCenterSettings.newBuilder().setCredentialsProvider(Config.gcpCredentialsProvider(configuration)).build()
   private val securityCenterClient = SecurityCenterClient.create(securityCenterSettings)
-  private val dynamoDbClient = AmazonDynamoDBClientBuilder.standard()
-    .withCredentials(securityCredentialsProvider)
-    .withRegion(Config.region)
-    .build()
+  private val dynamoDbClient = AWS.dynamoDbClient(securityCredentialsProvider, Config.region, stage)
   private val securityS3Client = AmazonS3ClientBuilder.standard()
     .withCredentials(securityCredentialsProvider)
     .withRegion(Config.region)

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Creates the directory where DynamoDbLocal will store its state as a file
+# Creates a table with the the right schema
+
+mkdir -p ~/.gu/security-hq
+
+aws dynamodb create-table --table-name security-hq-iam-TEST \
+    --attribute-definitions AttributeName=id,AttributeType=S AttributeName=dateNotificationSent,AttributeType=N \
+    --key-schema AttributeName=id,KeyType=HASH AttributeName=dateNotificationSent,KeyType=RANGE \
+    --billing-mode PAY_PER_REQUEST \
+    --endpoint-url http://localhost:8000 \
+    --region eu-west-1

--- a/script/setup
+++ b/script/setup
@@ -4,7 +4,7 @@
 
 mkdir -p ~/.gu/security-hq
 
-aws dynamodb create-table --table-name security-hq-iam-TEST \
+aws dynamodb create-table --table-name security-hq-iam-DEV \
     --attribute-definitions AttributeName=id,AttributeType=S AttributeName=dateNotificationSent,AttributeType=N \
     --key-schema AttributeName=id,KeyType=HASH AttributeName=dateNotificationSent,KeyType=RANGE \
     --billing-mode PAY_PER_REQUEST \


### PR DESCRIPTION
## What does this change?

This PR makes security hq's dynamo db client connect to `localhost:8000` instead of aws when running locally. To that effect this PR patches the sbt configuration to have `DynamoDbLocal` automatically started, and introduces an initialisation script for the database table and the directory that will hold it between applications runs.


## Will this require CloudFormation and/or updates to the AWS StackSet?

No
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?

No
<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->
