### PR TITLE
Display gcp projects sorted by findings criticality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ hq/test/jars
 
 # VS Code
 .bloop
+.bsp
 .metals
 .vscode
 project/metals.sbt

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -36,7 +36,7 @@ object Cloudwatch extends Logging {
   }
 
   def logMetricsForGCPReport(gcpReport: GcpReport): Unit = {
-    gcpReport.finding.toSeq.foreach {
+    gcpReport.findings.toSeq.foreach {
       case (project: String, findings: Seq[GcpFinding]) =>
         val criticalFindings = findings.filter(_.severity == Finding.Severity.CRITICAL)
         val highFindings = findings.filter(_.severity == Finding.Severity.HIGH)

--- a/hq/app/logic/GcpDisplay.scala
+++ b/hq/app/logic/GcpDisplay.scala
@@ -18,16 +18,16 @@ object GcpDisplay extends Logging {
   val dateTimePattern = "dd/MM/yy"
 
   def reportStatusSummary(reportFindings: Map[String, Seq[GcpFinding]]): List[(String, GcpReportSummaryWithFindings)] = {
-    reportFindings.map { case (projectName, findings) => 
-      (projectName, GcpReportSummaryWithFindings(
-        GcpReportSummary(
-          findings.count(_.severity == Severity.CRITICAL),
-          findings.count(_.severity == Severity.HIGH),
-          findings.count(_.severity == Severity.MEDIUM),
-          findings.count(_.severity == Severity.LOW),
-          findings.count(_.severity == Severity.SEVERITY_UNSPECIFIED)
-        ),findings ))
-    }.toList
+    sortProjectsByReportSummary(reportFindings.map { case (projectName, findings) =>
+          (projectName, GcpReportSummaryWithFindings(
+            GcpReportSummary(
+              findings.count(_.severity == Severity.CRITICAL),
+              findings.count(_.severity == Severity.HIGH),
+              findings.count(_.severity == Severity.MEDIUM),
+              findings.count(_.severity == Severity.LOW),
+              findings.count(_.severity == Severity.SEVERITY_UNSPECIFIED)
+            ),findings ))
+        }.toList)
   }
 
   def sortProjectsByReportSummary(projectSummaryWithFindings: List[(String, GcpReportSummaryWithFindings)]): List[(String, GcpReportSummaryWithFindings)] = {

--- a/hq/app/logic/GcpDisplay.scala
+++ b/hq/app/logic/GcpDisplay.scala
@@ -5,7 +5,7 @@ import com.google.cloud.securitycenter.v1.SecurityCenterClient.ListFindingsPaged
 import com.google.cloud.securitycenter.v1.{Finding, ListFindingsRequest, OrganizationName, SecurityCenterClient, SourceName}
 import com.google.protobuf.Value
 import config.Config
-import model.GcpFinding
+import model.{GcpFinding,ReportSummary,ReportSummaryWithFindings}
 import org.joda.time.DateTime
 import play.api.{Configuration, Logging}
 import utils.attempt.Attempt
@@ -14,8 +14,29 @@ import scala.jdk.CollectionConverters._
 import scala.util.matching.Regex
 
 object GcpDisplay extends Logging {
+ 
   val dateTimePattern = "dd/MM/yy"
 
+  def reportStatusSummary(reportFindings: Map[String, Seq[GcpFinding]]): List[(String, ReportSummaryWithFindings)] = {
+    reportFindings.map { case (projectName, findings) => 
+      (projectName, ReportSummaryWithFindings(
+        ReportSummary(
+          findings.count(_.severity == Severity.CRITICAL),
+          findings.count(_.severity == Severity.HIGH),
+          findings.count(_.severity == Severity.MEDIUM),
+          findings.count(_.severity == Severity.LOW),
+          findings.count(_.severity == Severity.SEVERITY_UNSPECIFIED)
+        ),findings ))
+    }.toList
+  }
+
+  def sortProjectsByReportSummary(projectSummaryWithFindings: List[(String, ReportSummaryWithFindings)]): List[(String, ReportSummaryWithFindings)] = {
+    projectSummaryWithFindings.sortBy { case (project, summaryWithFindings) => 
+      val reportSummary = summaryWithFindings.reportSummary
+      (-reportSummary.critical, -reportSummary.high, -reportSummary.medium, -reportSummary.low, -reportSummary.unspecified, project)
+    }
+  }
+  
   def getGcpFindings(org: OrganizationName, client: SecurityCenterClient, config: Configuration): Attempt[List[GcpFinding]] = {
     Attempt.Right {
       val gcpPagedResponse: ListFindingsPagedResponse = callGcpApi(org, client, config)

--- a/hq/app/logic/GcpDisplay.scala
+++ b/hq/app/logic/GcpDisplay.scala
@@ -5,7 +5,7 @@ import com.google.cloud.securitycenter.v1.SecurityCenterClient.ListFindingsPaged
 import com.google.cloud.securitycenter.v1.{Finding, ListFindingsRequest, OrganizationName, SecurityCenterClient, SourceName}
 import com.google.protobuf.Value
 import config.Config
-import model.{GcpFinding,ReportSummary,ReportSummaryWithFindings}
+import model.{GcpFinding,GcpReportSummary,GcpReportSummaryWithFindings}
 import org.joda.time.DateTime
 import play.api.{Configuration, Logging}
 import utils.attempt.Attempt
@@ -17,10 +17,10 @@ object GcpDisplay extends Logging {
  
   val dateTimePattern = "dd/MM/yy"
 
-  def reportStatusSummary(reportFindings: Map[String, Seq[GcpFinding]]): List[(String, ReportSummaryWithFindings)] = {
+  def reportStatusSummary(reportFindings: Map[String, Seq[GcpFinding]]): List[(String, GcpReportSummaryWithFindings)] = {
     reportFindings.map { case (projectName, findings) => 
-      (projectName, ReportSummaryWithFindings(
-        ReportSummary(
+      (projectName, GcpReportSummaryWithFindings(
+        GcpReportSummary(
           findings.count(_.severity == Severity.CRITICAL),
           findings.count(_.severity == Severity.HIGH),
           findings.count(_.severity == Severity.MEDIUM),
@@ -30,7 +30,7 @@ object GcpDisplay extends Logging {
     }.toList
   }
 
-  def sortProjectsByReportSummary(projectSummaryWithFindings: List[(String, ReportSummaryWithFindings)]): List[(String, ReportSummaryWithFindings)] = {
+  def sortProjectsByReportSummary(projectSummaryWithFindings: List[(String, GcpReportSummaryWithFindings)]): List[(String, GcpReportSummaryWithFindings)] = {
     projectSummaryWithFindings.sortBy { case (project, summaryWithFindings) => 
       val reportSummary = summaryWithFindings.reportSummary
       (-reportSummary.critical, -reportSummary.high, -reportSummary.medium, -reportSummary.low, -reportSummary.unspecified, project)

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -288,6 +288,6 @@ case class GcpFinding(
 
 case class GcpSccConfig(orgId: String, sourceId: String)
 
-case class ReportSummary(critical: Int, high: Int, medium: Int, low:Int, unspecified: Int)
+case class GcpReportSummary(critical: Int, high: Int, medium: Int, low:Int, unspecified: Int)
 
-case class ReportSummaryWithFindings(reportSummary: ReportSummary, reportFindings: Seq[GcpFinding])
+case class GcpReportSummaryWithFindings(reportSummary: GcpReportSummary, reportFindings: Seq[GcpFinding])

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -288,6 +288,6 @@ case class GcpFinding(
 
 case class GcpSccConfig(orgId: String, sourceId: String)
 
-case class GcpReportSummary(critical: Int, high: Int, medium: Int, low:Int, unspecified: Int)
+case class GcpReportSummary(critical: Int, high: Int, medium: Int, low: Int, unspecified: Int)
 
 case class GcpReportSummaryWithFindings(reportSummary: GcpReportSummary, reportFindings: Seq[GcpFinding])

--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -275,7 +275,7 @@ case class SnykError(error: String)
 
 case class Documentation(title: String, description: String, icon: String, slug: String)
 
-case class GcpReport(reportDate: DateTime, finding: Map[String, Seq[GcpFinding]] = Map.empty)
+case class GcpReport(reportDate: DateTime, findings: Map[String, Seq[GcpFinding]] = Map.empty)
 
 case class GcpFinding(
   project: String,
@@ -287,3 +287,7 @@ case class GcpFinding(
 )
 
 case class GcpSccConfig(orgId: String, sourceId: String)
+
+case class ReportSummary(critical: Int, high: Int, medium: Int, low:Int, unspecified: Int)
+
+case class ReportSummaryWithFindings(reportSummary: ReportSummary, reportFindings: Seq[GcpFinding])

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -63,34 +63,34 @@
 
         <div class="row">
             <ul class="collapsible" data-collapsible="accordion">
-                @for((projectName, findings) <- report.finding.toList.sortBy(_._1)) {
+                @for((projectName, summaryWithFindings) <- GcpDisplay.sortProjectsByReportSummary(GcpDisplay.reportStatusSummary(report.findings))) {
                     <li>
                     <div class="collapsible-header" tabindex="22">
                     <i class="material-icons">keyboard_arrow_down</i>
                     <span class="iam-header__name">@projectName</span>
-                        @if(findings.exists(_.severity == Severity.CRITICAL)) {
-                            <span class="icon-count">@findings.count(_.severity == Severity.CRITICAL)</span>
+                        @if(summaryWithFindings.reportSummary.critical != 0) {
+                            <span class="icon-count">@summaryWithFindings.reportSummary.critical</span>
                             <i class="material-icons red-text text-darken-4">error</i>
                         }
-                        @if(findings.exists(_.severity == Severity.HIGH)) {
-                            <span class="icon-count">@findings.count(_.severity == Severity.HIGH)</span>
+                        @if(summaryWithFindings.reportSummary.high != 0) {
+                            <span class="icon-count">@summaryWithFindings.reportSummary.high</span>
                             <i class="material-icons red-text">error</i>
                         }
-                        @if(findings.exists(_.severity == Severity.MEDIUM)) {
-                            <span class="icon-count">@findings.count(_.severity == Severity.MEDIUM)</span>
+                        @if(summaryWithFindings.reportSummary.medium != 0) {
+                            <span class="icon-count">@summaryWithFindings.reportSummary.medium</span>
                             <i class="material-icons orange-text">warning</i>
                         }
-                        @if(findings.exists(_.severity == Severity.LOW)) {
-                            <span class="icon-count">@findings.count(_.severity == Severity.LOW)</span>
+                        @if(summaryWithFindings.reportSummary.low != 0) {
+                            <span class="icon-count">@summaryWithFindings.reportSummary.low</span>
                             <i class="material-icons yellow-text">priority_high</i>
                         }
-                        @if(findings.exists(_.severity == Severity.SEVERITY_UNSPECIFIED)) {
-                            <span class="icon-count">@findings.count(_.severity == Severity.SEVERITY_UNSPECIFIED)</span>
+                        @if(summaryWithFindings.reportSummary.unspecified != 0) {
+                            <span class="icon-count">@summaryWithFindings.reportSummary.unspecified</span>
                             <i class="material-icons grey-text">not_listed_location</i>
                         }
                     </div>
                     <div class="collapsible-body">
-                    @views.html.gcp.gcpReportBody(GcpDisplay.sortFindings(findings.toList), report.reportDate)
+                    @views.html.gcp.gcpReportBody(GcpDisplay.sortFindings(summaryWithFindings.reportFindings.toList), report.reportDate)
                     </div>
                     </li>
                 }

--- a/hq/app/views/gcp/gcp.scala.html
+++ b/hq/app/views/gcp/gcp.scala.html
@@ -63,7 +63,7 @@
 
         <div class="row">
             <ul class="collapsible" data-collapsible="accordion">
-                @for((projectName, summaryWithFindings) <- GcpDisplay.sortProjectsByReportSummary(GcpDisplay.reportStatusSummary(report.findings))) {
+                @for((projectName, summaryWithFindings) <- GcpDisplay.reportStatusSummary(report.findings)) {
                     <li>
                     <div class="collapsible-header" tabindex="22">
                     <i class="material-icons">keyboard_arrow_down</i>

--- a/hq/test/logic/GcpDisplayTest.scala
+++ b/hq/test/logic/GcpDisplayTest.scala
@@ -2,12 +2,13 @@ package logic
 
 import model._
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
 import GcpDisplay._
 import com.google.cloud.securitycenter.v1.Finding.Severity
+import org.scalatest.matchers.should.Matchers
 
 
-class GcPDisplayTest extends FreeSpec with Matchers {
+class GcPDisplayTest extends AnyFreeSpec with Matchers {
     val dateTime = DateTime.now()
 
     "sortProjectsByReportSummary" - {

--- a/hq/test/logic/GcpDisplayTest.scala
+++ b/hq/test/logic/GcpDisplayTest.scala
@@ -15,8 +15,8 @@ class GcPDisplayTest extends FreeSpec with Matchers {
             val gcpFindingCritical1 = GcpFinding ("project1","",Severity.CRITICAL,dateTime,None,None)
             val gcpFindingCritical2 = GcpFinding ("project2","",Severity.CRITICAL,dateTime,None,None)
             val gcpFindingMedium2:GcpFinding = GcpFinding ("project2","",Severity.MEDIUM,dateTime,None,None)
-            val reportSummaryWithFindings1 = ReportSummaryWithFindings(ReportSummary(1,0,0,0,0),Seq(gcpFindingCritical1))
-            val reportSummaryWithFindings2 = ReportSummaryWithFindings(ReportSummary(1,0,1,0,0),Seq(gcpFindingCritical2,gcpFindingMedium2)) 
+            val reportSummaryWithFindings1 = GcpReportSummaryWithFindings(GcpReportSummary(1,0,0,0,0),Seq(gcpFindingCritical1))
+            val reportSummaryWithFindings2 = GcpReportSummaryWithFindings(GcpReportSummary(1,0,1,0,0),Seq(gcpFindingCritical2,gcpFindingMedium2))
 
             val unsortedFindings = Map("project1"->Seq(gcpFindingCritical1), "project2"->Seq(gcpFindingCritical2,gcpFindingMedium2))
             val sortedReport = List(("project2",reportSummaryWithFindings2),("project1",reportSummaryWithFindings1))
@@ -27,8 +27,8 @@ class GcPDisplayTest extends FreeSpec with Matchers {
         "when two projects have the same number of findings and severity order by project name" in {
             val gcpFindingCritical1 = GcpFinding ("projectB","",Severity.CRITICAL,dateTime,None,None)
             val gcpFindingCritical2 = GcpFinding ("projectA","",Severity.CRITICAL,dateTime,None,None)
-            val reportSummaryWithFindings1 = ReportSummaryWithFindings(ReportSummary(1,0,0,0,0),Seq(gcpFindingCritical1))
-            val reportSummaryWithFindings2 = ReportSummaryWithFindings(ReportSummary(1,0,0,0,0),Seq(gcpFindingCritical2)) 
+            val reportSummaryWithFindings1 = GcpReportSummaryWithFindings(GcpReportSummary(1,0,0,0,0),Seq(gcpFindingCritical1))
+            val reportSummaryWithFindings2 = GcpReportSummaryWithFindings(GcpReportSummary(1,0,0,0,0),Seq(gcpFindingCritical2))
 
             val unsortedFindings = Map("projectB"->Seq(gcpFindingCritical1), "projectA"->Seq(gcpFindingCritical2))
             val sortedReport = List(("projectA",reportSummaryWithFindings2),("projectB",reportSummaryWithFindings1))

--- a/hq/test/logic/GcpDisplayTest.scala
+++ b/hq/test/logic/GcpDisplayTest.scala
@@ -1,0 +1,39 @@
+package logic
+
+import model._
+import org.joda.time.DateTime
+import org.scalatest.{FreeSpec, Matchers}
+import GcpDisplay._
+import com.google.cloud.securitycenter.v1.Finding.Severity
+
+
+class GcPDisplayTest extends FreeSpec with Matchers {
+    val dateTime = DateTime.now()
+
+    "sortProjectsByReportSummary" - {
+        "correctly sort two projects with different findings by severity" in {
+            val gcpFindingCritical1 = GcpFinding ("project1","",Severity.CRITICAL,dateTime,None,None)
+            val gcpFindingCritical2 = GcpFinding ("project2","",Severity.CRITICAL,dateTime,None,None)
+            val gcpFindingMedium2:GcpFinding = GcpFinding ("project2","",Severity.MEDIUM,dateTime,None,None)
+            val reportSummaryWithFindings1 = ReportSummaryWithFindings(ReportSummary(1,0,0,0,0),Seq(gcpFindingCritical1))
+            val reportSummaryWithFindings2 = ReportSummaryWithFindings(ReportSummary(1,0,1,0,0),Seq(gcpFindingCritical2,gcpFindingMedium2)) 
+
+            val unsortedFindings = Map("project1"->Seq(gcpFindingCritical1), "project2"->Seq(gcpFindingCritical2,gcpFindingMedium2))
+            val sortedReport = List(("project2",reportSummaryWithFindings2),("project1",reportSummaryWithFindings1))
+
+            sortProjectsByReportSummary(reportStatusSummary(unsortedFindings)) shouldEqual sortedReport
+        }
+    
+        "when two projects have the same number of findings and severity order by project name" in {
+            val gcpFindingCritical1 = GcpFinding ("projectB","",Severity.CRITICAL,dateTime,None,None)
+            val gcpFindingCritical2 = GcpFinding ("projectA","",Severity.CRITICAL,dateTime,None,None)
+            val reportSummaryWithFindings1 = ReportSummaryWithFindings(ReportSummary(1,0,0,0,0),Seq(gcpFindingCritical1))
+            val reportSummaryWithFindings2 = ReportSummaryWithFindings(ReportSummary(1,0,0,0,0),Seq(gcpFindingCritical2)) 
+
+            val unsortedFindings = Map("projectB"->Seq(gcpFindingCritical1), "projectA"->Seq(gcpFindingCritical2))
+            val sortedReport = List(("projectA",reportSummaryWithFindings2),("projectB",reportSummaryWithFindings1))
+
+            sortProjectsByReportSummary(reportStatusSummary(unsortedFindings)) shouldEqual sortedReport
+        }
+    }
+}


### PR DESCRIPTION
## What does this change?
Currently GCP projects are displayed ordered alphabetically. While this is useful to quickly identify known projects it doesn't provide an easy way to prioritise remediation effort. The change implements GCP project sorting by number of vulnerabilities and their criticalities.  The projects with higher number of findings with higher criticality will be displayed at the top of the list.

![gcp-sorted](https://user-images.githubusercontent.com/37340283/153921340-c6df6ab2-c4cf-4ec4-9d09-613bd48205c4.JPG)

## What is the value of this?
It would be easier for reviewers to focus their remediation effort.

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

## Will this require changes to config?
No

## Any additional notes?
No CSS and JS changes
