### PR TITLE
Outdated credentials job bug fixes

### DIFF
--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -105,7 +105,7 @@ object IamRemediation extends Logging {
       userRemediationHistory <- remediationHistories
       vulnerableKey <- identifyVulnerableKeys(userRemediationHistory, now)
       keyPreviousAlert = identifyMostRecentActivity(userRemediationHistory, vulnerableKey)
-      keyNextActivity <- identifyRemediationOperation(keyPreviousAlert, now, userRemediationHistory)
+      keyNextActivity <- identifyRemediationOperation(keyPreviousAlert, now, userRemediationHistory, vulnerableKey)
     } yield keyNextActivity
   }
 
@@ -151,7 +151,7 @@ object IamRemediation extends Logging {
     mostRecentRemediationActivity match {
       case None =>
         // If there is no recent activity, then the required operation must be a Warning.
-        Some(RemediationOperation(userRemediationHistory, Warning, OutdatedCredential, problemCreationDate = now))
+        Some(RemediationOperation(userRemediationHistory, Warning, OutdatedCredential, problemCreationDate = vulnerableKey.lastRotated.getOrElse(now)))
       case Some(mostRecentActivity) =>
         mostRecentActivity.iamRemediationActivityType match {
         case Warning if now.isAfter(mostRecentActivity.dateNotificationSent.plusDays(daysBetweenWarningAndFinalNotification - 1)) =>

--- a/hq/app/logic/IamRemediation.scala
+++ b/hq/app/logic/IamRemediation.scala
@@ -120,18 +120,14 @@ object IamRemediation extends Logging {
     vulnerableKey.lastRotated match {
       case Some(lastRotatedDate) =>
         // filter activity list to find matching db records for given access key
-        val keyPreviousActivities = remediationHistory.activityHistory.filter { activity =>
-          activity.problemCreationDate.withTimeAtStartOfDay == lastRotatedDate.withTimeAtStartOfDay()
-        }
+        val keyPreviousActivities = remediationHistory.activityHistory.filter(_.problemCreationDate.isEqual(lastRotatedDate))
         keyPreviousActivities match {
           case Nil =>
             // there is no recent activity for the given access key, so return None.
             None
           case remediationActivities =>
             // get the most recent remediation activity
-            Some(remediationActivities.maxBy { activity =>
-              Days.daysBetween(activity.problemCreationDate.withTimeAtStartOfDay(), activity.dateNotificationSent.withTimeAtStartOfDay()).getDays
-            })
+            Some(remediationActivities.maxBy(_.dateNotificationSent.getMillis))
         }
       case None =>
         val name = remediationHistory.iamUser.username

--- a/hq/app/notifications/AnghammaradNotifications.scala
+++ b/hq/app/notifications/AnghammaradNotifications.scala
@@ -44,7 +44,7 @@ object AnghammaradNotifications extends Logging {
          |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
          |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
          |(if you're already planning on doing this, please ignore this message).
-         |If this is not rectified before ${printDay(now.plusDays(daysBetweenWarningAndFinalNotification))}, Security HQ will automatically disable this user."
+         |If this is not rectified before ${printDay(now.plusDays(daysBetweenWarningAndFinalNotification + daysBetweenFinalNotificationAndRemediation))}, Security HQ will automatically disable this user."
          |""".stripMargin
     val subject = s"Action ${awsAccount.name}: Vulnerable credential"
     Notification(subject, message + genericOutdatedCredentialText, Nil, List(Account(awsAccount.accountNumber)), channel, sourceSystem)


### PR DESCRIPTION
## What does this change?
Adds a few small bug fixes to the outdated credentials job which we have been testing in the `Domains` account. Namely:
- (Main fix) the `problemCreationDate` is correctly initialised to the last rotated date of the vulnerable access key, rather than the time the job ran, which will correct both the notification message and importantly allow the job to find previous warnings
- Simplifies the filtering of the activity history and removes the day-level-granularity comparison, preferring exact equality. This should prevent mix ups between keys created on the same day.
- Small correction to the rectification date on the initial warning email
- Adjusts the conditions for when a final warning or remediation should be performed, giving at least a day's grace between stages of remediation (unless `daysBetweenWarningAndFinalNotification` is configured to be zero or less)

The first commit in this PR can be ignored for now, I will revert it before merging. It just helps with testing.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Correctly functioning outdated credentials job.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
