### PR TITLE
Schedule and instantiate IamRemediationService

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -11,6 +11,7 @@ import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder
 import com.google.cloud.securitycenter.v1.{SecurityCenterClient, SecurityCenterSettings}
 import config.Config
 import controllers._
+import db.IamRemediationDb
 import filters.HstsFilter
 import model.AwsAccount
 import org.quartz.impl.StdSchedulerFactory
@@ -24,7 +25,7 @@ import play.filters.csrf.CSRFComponents
 import router.Routes
 import schedule.JobScheduler
 import schedule.unrecognised.IamUnrecognisedUserJob
-import services.{CacheService, MetricService}
+import services.{CacheService, IamRemediationService, MetricService}
 import utils.attempt.Attempt
 
 import scala.concurrent.Await
@@ -118,6 +119,16 @@ class AppComponents(context: Context)
     environment,
     cacheService
   )
+
+  new IamRemediationService(
+    cacheService,
+    securitySnsClient,
+    new IamRemediationDb(dynamoDbClient),
+    configuration,
+    iamClients,
+    applicationLifecycle,
+    environment
+  )(executionContext)
 
   val unrecognisedUserJob = new IamUnrecognisedUserJob(cacheService, securitySnsClient, securityS3Client, iamClients, configuration)(executionContext)
 

--- a/hq/conf/application.conf
+++ b/hq/conf/application.conf
@@ -64,6 +64,7 @@ alert {
     iamUnrecognisedUserS3Bucket = ${IAM_UNRECOGNISED_USER_S3_BUCKET}
     iamUnrecognisedUserS3Key = ${IAM_UNRECOGNISED_USER_S3_KEY}
     allowedAccountIds = ${ALLOWED_ACCOUNT_IDS}
+    accountIdsForIamRemediationService = ${ACCOUNT_IDS_FOR_IAM_REMEDIATION_SERVICE}
 }
 
 ## Akka

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -283,15 +283,16 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     val operationsForAccountB = operationForAccountId("b", "machineUser2")
     val operationsForAccountC = operationForAccountId("c", "machineUser3")
     val operations = List(operationsForAccountA, operationsForAccountB, operationsForAccountC)
+    val serviceAccounts = List("a", "b", "c")
 
     "if allowedAccounts is empty" - {
       val allowedAccounts = Nil
       "then all operations are not allowed" in {
-        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts, serviceAccounts).operationsOnAccountsThatAreNotAllowed
         forbidden shouldEqual operations
       }
       "then allowed operations is empty" in {
-        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts, serviceAccounts).allowedOperations
         allowed shouldEqual Nil
       }
     }
@@ -299,23 +300,27 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     "if there is one allowed account provided" - {
       val allowedAccounts = List("a")
       "then all operations that don't match provided allowed account are forbidden" in {
-        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts, serviceAccounts).operationsOnAccountsThatAreNotAllowed
         forbidden shouldEqual List(operationsForAccountB, operationsForAccountC)
       }
       "then allowed operations matches provided allowed account" in {
-        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts, serviceAccounts).allowedOperations
         allowed shouldEqual List(operationsForAccountA)
+      }
+      "and it is not an account that is a client of the remediation service, allowed operations is empty" in {
+        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts, List("b", "c")).allowedOperations
+        allowed shouldEqual Nil
       }
     }
 
     "if multiple allowed accounts are provided" - {
       val allowedAccounts = List("a", "b")
       "then all operations that don't match any allowed accounts are forbidden" in {
-        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        val forbidden = partitionOperationsByAllowedAccounts(operations, allowedAccounts, serviceAccounts).operationsOnAccountsThatAreNotAllowed
         forbidden shouldEqual List(operationsForAccountC)
       }
       "then matching operations are allowed" in {
-        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts).allowedOperations
+        val allowed = partitionOperationsByAllowedAccounts(operations, allowedAccounts, serviceAccounts).allowedOperations
         allowed shouldEqual List(operationsForAccountA, operationsForAccountB)
       }
     }
@@ -323,11 +328,11 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     "if operations to partition is empty" - {
       val allowedAccounts = List("a", "b")
       "then forbidden operations should also be empty" in {
-        val forbidden = partitionOperationsByAllowedAccounts(Nil, allowedAccounts).operationsOnAccountsThatAreNotAllowed
+        val forbidden = partitionOperationsByAllowedAccounts(Nil, allowedAccounts, serviceAccounts).operationsOnAccountsThatAreNotAllowed
         forbidden shouldEqual Nil
       }
       "then allowed operations should also be empty" in {
-        val allowed = partitionOperationsByAllowedAccounts(Nil, allowedAccounts).allowedOperations
+        val allowed = partitionOperationsByAllowedAccounts(Nil, allowedAccounts, serviceAccounts).allowedOperations
         allowed shouldEqual Nil
       }
     }


### PR DESCRIPTION
## What does this change?
This PR adds scheduling and instantiates the `IamRemediationService` so that it will be triggered when the app starts and will run every 5 hours.

In addition, it adds an additional config property; a list of AWS account Ids for which the remediation service is run on. Also, this PR changes the cadence of the remediation service, so that it can be tested more easily. 

## What is the value of this?
The additional config value means that the feature can be rolled out more incrementally, because not all accounts are ready for this service to be turned on.

## Will this require CloudFormation and/or updates to the AWS StackSet?
No.

## Will this require changes to config?
Yes! Here is the new config property, `ACCOUNT_IDS_FOR_IAM_REMEDIATION_SERVICE`, which is a list of AWS Account Ids.

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
Here is the rollout plan:
1. Add Deploy Tools and Domains to the list of account Ids in config
2. Deploy this branch to PROD and check that the expected operations take place everyday.
3. Revert the cadence change back to 7 days from the 1 day that this PR changed it to (`daysBetweenWarningAndFinalNotification` and `daysBetweenFinalNotificationAndRemediation`).
3. Add other accounts to the list in config which don't currently have any outdated credentials
4. Discuss a roadmap with teams that do have outdated credentials to determine when the service can be run in their account.
