### PR TITLE
Disable snyk dashboard

### DIFF
--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -48,7 +48,7 @@ class CacheService(
   private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(startingCache)
   private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(startingCache)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
-  private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("cache").attempt)))
+  private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.snykDashboardDecomission("cache").attempt)))
   private val gcpBox: Box[Attempt[GcpReport]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorGcp("GCP").attempt)))
 
   def getAllPublicBuckets: Map[AwsAccount, Either[FailedAttempt, List[BucketDetail]]] = publicBucketsBox.get()
@@ -177,10 +177,6 @@ class CacheService(
       refreshCredentialsBox()
     }
 
-    val snykSubscription = Observable.interval(initialDelay + 6000.millis, 30.minutes).subscribe { _ =>
-      refreshSnykBox()
-    }
-
     val gcpSubscription = Observable.interval(initialDelay + 6000.millis, 90.minutes).subscribe { _ =>
       logger.info("refreshing the GCP Box now")
       refreshGcpBox()
@@ -191,7 +187,6 @@ class CacheService(
       exposedKeysSubscription.unsubscribe()
       sgSubscription.unsubscribe()
       credentialsSubscription.unsubscribe()
-      snykSubscription.unsubscribe()
       gcpSubscription.unsubscribe()
       Future.successful(())
     }

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -64,6 +64,12 @@ object Failure {
     Failure(details, friendlyMessage, 500)
   }
 
+  def snykDashboardDecomission(cacheContent: String): Failure = {
+    val details = s"Cache service error; unable to retrieve $cacheContent"
+    val friendlyMessage = s"This dashboard has been temporarily closed due to snyk disabling the API it relied on. Please go to snyk.io directly for information about vulnerabilities in guardian services."
+    Failure(details, friendlyMessage, 500)
+  }
+
   def cacheServiceErrorGcp(cacheContent: String): Failure = {
     val details = s"Cache service error; unable to retrieve $cacheContent"
     val friendlyMessage = s"Oops! We're still loading the $cacheContent data. Please refresh the page shortly."


### PR DESCRIPTION
## What does this change?

This leaves the UI itself up, but disables the fetching of snyk data in CacheService, and displays a deliberate error message.

Do you think we can get away with this @jfsoul ? I'm being a little basic here, wasn't sure where to draw the line between doing almost nothing and dismantling the whole thing, like routes templates models etc

![Security_HQ](https://user-images.githubusercontent.com/1672034/153215336-65c8298d-2c34-415c-be1e-0429b44d34fd.png)


## What is the value of this?


Snyk is going to decommission the API we need soon, so this is getting ahead of that

## Will this require CloudFormation and/or updates to the AWS StackSet?

No
## Will this require changes to config?

No
<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
