### PR TITLE
Outline "Password no MFA" job

### DIFF
--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -63,16 +63,16 @@ object IamRemediation extends Logging {
     } && key.keyStatus == AccessKeyEnabled
   }
 
-  def identityAllUsersWithPasswordNoMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)], now: DateTime): List[(AwsAccount, List[IAMUser])] = {
+  def identityAllUsersWithPasswordMissingMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)], now: DateTime): List[(AwsAccount, List[IAMUser])] = {
     accountCredentialReports.map { case (awsAccount, credentialReport) =>
-      (awsAccount, identityUsersWithPasswordNoMFA(credentialReport, now))
+      (awsAccount, identityUsersWithPasswordMissingMFA(credentialReport, now))
     }
   }
 
   /**
    * Looks through the credentials report to identify users with passwords, but no MFA
    */
-  private[logic] def identityUsersWithPasswordNoMFA(credentialReportDisplay: CredentialReportDisplay, now: DateTime): List[IAMUser] = ???
+  private[logic] def identityUsersWithPasswordMissingMFA(credentialReportDisplay: CredentialReportDisplay, now: DateTime): List[IAMUser] = ???
 
   /**
     * Given an IAMUser (in an AWS account), look up that user's activity history form the Database.

--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -33,14 +33,14 @@ object IamRemediation extends Logging {
     */
   def identifyAllUsersWithOutdatedCredentials(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)], now: DateTime): List[(AwsAccount, List[IAMUser])] = {
     accountCredentialReports.map { case (awsAccount, credentialReport) =>
-      (awsAccount, identifyUsersWithOutdatedCredentials(awsAccount, credentialReport, now))
+      (awsAccount, identifyUsersWithOutdatedCredentials(credentialReport, now))
     }
   }
 
   /**
     * Looks through the credentials report to identify users with Access Keys that are older than we allow.
     */
