### PR TITLE
Create per-user opt-out for Outdated Credentials job

### DIFF
--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -18,6 +18,7 @@ import scala.util.Try
 object Config {
   val iamHumanUserRotationCadence: Long = 90
   val iamMachineUserRotationCadence: Long = 365
+  val outdatedCredentialOptOutUserTag = "SecurityHQ::OutdatedCredentialOptOut"
   val daysBetweenWarningAndFinalNotification = 7
   val daysBetweenFinalNotificationAndRemediation = 7
 

--- a/hq/test/logic/IamRemediationTest.scala
+++ b/hq/test/logic/IamRemediationTest.scala
@@ -61,6 +61,7 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     val humanWithHealthyKey = HumanUser("jon.soul", true, noAccessKey, humanEnabledAccessKeyHealthy, Green, None, None, Nil)
     val machineWithOneOldEnabledAccessKey = MachineUser("machine1", machineAccessKeyOldAndEnabled, noAccessKey, Green, None, None, Nil)
     val machineWithOneOldEnabledAccessKey2 = MachineUser("machine2", machineAccessKeyOldAndEnabledOnTimeThreshold, noAccessKey, Green, None, None, Nil)
+    val machineWithOneOldEnabledAccessKeyAndOptOutTag = MachineUser("machine3", machineAccessKeyOldAndEnabledOnTimeThreshold, noAccessKey, Green, None, None, List(Tag(Config.outdatedCredentialOptOutUserTag, "")))
 
     "given a vulnerable human user, return that user" in {
       val credsReport = CredentialReportDisplay(date, Seq(), Seq(humanWithOneOldEnabledAccessKey))
@@ -69,6 +70,10 @@ class IamRemediationTest extends FreeSpec with Matchers with OptionValues with A
     "given a vulnerable machine user, return that user" in {
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldEnabledAccessKey), Seq())
       identifyUsersWithOutdatedCredentials(credsReport, date).map(_.username) shouldEqual List("machine1")
+    }
+    "given a vulnerable user with opt-out tag, return an empty list" in {
+      val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldEnabledAccessKeyAndOptOutTag), Seq())
+      identifyUsersWithOutdatedCredentials(credsReport, date).map(_.username) shouldBe empty
     }
     "given a vulnerable human and machine user, return both users" in {
       val credsReport = CredentialReportDisplay(date, Seq(machineWithOneOldEnabledAccessKey), Seq(humanWithOneOldEnabledAccessKey))


### PR DESCRIPTION
## What does this change?
Adds a tag that can be applied to IAM users which will opt them out of identification by the Outdated Credentials job. This is to deal with the (thankfully rare) scenario where an account contains a key that cannot simply be rotated e.g. it is embedded in a large number of places. This opt-out tag would allow us to enable the job on those accounts even while the team is working on rotating it. *It should be a last resort only*

The upside to this approach is that when we are able to rotate the user, all that needs to be done is to remove the tag. The downside is that this is a publicly visible key that can be used to bypass a useful security measure. If it is abused then we won't be alerted immediately, but we will start to see keys in the dashboard over 365 days old in accounts where the job is enabled. I think this should be enough to spot overuse eventually (plus we trust our colleagues!)

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Allows us to enable the job in more accounts

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
We could put the tag key in config, but we trust our colleagues so I don't see the value

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
