### PR TITLE
Add build server protocol directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ project/project
 
 # DynamoDB local
 .dynamodb-local
+
+# Build server protocol (introduced in sbt 1.4.0)
+.bsp


### PR DESCRIPTION
## What does this change?
Adds the `.bsp` directory to the gitignore file. This is a directory used by the build server protocol, adopted in sbt 1.4.0 which we recently updated to.

Ref: https://www.scala-lang.org/blog/2020/10/27/bsp-in-sbt.html