### PR TITLE
Update Play Google Auth

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,9 @@ lazy val hq = (project in file("hq"))
     libraryDependencies ++= Seq(
       ws,
       filters,
-      "com.gu" %% "play-googleauth" % "0.7.6",
+      "com.gu.play-googleauth" %% "play-v28" % "2.2.2",
+      "com.gu.play-secret-rotation" %% "play-v28" % "0.33",
+      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.33",
       "joda-time" % "joda-time" % "2.10.5",
       "org.typelevel" %% "cats-core" % "2.0.0",
       "com.github.tototoshi" %% "scala-csv" % "1.3.5",
@@ -49,6 +51,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-dynamodb" % awsSdkVersion,
       "com.vladsch.flexmark" % "flexmark" % "0.62.2",
       "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ resolvers += DefaultMavenRepository
 
 val awsSdkVersion = "1.11.596"
 val playJsonVersion = "2.8.1"
-val jacksonVersion = "2.10.1"
+val jacksonVersion = "2.12.3"
 
 // Until all dependencies are on scala-java8-compat v1.x, this avoids unnecessary fatal eviction errors
 // See https://github.com/akka/akka/pull/30375
@@ -54,6 +54,7 @@ lazy val hq = (project in file("hq"))
       "com.amazonaws" % "aws-java-sdk-ssm" % awsSdkVersion,
       "io.reactivex" %% "rxscala" % "0.26.5",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
       "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
       "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -71,7 +71,8 @@ class AppComponents(context: Context)
   }
 
   private val snykConfig = Config.getSnykConfig(configuration)
-  private val googleAuthConfig = Config.googleSettings(httpConfiguration, configuration)
+  private val ssmClient = AWS.ssmClient(securityCredentialsProvider, Config.region)
+  private val googleAuthConfig = Config.googleSettings(httpConfiguration, configuration, ssmClient)
   private val ec2Clients = AWS.ec2Clients(configuration, availableRegions)
   private val cfnClients = AWS.cfnClients(configuration, availableRegions)
   private val taClients = AWS.taClients(configuration)

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -94,7 +94,7 @@ class AppComponents(context: Context)
     .withCredentials(securityCredentialsProvider)
     .withRegion(Config.region)
     .build()
-  private val googleAuthConfig = Config.googleSettings(httpConfiguration, configuration, securitySsmClient)
+  private val googleAuthConfig = Config.googleSettings(stage, stack, configuration, securitySsmClient)
 
   private val securityDynamoDbClient = stage match {
     case PROD =>

--- a/hq/app/auth/SecurityHQAuthActions.scala
+++ b/hq/app/auth/SecurityHQAuthActions.scala
@@ -1,6 +1,6 @@
 package auth
 
-import com.gu.googleauth.{AuthAction, GoogleAuthConfig, LoginSupport}
+import com.gu.googleauth.{AuthAction, GoogleAuthConfig, GoogleGroupChecker, LoginSupport}
 import config.Config
 import controllers.routes
 import play.api.Configuration
@@ -20,7 +20,7 @@ trait SecurityHQAuthActions extends LoginSupport {
   override val defaultRedirectTarget: Call = routes.HQController.index
   override val authConfig: GoogleAuthConfig
 
-  val googleGroupChecker = Config.googleGroupChecker
+  val googleGroupChecker: GoogleGroupChecker = Config.googleGroupChecker
   val requiredGoogleGroups = Set(Config.twoFAGroup)
   val authAction = new AuthAction[AnyContent](authConfig, loginTarget, bodyParser)(ec)
 

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -12,6 +12,7 @@ import com.amazonaws.services.ec2.{AmazonEC2Async, AmazonEC2AsyncClientBuilder}
 import com.amazonaws.services.elasticfilesystem.{AmazonElasticFileSystemAsync, AmazonElasticFileSystemAsyncClientBuilder}
 import com.amazonaws.services.identitymanagement.{AmazonIdentityManagementAsync, AmazonIdentityManagementAsyncClientBuilder}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
 import com.amazonaws.services.support.{AWSSupportAsync, AWSSupportAsyncClientBuilder}
 import config.Config
 import model.{AwsAccount, DEV, PROD, Stage}
@@ -88,4 +89,9 @@ object AWS {
           .build()
     }
   }
+  def ssmClient(securityCredentialsProvider: AWSCredentialsProvider, region: Regions = Regions.EU_WEST_1): AWSSimpleSystemsManagement =
+    AWSSimpleSystemsManagementClientBuilder.standard()
+      .withCredentials(securityCredentialsProvider)
+      .withRegion(region)
+      .build()
 }

