### PR TITLE
WIP Bump libraries to versions without vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xf
 // resolvers += "guardian-bintray" at "https://dl.bintray.com/guardian/sbt-plugins/"
 resolvers += DefaultMavenRepository
 
-val awsSdkVersion = "1.11.596"
+val awsSdkVersion = "1.12.150"
 val playJsonVersion = "2.8.1"
 val jacksonVersion = "2.10.1"
 
@@ -51,7 +51,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-      "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
+      "com.google.cloud" % "google-cloud-securitycenter" % "2.3.2",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xf
 // resolvers += "guardian-bintray" at "https://dl.bintray.com/guardian/sbt-plugins/"
 resolvers += DefaultMavenRepository
 
-val awsSdkVersion = "1.12.150"
+val awsSdkVersion = "1.11.596"
 val playJsonVersion = "2.8.1"
 val jacksonVersion = "2.10.1"
 


### PR DESCRIPTION
## What does this change?

Upgrades the aws sdk version from `1.11.596` to `1.12.150`, and `google-cloud-securitycenter` from `1.3.6` to `2.3.2`

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

These new versions contain fixes for 3 high severity vulnerabilities identified by snyk, relating to jackson-databind and google's protofbug library.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

No
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?

No
<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
