### PR TITLE
Refactor use (and lack of use) of IamClient for consistency

### DIFF
--- a/hq/app/aws/iam/IAMClient.scala
+++ b/hq/app/aws/iam/IAMClient.scala
@@ -2,15 +2,14 @@ package aws.iam
 
 import aws.AwsAsyncHandler._
 import aws.cloudformation.CloudFormation
-import aws.{AwsClient, AwsClients}
+import aws.{AwsAsyncHandler, AwsClient, AwsClients}
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.AmazonCloudFormationAsync
 import com.amazonaws.services.identitymanagement.AmazonIdentityManagementAsync
-import com.amazonaws.services.identitymanagement.model.{GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest, ListAccessKeysRequest, ListAccessKeysResult, ListUserTagsRequest, UpdateAccessKeyRequest}
+import com.amazonaws.services.identitymanagement.model.{DeleteLoginProfileRequest, DeleteLoginProfileResult, GenerateCredentialReportRequest, GenerateCredentialReportResult, GetCredentialReportRequest, ListAccessKeysRequest, ListAccessKeysResult, ListUserTagsRequest, NoSuchEntityException, UpdateAccessKeyRequest}
 import logic.{CredentialsReportDisplay, Retry}
-import model.{CredentialActive, CredentialDisabled, CredentialMetadata}
+import model.{AwsAccount, CredentialActive, CredentialDisabled, CredentialMetadata, CredentialReportDisplay, HumanUser, IAMCredential, IAMCredentialsReport, IAMUser, Tag}
 import org.joda.time.DateTime
-import model.{AwsAccount, CredentialReportDisplay, IAMCredential, IAMCredentialsReport, IAMUser, Tag}
 import play.api.Logging
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -144,4 +143,19 @@ object IAMClient extends Logging {
       _ <- handleAWSErrs(client)(awsToScala(client)(_.updateAccessKeyAsync)(request))
     } yield ()
   }