--- a/hq/app/aws/AWS.scala
+++ b/hq/app/aws/AWS.scala
@@ -74,24 +74,4 @@ object AWS {
 
   def efsClients(configuration: Configuration, regions: List[Regions]): AwsClients[AmazonElasticFileSystemAsync] =
     clients(withCustomThreadPool(AmazonElasticFileSystemAsyncClientBuilder.standard()), configuration, regions:_*)
-
-  def dynamoDbClient(securityCredentialsProvider: AWSCredentialsProvider, region: Regions, stage: Stage): AmazonDynamoDB = {
-    stage match {
-      case PROD =>
-        AmazonDynamoDBClientBuilder.standard()
-          .withCredentials(securityCredentialsProvider)
-          .withRegion(region)
-          .build()
-      case DEV =>
-        AmazonDynamoDBClientBuilder.standard()
-          .withCredentials(securityCredentialsProvider)
-          .withEndpointConfiguration(new EndpointConfiguration("http://localhost:8000", region.name))
-          .build()
-    }
-  }
-  def ssmClient(securityCredentialsProvider: AWSCredentialsProvider, region: Regions = Regions.EU_WEST_1): AWSSimpleSystemsManagement =
-    AWSSimpleSystemsManagementClientBuilder.standard()
-      .withCredentials(securityCredentialsProvider)
-      .withRegion(region)
-      .build()
 }

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -26,6 +26,7 @@ object Config {
   val outdatedCredentialOptOutUserTag = "SecurityHQ::OutdatedCredentialOptOut"
   val daysBetweenWarningAndFinalNotification = 7
   val daysBetweenFinalNotificationAndRemediation = 7
+  val app = "security-hq"
 
   // TODO fetch the region dynamically from the instance
   val region: Regions = Regions.EU_WEST_1
@@ -44,7 +45,7 @@ object Config {
     }
   }
 
-  def googleSettings(httpConfiguration: HttpConfiguration, config: Configuration, ssmClient: AWSSimpleSystemsManagement): GoogleAuthConfig = {
+  def googleSettings(stage: Stage, stack: String, config: Configuration, ssmClient: AWSSimpleSystemsManagement): GoogleAuthConfig = {
     val clientId = requiredString(config, "auth.google.clientId")
     val clientSecret = requiredString(config, "auth.google.clientSecret")
     val domain = requiredString(config, "auth.domain")
@@ -53,7 +54,7 @@ object Config {
     val secretStateSupplier: SnapshotProvider = {
       new SecretSupplier(
         TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
-        s"/PROD/security/security-hq/play.http.secret.key",
+        s"/${stage.toString}/$stack/$app/play.http.secret.key",
         AwsSdkV1(ssmClient)
       )
     }

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -1,15 +1,20 @@
 package config
 
-import com.amazonaws.regions.Regions
+import aws.AwsClient
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
+import com.gu.play.secretrotation.aws.parameterstore.{AwsSdkV1, SecretSupplier}
+import com.gu.play.secretrotation.{RotatingSecretComponents, SnapshotProvider, TransitionTiming}
 import model._
 import play.api.Configuration
 import play.api.http.HttpConfiguration
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import java.io.FileInputStream
+import java.time.Duration.{ofHours, ofMinutes}
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.util.Try
@@ -39,17 +44,26 @@ object Config {
     }
   }
 
-  def googleSettings(httpConfiguration: HttpConfiguration, config: Configuration): GoogleAuthConfig = {
+  def googleSettings(httpConfiguration: HttpConfiguration, config: Configuration, ssmClient: AWSSimpleSystemsManagement): GoogleAuthConfig = {
     val clientId = requiredString(config, "auth.google.clientId")
     val clientSecret = requiredString(config, "auth.google.clientSecret")
     val domain = requiredString(config, "auth.domain")
     val redirectUrl = s"${requiredString(config, "host")}/oauthCallback"
+
+    val secretStateSupplier: SnapshotProvider = {
+      new SecretSupplier(
+        TransitionTiming(usageDelay = ofMinutes(3), overlapDuration = ofHours(2)),
+        s"/PROD/security/security-hq/play.http.secret.key",
+        AwsSdkV1(ssmClient)
+      )
+    }
+
     GoogleAuthConfig(
       clientId,
       clientSecret,
       redirectUrl,
-      domain,
-      antiForgeryChecker = AntiForgeryChecker.borrowSettingsFromPlay(httpConfiguration)
+      List(domain),
+      antiForgeryChecker = AntiForgeryChecker(secretStateSupplier)
     )
   }
 

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -92,12 +92,7 @@ object Config {
       ServiceAccountCredentials.fromStream(jsonCertStream)
     }
 
-    val serviceAccount = GoogleServiceAccount(
-      credentials.getClientEmail,
-      credentials.getPrivateKey,
-      twoFAUser
-    )
-    new GoogleGroupChecker(serviceAccount)
+    new GoogleGroupChecker(twoFAUser, credentials)
   }
 
   def twoFAGroup(implicit config: Configuration): String = {


### PR DESCRIPTION
## What does this change?
Updates the version of play google auth we're using to `2.2.2` which introduces play secret rotation for the first time. To begin with this will use a static secret from SSM, and later we can introduce a rotation strategy.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
This work is a precursor to moving to scala 2.13 and to addressing some vulnerabilities identified by snyk.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
Yes, I've already added DEV and PROD secrets to SSM.

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
