### PR TITLE
Clarify remediation date in notification and remove extra quotes

### DIFF
--- a/hq/app/notifications/AnghammaradNotifications.scala
+++ b/hq/app/notifications/AnghammaradNotifications.scala
@@ -44,7 +44,8 @@ object AnghammaradNotifications extends Logging {
          |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
          |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
          |(if you're already planning on doing this, please ignore this message).
-         |If this is not rectified before ${printDay(now.plusDays(daysBetweenWarningAndFinalNotification + daysBetweenFinalNotificationAndRemediation))}, Security HQ will automatically disable this user."
+         |If this is not rectified before ${printDay(now.plusDays(daysBetweenWarningAndFinalNotification + daysBetweenFinalNotificationAndRemediation))},
+         |Security HQ will automatically disable this user at the next opportunity.
          |""".stripMargin
     val subject = s"Action ${awsAccount.name}: Vulnerable credential"
     Notification(subject, message + genericOutdatedCredentialText, Nil, List(Account(awsAccount.accountNumber)), channel, sourceSystem)
@@ -60,7 +61,8 @@ object AnghammaradNotifications extends Logging {
          |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
          |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
          |(if you're already planning on doing this, please ignore this message).
-         |If this is not rectified before ${printDay(now.plusDays(daysBetweenFinalNotificationAndRemediation))}, Security HQ will automatically disable this user."
+         |If this is not rectified before ${printDay(now.plusDays(daysBetweenFinalNotificationAndRemediation))},
+         |Security HQ will automatically disable this user at the next opportunity.
          |""".stripMargin
     val subject = s"Action ${awsAccount.name}: Vulnerable credential will be disabled soon"
     Notification(subject, message + genericOutdatedCredentialText, Nil, List(Account(awsAccount.accountNumber)), channel, sourceSystem)


### PR DESCRIPTION
## What does this change?
Adds "...at the next opportunity" to the end of the notification messages to indicate that the remediation may not happen on that day, because the job doesn't run at the weekend currently. I've kept it generic sounding so we don't have to worry too much about changing the scheduling and keeping this message up to date.

Also removes an extra quote from the messages.