### PR TITLE
Identify human users without MFA

### DIFF
--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -63,7 +63,7 @@ object IamRemediation extends Logging {
     } && key.keyStatus == AccessKeyEnabled
   }
 
-  def identityAllUsersWithPasswordMissingMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)], now: DateTime): List[(AwsAccount, List[IAMUser])] = {
+  def identityAllUsersWithPasswordMissingMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)]): List[(AwsAccount, List[IAMUser])] = {
     accountCredentialReports.map { case (awsAccount, credentialReport) =>
       (awsAccount, identityUsersWithPasswordMissingMFA(credentialReport))
     }

--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -63,16 +63,18 @@ object IamRemediation extends Logging {
     } && key.keyStatus == AccessKeyEnabled
   }
 
-  def identityAllUsersWithPasswordNoMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)], now: DateTime): List[(AwsAccount, List[IAMUser])] = {
+  def identityAllUsersWithPasswordNoMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)]): List[(AwsAccount, List[IAMUser])] = {
     accountCredentialReports.map { case (awsAccount, credentialReport) =>
-      (awsAccount, identityUsersWithPasswordNoMFA(credentialReport, now))
+      (awsAccount, identifyUsersWithPasswordNoMFA(credentialReport))
     }
   }
 
   /**
    * Looks through the credentials report to identify users with passwords, but no MFA
    */
-  private[logic] def identityUsersWithPasswordNoMFA(credentialReportDisplay: CredentialReportDisplay, now: DateTime): List[IAMUser] = ???
+  private[logic] def identifyUsersWithPasswordNoMFA(credentialReportDisplay: CredentialReportDisplay): List[IAMUser] = {
+    credentialReportDisplay.humanUsers.filterNot(_.hasMFA).toList
+  }
 
   /**
     * Given an IAMUser (in an AWS account), look up that user's activity history form the Database.

--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -63,16 +63,16 @@ object IamRemediation extends Logging {
     } && key.keyStatus == AccessKeyEnabled
   }
 
-  def identityAllUsersWithPasswordMissingMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)]): List[(AwsAccount, List[IAMUser])] = {
+  def identifyAllUsersWithPasswordMissingMFA(accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)]): List[(AwsAccount, List[IAMUser])] = {
     accountCredentialReports.map { case (awsAccount, credentialReport) =>
-      (awsAccount, identityUsersWithPasswordMissingMFA(credentialReport))
+      (awsAccount, identifyUsersWithPasswordMissingMFA(credentialReport))
     }
   }
 
   /**
    * Looks through the credentials report to identify users with passwords, but no MFA
    */
-  private[logic] def identityUsersWithPasswordMissingMFA(credentialReportDisplay: CredentialReportDisplay): List[IAMUser] = {
+  private[logic] def identifyUsersWithPasswordMissingMFA(credentialReportDisplay: CredentialReportDisplay): List[IAMUser] = {
     credentialReportDisplay.humanUsers.filterNot(_.hasMFA).toList
   }
 

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -87,7 +87,7 @@ class IamRemediationService(
       rawCredsReports = cacheService.getAllCredentials
       accountsCredReports = getCredsReportDisplayForAccount(rawCredsReports)
       // identify users with outdated credentials for each account, from the credentials report
-      accountUsersWithOutdatedCredentials = identityAllUsersWithPasswordNoMFA(accountsCredReports, now)
+      accountUsersWithOutdatedCredentials = identityAllUsersWithPasswordNoMFA(accountsCredReports)
       // DB lookup of previous SHQ activity for each user to produce a list of "candidate" vulnerabilities
       vulnerabilitiesWithRemediationHistory <- lookupActivityHistory(accountUsersWithOutdatedCredentials, dynamo)
       // based on activity history, decide which of these candidates have outstanding SHQ operations TODO: this isn't yet coded for password problems

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -87,7 +87,7 @@ class IamRemediationService(
       rawCredsReports = cacheService.getAllCredentials
       accountsCredReports = getCredsReportDisplayForAccount(rawCredsReports)
       // identify users with outdated credentials for each account, from the credentials report
-      accountUsersWithOutdatedCredentials = identityAllUsersWithPasswordMissingMFA(accountsCredReports)
+      accountUsersWithOutdatedCredentials = identifyAllUsersWithPasswordMissingMFA(accountsCredReports)
       // DB lookup of previous SHQ activity for each user to produce a list of "candidate" vulnerabilities
       vulnerabilitiesWithRemediationHistory <- lookupActivityHistory(accountUsersWithOutdatedCredentials, dynamo)
       // based on activity history, decide which of these candidates have outstanding SHQ operations

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -102,19 +102,19 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     "given a user with a password and No MFA, should return that user" in {
       val humanUserWithNoMFA = HumanUser("jon.soul", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red(), None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanUserWithNoMFA))
-      identifyUsersWithPasswordNoMFA(credsReport).map(_.username) shouldEqual List(humanUserWithNoMFA.username)
+      identifyUsersWithPasswordMissingMFA(credsReport).map(_.username) shouldEqual List(humanUserWithNoMFA.username)
     }
 
     "given a user with a password and MFA, should return not that user" in {
       val humanUserWithMFA = HumanUser("jon.soul", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanUserWithMFA))
-      identifyUsersWithPasswordNoMFA(credsReport).map(_.username) shouldBe List.empty
+      identifyUsersWithPasswordMissingMFA(credsReport).map(_.username) shouldBe List.empty
     }
 
     "given a machine user, should return not that user" in {
       val machineUser = MachineUser("jon.soul", AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
       val credsReport = CredentialReportDisplay(date, Seq(machineUser), Seq())
-      identifyUsersWithPasswordNoMFA(credsReport).map(_.username) shouldBe List.empty
+      identifyUsersWithPasswordMissingMFA(credsReport).map(_.username) shouldBe List.empty
     }
   }
 

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -98,6 +98,26 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     }
   }
 
+  "identifyUsersWithPasswordNoMFA" - {
+    "given a user with a password and No MFA, should return that user" in {
+      val humanUserWithNoMFA = HumanUser("jon.soul", hasMFA = false, AccessKey(NoKey, None), AccessKey(NoKey, None), Red(), None, None, Nil)
+      val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanUserWithNoMFA))
+      identifyUsersWithPasswordNoMFA(credsReport).map(_.username) shouldEqual List(humanUserWithNoMFA.username)
+    }
+
+    "given a user with a password and MFA, should return not that user" in {
+      val humanUserWithMFA = HumanUser("jon.soul", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
+      val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanUserWithMFA))
+      identifyUsersWithPasswordNoMFA(credsReport).map(_.username) shouldBe List.empty
+    }
+
+    "given a machine user, should return not that user" in {
+      val machineUser = MachineUser("jon.soul", AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, Nil)
+      val credsReport = CredentialReportDisplay(date, Seq(machineUser), Seq())
+      identifyUsersWithPasswordNoMFA(credsReport).map(_.username) shouldBe List.empty
+    }
+  }
+
   "calculateOutstandingOperations" - {
     // human activities - warning
     val humanActivityWarningLastNotificationGreaterThanCadence = IamRemediationActivity(account.id, humanWithOneOldEnabledAccessKey.username, date.minusDays(daysBetweenWarningAndFinalNotification + 1), Warning, OutdatedCredential, humanAccessKeyOldAndEnabled1.lastRotated.get)


### PR DESCRIPTION
## What does this change?
Adds an implementation and tests for the method we use to identify human users (those with passwords) but with no MFA enabled.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Starts filling in the implementation of a job to disable users who have a password without MFA enabled

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