-  def identifyUsersWithOutdatedCredentials(awsAccount: AwsAccount, credentialReportDisplay: CredentialReportDisplay, now: DateTime): List[IAMUser] = {
+  def identifyUsersWithOutdatedCredentials(credentialReportDisplay: CredentialReportDisplay, now: DateTime): List[IAMUser] = {
     credentialReportDisplay.machineUsers.filter(user => hasOutdatedMachineKey(List(user.key1, user.key2), now)).toList ++
       credentialReportDisplay.humanUsers.filter(user => hasOutdatedHumanKey(List(user.key1, user.key2), now))
   }

--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -97,10 +97,8 @@ object IamRemediation extends Logging {
     * Looks through the candidate's remediation history and outputs the work to be done per access key.
     * This means that the same user could appear in the output list twice, because both of their keys may require an operation.
     * By comparing the current date with the date of the most recent activity, we know which operation to perform next.
-   *
-   * TODO: this should be generic for all IAMProblem types (i.e. it should also work for passwords with no MFA)
     */
-  def calculateOutstandingOperations(remediationHistories: List[IamUserRemediationHistory], now: DateTime): List[RemediationOperation] = {
+  def calculateOutstandingAccessKeyOperations(remediationHistories: List[IamUserRemediationHistory], now: DateTime): List[RemediationOperation] = {
     for {
       userRemediationHistory <- remediationHistories
       vulnerableKey <- identifyVulnerableKeys(userRemediationHistory, now)
@@ -140,6 +138,11 @@ object IamRemediation extends Logging {
         None
     }
   }
+
+  /**
+   * Looks through the candidate's remediation history and outputs the operations to be done.
+   */
+  def calculateOutstandingPasswordOperations(remediationHistories: List[IamUserRemediationHistory], now: DateTime): List[RemediationOperation] = ???
 
   private[logic] def identifyRemediationOperation(mostRecentRemediationActivity: Option[IamRemediationActivity], now: DateTime,
     userRemediationHistory: IamUserRemediationHistory): Option[RemediationOperation] =

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -87,7 +87,7 @@ class IamRemediationService(
       rawCredsReports = cacheService.getAllCredentials
       accountsCredReports = getCredsReportDisplayForAccount(rawCredsReports)
       // identify users with outdated credentials for each account, from the credentials report
-      accountUsersWithOutdatedCredentials = identityAllUsersWithPasswordNoMFA(accountsCredReports, now)
+      accountUsersWithOutdatedCredentials = identityAllUsersWithPasswordMissingMFA(accountsCredReports, now)
       // DB lookup of previous SHQ activity for each user to produce a list of "candidate" vulnerabilities
       vulnerabilitiesWithRemediationHistory <- lookupActivityHistory(accountUsersWithOutdatedCredentials, dynamo)
       // based on activity history, decide which of these candidates have outstanding SHQ operations

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -51,7 +51,7 @@ class IamRemediationService(
       // DB lookup of previous SHQ activity for each user to produce a list of "candidate" vulnerabilities
       vulnerabilitiesWithRemediationHistory <- lookupActivityHistory(accountUsersWithOutdatedCredentials, dynamo)
       // based on activity history, decide which of these candidates have outstanding SHQ operations
-      outstandingOperations = calculateOutstandingOperations(vulnerabilitiesWithRemediationHistory, now)
+      outstandingOperations = calculateOutstandingAccessKeyOperations(vulnerabilitiesWithRemediationHistory, now)
       // we'll only perform operations on accounts that have been configured as eligible
       filteredOperations = partitionOperationsByAllowedAccounts(outstandingOperations, allowedAwsAccountIds)
       // we won't execute these operations, but can log them instead
@@ -90,8 +90,8 @@ class IamRemediationService(
       accountUsersWithOutdatedCredentials = identityAllUsersWithPasswordNoMFA(accountsCredReports, now)
       // DB lookup of previous SHQ activity for each user to produce a list of "candidate" vulnerabilities
       vulnerabilitiesWithRemediationHistory <- lookupActivityHistory(accountUsersWithOutdatedCredentials, dynamo)
-      // based on activity history, decide which of these candidates have outstanding SHQ operations TODO: this isn't yet coded for password problems
-      outstandingOperations = calculateOutstandingOperations(vulnerabilitiesWithRemediationHistory, now)
+      // based on activity history, decide which of these candidates have outstanding SHQ operations
+      outstandingOperations = calculateOutstandingPasswordOperations(vulnerabilitiesWithRemediationHistory, now)
       // we'll only perform operations on accounts that have been configured as eligible
       filteredOperations = partitionOperationsByAllowedAccounts(outstandingOperations, allowedAwsAccountIds)
       // we won't execute these operations, but can log them instead

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -64,37 +64,37 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
 
     "given a vulnerable human user, return that user" in {
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanWithOneOldEnabledAccessKey))
-      identifyUsersWithOutdatedCredentials(account, credsReport, date).map(_.username) shouldEqual List("amina.adewusi")
+      identifyUsersWithOutdatedCredentials(credsReport, date).map(_.username) shouldEqual List("amina.adewusi")
     }
     "given a vulnerable machine user, return that user" in {
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldEnabledAccessKey), Seq())
-      identifyUsersWithOutdatedCredentials(account, credsReport, date).map(_.username) shouldEqual List("machine1")
+      identifyUsersWithOutdatedCredentials(credsReport, date).map(_.username) shouldEqual List("machine1")
     }
     "given a vulnerable human and machine user, return both users" in {
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldEnabledAccessKey), Seq(humanWithOneOldEnabledAccessKey))
-      identifyUsersWithOutdatedCredentials(account, credsReport, date).map(_.username) should contain allOf ("amina.adewusi", "machine1")
+      identifyUsersWithOutdatedCredentials(credsReport, date).map(_.username) should contain allOf ("amina.adewusi", "machine1")
     }
     "given users with old disabled keys, return an empty list" in {
       val humanWithOneOldDisabledAccessKey = HumanUser("adam.fisher", true, noAccessKey, AccessKey(AccessKeyDisabled, Some(date.minusMonths(4))), Green, None, None, Nil)
       val machineAccessKeyOldAndDisabled = AccessKey(AccessKeyDisabled, Some(date.minusMonths(13)))
       val machineWithOneOldDisabledAccessKey = MachineUser("machine3", noAccessKey, machineAccessKeyOldAndDisabled, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldDisabledAccessKey), Seq(humanWithOneOldDisabledAccessKey))
-      identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
+      identifyUsersWithOutdatedCredentials(credsReport, date) shouldBe empty
     }
     "given no users with access keys, return an empty list" in {
       val humanWithNoKeys = HumanUser("jorge.azevedo", true, noAccessKey, noAccessKey, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanWithNoKeys))