+
+  def deleteLoginProfile(awsAccount: AwsAccount, username: String, iamClients: AwsClients[AmazonIdentityManagementAsync])(implicit ec: ExecutionContext): Attempt[Option[DeleteLoginProfileResult]] = {
+    val request = new DeleteLoginProfileRequest()
+      .withUserName(username)
+    for {
+      client <- iamClients.get(awsAccount, SOLE_REGION)
+      result <- handleDeleteLoginProfileErrs(client, username)(awsToScala(client)(_.deleteLoginProfileAsync)(request))
+    } yield result
+  }
+
+  private def handleDeleteLoginProfileErrs(awsClient: AwsClient[AmazonIdentityManagementAsync], username: String)(f: => Future[DeleteLoginProfileResult])(implicit ec: ExecutionContext): Attempt[Option[DeleteLoginProfileResult]] =
+    AwsAsyncHandler.handleAWSErrs(awsClient)(f.map(Some.apply).recover({
+      case e if e.getMessage.contains(s"Login Profile for User $username cannot be found") => None
+      case _: NoSuchEntityException => None
+    }))
 }

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -76,8 +76,8 @@ object Cloudwatch extends Logging {
     putMetric(defaultNamespace, "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
   }
 
-  def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value): Unit = {
-    putMetric(defaultNamespace, "IamRemovePassword", Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)), 1)
+  def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1): Unit = {
+    putMetric(defaultNamespace, "IamRemovePassword", Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)), value)
   }
 
   def putIamDisableAccessKeyMetric(reaperExecutionStatus: ReaperExecutionStatus.Value): Unit = {

--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -76,7 +76,7 @@ object Cloudwatch extends Logging {
     putMetric(defaultNamespace, "Vulnerabilities", Seq(("GcpProject", project),("DataType", dataType.toString)), value)
   }
 
-  def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1): Unit = {
+  def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int): Unit = {
     putMetric(defaultNamespace, "IamRemovePassword", Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)), value)
   }
 

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -57,7 +57,7 @@ object CredentialsReportDisplay {
 
     val amberStatusReasons: Seq[ReportStatusReason] = Seq(
       Some(ActiveAccessKey).filter(_ => keys.exists(_.keyStatus == AccessKeyEnabled)),
-      Some(MissingUsernameTag).filterNot(_ => isTaggedForUnrecognisedUser(cred.tags))
+      Some(MissingUsernameTag).filterNot(_ => IamUnrecognisedUsers.isTaggedForUnrecognisedUser(cred.tags))
     ).flatten
 
     if (redStatusReasons.nonEmpty)
@@ -165,15 +165,6 @@ object CredentialsReportDisplay {
     report.copy(
       machineUsers = report.machineUsers.sortBy(user => (user.reportStatus, user.username)),
       humanUsers = report.humanUsers.sortBy(user => (user.reportStatus, user.username))
-    )
-  }
-
-  val USERNAME_TAG_KEY = "GoogleUsername"
-  def isTaggedForUnrecognisedUser(tags: List[Tag]): Boolean = {
-    tags.exists(t =>
-      t.key == USERNAME_TAG_KEY &&
-        t.value != "" &&
-        t.value.contains(".")
     )
   }
 

--- a/hq/app/logic/IamListAccessKeys.scala
+++ b/hq/app/logic/IamListAccessKeys.scala
@@ -11,6 +11,7 @@ import utils.attempt.Attempt
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
+//TODO: split up and move this into IAMClient/IAMOutdatedCredentials as appropriate
 object IamListAccessKeys {
 
   // get information on all access keys for a given AWS account

--- a/hq/app/logic/IamUnrecognisedUsers.scala
+++ b/hq/app/logic/IamUnrecognisedUsers.scala
@@ -80,7 +80,7 @@ object IamUnrecognisedUsers extends Logging {
 
   def isTaggedForUnrecognisedUser(tags: List[Tag]): Boolean = {
     tags.exists(t =>
-      t.key == IamUnrecognisedUsers.USERNAME_TAG_KEY &&
+      t.key == USERNAME_TAG_KEY &&
         t.value != "" &&
         t.value.contains(".")
     )

--- a/hq/app/logic/IamUnrecognisedUsers.scala
+++ b/hq/app/logic/IamUnrecognisedUsers.scala
@@ -121,7 +121,7 @@ object IamUnrecognisedUsers extends Logging {
     results.tap {
       case Left(failure) =>
         logger.error(s"failed to delete at least one password: ${failure.logMessage}")
-        Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure)
+        Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
       case Right(success) =>
         logger.info(s"passwords deleted for ${vulnerableUsers.map(_.username).mkString(",")}")
         Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, success.flatten.length)

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -101,7 +101,7 @@ class IamRemediationService(
       janusUsernames = getJanusUsernames(janusData)
       accountCredsReports = getCredsReportDisplayForAccount(cacheService.getAllCredentials)
       allowedAccountsUnrecognisedUsers = unrecognisedUsersForAllowedAccounts(accountCredsReports, janusUsernames, config.allowedAccounts)
-      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(disableUser(_, iamClients))
+      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(disableAccountUsers(_, iamClients))
       notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers)
       notificationIds <- Attempt.traverse(notifications)(AnghammaradNotifications.send(_, config.anghammaradSnsTopicArn, snsClient))
     } yield notificationIds

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -107,7 +107,7 @@ class IamRemediationService(
     } yield notificationIds
     result.tap {
       case Left(failedAttempt) => logger.error(s"Failed to run unrecognised user job: ${failedAttempt.logMessage}")
-      case Right(notificationIds) => logger.info(s"Successfully ran unrecognised user job and sent ${notificationIds.flatten.length} notifications.")
+      case Right(notificationIds) => logger.info(s"Successfully ran unrecognised user job and sent ${notificationIds.length} notifications.")
     }.unit
   }
 


### PR DESCRIPTION
## What does this change?
This refactor aims to address some inconsistencies and duplication in the functionality that removes passwords and disables access keys in AWS IAM. Namely:
- Disabling of access keys was done in 2 places
- Password removals were not using the IamClient at all
- Existing methods had inconsistent signatures

We aim for the IamClient to be a fairly thin wrapper around the AWS SDK, with the application specifics of how those are used housed elsewhere. We could probably go further than this does, but that can come later and is less justified anyway.

There were a couple of other minor changes included, like removing a bit more unrelated duplication, and some moving of methods.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Clearer separation of application logic from AWS SDK interaction and less duplication of functionality.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
I'll need to do some testing of both jobs before this can be released.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
