### PR TITLE
Upgrade SBT to 1.5.7

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.5.7


### PR DESCRIPTION
## What does this change?
Upgrades sbt to 1.5.7 in order to include the latest version of log4j (2.16.0), which is patched to mitigate CVE-2021-44228

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Running latest sbt is valuable anyway for all the usual reasons, but mostly to avoid log4j-introduced vulnerability of any kind

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
