### PR TITLE
Move to Java 11

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -28,13 +28,12 @@ jobs:
         with:
           awsRoleToAssume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
-      # Change this if using Java 11.
       # Configuring caching is also recommended.
       # See https://github.com/actions/setup-java
-      - name: Setup Java 8
+      - name: Setup Java 11
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'adopt'
 
       # (Respects .nvmrc)

--- a/README.md
+++ b/README.md
@@ -129,13 +129,15 @@ run each of these commands:
 ### Running project
 From the root of the project:
 
-1. Get Security Janus credentials. 
+1. Get Security Janus credentials.
 
-2. Run sbt: `$ ./sbt`
+2. Ensure you are running Java 11
 
-3. Select the project that you want to run: `sbt:security-hq> project hq`
+3. Run sbt: `$ ./sbt`
 
-4. Start the application: `sbt:security-hq> run`
+4. Select the project that you want to run: `sbt:security-hq> project hq`
+
+5. Start the application: `sbt:security-hq> run`
 
 Once the sever has started, the webapp is accessible at [https://security-hq.local.dev-gutools.co.uk/](https://security-hq.local.dev-gutools.co.uk/)
 

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val hq = (project in file("hq"))
     dynamoDBLocalDBPath := Some(System.getProperty("user.home") ++ "/.gu/security-hq"),
 
     Debian / serverLoading := Some(Systemd),
-    debianPackageDependencies := Seq("openjdk-8-jre-headless"),
+    debianPackageDependencies := Seq("java-11-amazon-corretto-jdk:arm64"),
     maintainer := "Security Team <devx.sec.ops@guardian.co.uk>",
     packageSummary := "Security HQ app.",
     packageDescription := """Deb for Security HQ - the Guardian's service to centralise security information for our AWS accounts.""",
@@ -122,14 +122,12 @@ lazy val hq = (project in file("hq"))
       "-J-XX:+UseCompressedOops",
       "-J-XX:+UseConcMarkSweepGC",
       "-J-XX:NativeMemoryTracking=detail",
-      // Bug in Java 8 means these values can't be integers until we upgrade https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8219312
-      "-J-XX:MaxRAMPercentage=50.0",
-      "-J-XX:InitialRAMPercentage=50.0",
+      "-J-XX:MaxRAMPercentage=50",
+      "-J-XX:InitialRAMPercentage=50",
       "-XX:NewRatio=3",
       "-J-XX:MaxMetaspaceSize=300m",
-      "-J-XX:+PrintGCDetails",
-      "-J-XX:+PrintGCDateStamps",
-      s"-J-Xloggc:/var/log/${packageName.value}/gc.log"
+      "-J-Xlog:gc*",
+      s"-J-Xlog:gc:/var/log/${packageName.value}/gc.log"
     )
 
   )

--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -29,6 +29,6 @@ deployments:
       amiParameter: AMISecurityhq
       amiEncrypted: true
       amiTags:
-        Recipe: security-java-lts-arm64
+        Recipe: security-java-11-arm64
         BuiltBy: amigo
         AmigoStage: PROD


### PR DESCRIPTION
## What does this change?
Updates to Java 11, which the Guardian's Play Secret Rotation library ultimately depends on (via https://github.com/guardian/play-secret-rotation/blob/main/build.sbt#L18) on https://github.com/ben-manes/caffeine/releases/tag/v3.0.0.

<!-- Screenshots may be helpful to demonstrate -->