### PR TITLE
Upgrade SBT to 1.5.7 to protect from log4j exploit

### DIFF
--- a/hq/app/auth/SecurityHQAuthActions.scala
+++ b/hq/app/auth/SecurityHQAuthActions.scala
@@ -15,9 +15,9 @@ trait SecurityHQAuthActions extends LoginSupport {
   implicit val bodyParser: BodyParser[AnyContent]
   implicit val ec: ExecutionContext
 
-  val loginTarget: Call = routes.AuthController.login()
-  override val failureRedirectTarget: Call = routes.AuthController.loginError()
-  override val defaultRedirectTarget: Call = routes.HQController.index()
+  val loginTarget: Call = routes.AuthController.login
+  override val failureRedirectTarget: Call = routes.AuthController.loginError
+  override val defaultRedirectTarget: Call = routes.HQController.index
   override val authConfig: GoogleAuthConfig
 
   val googleGroupChecker = Config.googleGroupChecker

--- a/hq/app/controllers/AuthController.scala
+++ b/hq/app/controllers/AuthController.scala
@@ -25,7 +25,7 @@ class AuthController(environment: Environment, val config: Configuration, val au
   }
 
   def logout = Action { implicit request =>
-    Redirect(routes.HQController.index()).withNewSession
+    Redirect(routes.HQController.index).withNewSession
   }
 
   def oauthCallback = Action.async { implicit request =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.4
+sbt.version=1.5.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("com.localytics" % "sbt-dynamodb" % "2.0.2")
 libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts Artifact("jdeb", "jar", "jar")
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.1")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.11")
 
 // web plugins
 
@@ -22,6 +22,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.2")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 


### PR DESCRIPTION
## What does this change?
Due to the log4j exploit, this PR upgrades sbt to 1.5.7 where log4j has been updated to a safe version. 

## What is the value of this?

This means that it should not be possible for SHQ to be compromised using log4j in sbt. This possibility is very much an edge case, but this change seems prudent nevertheless.

## Will this require CloudFormation and/or updates to the AWS StackSet?
No.

## Will this require changes to config?
No.

## Any additional notes?
The sbt upgrade also required a play upgrade, which triggered binary incompatibility warnings with scala-java8-compat. This has been fixed using a `libraryDependencySchemes` setting as described here: https://github.com/guardian/status-app/pull/94/files/23687b0a44a0b0ad3afad39a19d903b4b22e6160#diff-5634c415cd8c8504fdb973a3ed092300b43c4b8fc1e184f7249eb29a55511f91R17.