-      identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
+      identifyUsersWithOutdatedCredentials(credsReport, date) shouldBe empty
     }
     "given no vulnerable access keys, return an empty list" in {
       val machineAccessKeyHealthyAndEnabled = AccessKey(AccessKeyEnabled, Some(date.minusMonths(11)))
       val machineWithHealthyKey = MachineUser("machine4", noAccessKey, machineAccessKeyHealthyAndEnabled, Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(machineWithHealthyKey), Seq(humanWithHealthyKey))
-      identifyUsersWithOutdatedCredentials(account, credsReport, date) shouldBe empty
+      identifyUsersWithOutdatedCredentials(credsReport, date) shouldBe empty
     }
     "given a machine user whose access key was last rotated exactly on the last acceptable healthy rotation date, return user" in {
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldEnabledAccessKey2), Seq())
-      identifyUsersWithOutdatedCredentials(account, credsReport, date) should have length 1
+      identifyUsersWithOutdatedCredentials(credsReport, date) should have length 1
     }
   }
 

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -122,20 +122,20 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     val machineTwoKeysRequireAction = IamUserRemediationHistory(account, machineWithTwoOldEnabledAccessKeys, List(machineActivityWarningLastNotificationEqualToCadence, machineActivityWarningKeyLastRotatedEqualCadenceThreshold))
 
     "given two users, each with 2 keys that require operations, output a list of size 4" in {
-      calculateOutstandingOperations(List(humanBothKeysRequireAction, machineTwoKeysRequireAction), date) should have length 4
+      calculateOutstandingAccessKeyOperations(List(humanBothKeysRequireAction, machineTwoKeysRequireAction), date) should have length 4
     }
     "given two users, each with 1 key that requires an operation, output a list of size 2" in {
-      calculateOutstandingOperations(List(humanOneKeyRequiresAction,  machineOneKeyWarning), date) should have length 2
+      calculateOutstandingAccessKeyOperations(List(humanOneKeyRequiresAction,  machineOneKeyWarning), date) should have length 2
     }
     "given one user with 2 keys that require an operation, output a list of size 2" in {
-      calculateOutstandingOperations(List(machineTwoKeysRequireAction), date) should have length 2
+      calculateOutstandingAccessKeyOperations(List(machineTwoKeysRequireAction), date) should have length 2
     }
     "given one user with 1 key that requires an operation, output a list of size 1" in {
-      calculateOutstandingOperations(List(humanOneKeyRequiresAction), date) should have length 1
+      calculateOutstandingAccessKeyOperations(List(humanOneKeyRequiresAction), date) should have length 1
     }
     // this scenario should never happen, keeping this test here to note this.
     "given an empty input list, return an empty output list" in {
-      calculateOutstandingOperations(Nil, date) shouldEqual Nil
+      calculateOutstandingAccessKeyOperations(Nil, date) shouldEqual Nil
     }
 
     "identifyRemediationOperation" - {


### PR DESCRIPTION
## What does this change?
Adds the outline for a new remediation job that will remove passwords where there is no associated MFA. This follows the same pattern as the reworked "Outdated Credentials" job, so we can re-use a lot from there. The remaining work in filling out this job has been added as tasks to trello.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Starts work to implement the second remediation job in the new structure.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
This job (and the outdated credentials one) are not yet called/run from anywhere

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
