### PR TITLE
Use aws-actions/configure-aws-credentials instead of guardian/actions-assume-aws-role

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -16,17 +16,18 @@ jobs:
 
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
-      # required by guardian/actions-assume-aws-role
+      # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v2
 
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
-      # See https://github.com/guardian/actions-assume-aws-role
-      - uses: guardian/actions-assume-aws-role@v1
+      # See https://github.com/aws-actions/configure-aws-credentials
+      - uses: aws-actions/configure-aws-credentials@v1
         with:
-          awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
 
       # Change this if using Java 11.
       # Configuring caching is also recommended.


### PR DESCRIPTION
## What does this change?

We developed https://github.com/guardian/actions-assume-aws-role to support the migration to GitHub Actions (more specifically, it allowed us to upload build artifacts to Riff-Raff's S3 buckets without using permanent credentials).

There is now an official action (maintained by AWS) which offers this functionality - https://github.com/aws-actions/configure-aws-credentials. This PR switches to using the AWS alternative instead of the (now deprecated) Guardian action. 

Related PRs:
https://github.com/guardian/actions-assume-aws-role/pull/80
https://github.com/guardian/node-riffraff-artifact/pull/33
https://github.com/guardian/sbt-riffraff-artifact/pull/69