### PR TITLE
Treat missing login profile as successful password removal

### DIFF
--- a/hq/app/schedule/vulnerable/IamRemovePassword.scala
+++ b/hq/app/schedule/vulnerable/IamRemovePassword.scala
@@ -1,17 +1,17 @@
 package schedule.vulnerable
 
-import aws.AwsAsyncHandler.{awsToScala, handleAWSErrs}
-import aws.AwsClients
+import aws.AwsAsyncHandler.awsToScala
 import aws.iam.IAMClient.SOLE_REGION
+import aws.{AwsAsyncHandler, AwsClient, AwsClients}
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
-import com.amazonaws.services.identitymanagement.model.{DeleteLoginProfileRequest, DeleteLoginProfileResult}
+import com.amazonaws.services.identitymanagement.model.{DeleteLoginProfileRequest, DeleteLoginProfileResult, NoSuchEntityException}
 import logging.Cloudwatch
 import logging.Cloudwatch.ReaperExecutionStatus
 import model.{AwsAccount, VulnerableUser}
 import play.api.Logging
 import utils.attempt.Attempt
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 object IamRemovePassword extends Logging {
 
@@ -24,22 +24,26 @@ object IamRemovePassword extends Logging {
       val result: Attempt[Option[DeleteLoginProfileResult]] = for {
         client <- iamClients.get(account, SOLE_REGION)
         request = new DeleteLoginProfileRequest().withUserName(user.username)
-        deleteResult <- handleAWSErrs(client)(awsToScala(client)(_.deleteLoginProfileAsync)(request))
-      } yield Some(deleteResult)
-      result.fold(
-        { failure =>
-          logger.error(s"failed to delete password for username: ${user.username}. ${failure.logMessage}")
-          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure)
-        },
-        { success =>
-          logger.info(s"password deleted for ${user.username}. DeleteLoginProfile Response: ${success.map(_.getSdkResponseMetadata.getRequestId)}.")
-          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success)
+        response = awsToScala(client)(_.deleteLoginProfileAsync)(request)
+        deleteResult <- handleAWSErrs(client, user)(response)
+      } yield deleteResult
+      result.tap {
+          case Left(failure) =>
+            logger.error(s"failed to delete password for username: ${user.username}. ${failure.logMessage}")
+            Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure)
+          case Right(success) =>
+            logger.info(s"password deleted for ${user.username}. DeleteLoginProfile Response: ${success.map(_.getSdkResponseMetadata.getRequestId)}.")
+            Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success)
         }
-      )
-      result
     } else {
       logger.info(s"will not attempt to remove password, because this ${user.username} is a machine user.")
       Attempt.Right(None)
     }
   }
+
+  def handleAWSErrs(awsClient: AwsClient[AmazonIdentityManagementAsync], user: VulnerableUser)(f: => Future[DeleteLoginProfileResult])(implicit ec: ExecutionContext): Attempt[Option[DeleteLoginProfileResult]] =
+    AwsAsyncHandler.handleAWSErrs(awsClient)(f.map(Some.apply).recover({
+      case e if e.getMessage.contains(s"Login Profile for User ${user.username} cannot be found") => None
+      case _: NoSuchEntityException => None
+    }))
 }


### PR DESCRIPTION
## What does this change?
This adds error recovery during attempts to remove a login profile (i.e. password) from an IAM user. Currently we handle errors from AWS by transforming them into more helpful `FailedAttempt` types, but generally there hasn't yet been a need to recover from an error by treating it as a successful attempt. However, we don't actually care if a password we try to remove no longer exists (very possible due to the current 4 hour lag in source data from the credentials report), so in this instance we treat it as a success.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
If the jobs that utilise this feature are run more frequently, they will not fail when attempting to remove passwords multiple times.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
If interested, there were alternative, more generic, approaches explored in #381 and #382. Since we're only needing to do error recovery in one place at the moment, this is probably the better approach to avoid unnecessary abstraction.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
