### PR TITLE
Remove "not found" buckets from S3 report

### DIFF
--- a/hq/app/model/models.scala
+++ b/hq/app/model/models.scala
@@ -129,6 +129,11 @@ case class BucketDetail(
   isEncrypted: Boolean = false
 ) extends TrustedAdvisorCheckDetails
 
+sealed trait BucketEncryptionResponse
+case object Encrypted extends BucketEncryptionResponse
+case object NotEncrypted extends BucketEncryptionResponse
+case object BucketNotFound extends BucketEncryptionResponse
+
 sealed trait SGInUse
 case class Ec2Instance(instanceId: String) extends SGInUse
 case class ELB(description: String) extends SGInUse


### PR DESCRIPTION
## What does this change?
We currently have an issue when S3 buckets that are listed in the Trusted Advisor report (which is refreshed by AWS very infrequently) are subsequently deleted. This means for an account where a bucket is removed, we stop processing results and return an error for the entire account:

<img width="467" alt="image" src="https://user-images.githubusercontent.com/8754692/155360113-ce5b04b5-655b-44d2-beb9-34b7ef15e9ea.png">

With this change we are instead recovering from `BucketNotFound` errors and simply removing those buckets from the account's list, which seems most appropriate in this situation.

(Note the lack of error)
<img width="359" alt="image" src="https://user-images.githubusercontent.com/8754692/155360373-2dfbd102-01d6-4004-ac3f-a5e44476707b.png">
  

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Removes the occasional error from the dashboard when a bucket is deleted in an account, and it should mean our metric shipping is more stable, as _any_ error meant those weren't sent (which probably needs revisiting separately)

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
