### PR TITLE
Report all error statuses to cloudwatch for IAM

### DIFF
--- a/hq/app/logging/Cloudwatch.scala
+++ b/hq/app/logging/Cloudwatch.scala
@@ -4,7 +4,7 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.google.cloud.securitycenter.v1.Finding
 import logic.CredentialsReportDisplay
-import logic.CredentialsReportDisplay.{ReportSummary, reportStatusSummary, reportStatusSummaryWithoutOutdatedKeys}
+import logic.CredentialsReportDisplay.{ReportSummary, reportStatusSummary}
 import model.{AwsAccount, CredentialReportDisplay, GcpFinding, GcpReport}
 import play.api.Logging
 import utils.attempt.FailedAttempt
@@ -50,7 +50,7 @@ object Cloudwatch extends Logging {
   def logMetricsForCredentialsReport(data: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]] ) : Unit = {
     data.toSeq.foreach {
       case (account: AwsAccount, Right(details: CredentialReportDisplay)) =>
-        val reportSummary: ReportSummary = reportStatusSummaryWithoutOutdatedKeys(details)
+        val reportSummary: ReportSummary = reportStatusSummary(details)
         putAwsMetric(account, DataType.iamCredentialsCritical, reportSummary.errors)
         putAwsMetric(account, DataType.iamCredentialsWarning, reportSummary.warnings)
         putAwsMetric(account, DataType.iamCredentialsTotal, reportSummary.errors + reportSummary.warnings)

--- a/hq/app/logic/CredentialsReportDisplay.scala
+++ b/hq/app/logic/CredentialsReportDisplay.scala
@@ -126,23 +126,6 @@ object CredentialsReportDisplay {
     ReportSummary(warnings, errors, others)
   }
 
-  /*
-    This should be considered temporary (hence duplication of the above). It is to support a rollout
-    of the critical errors in security HQ (so we have visibility) without yet updating other dashboards
-   */
-  def reportStatusSummaryWithoutOutdatedKeys(report: CredentialReportDisplay): ReportSummary = {
-    val reportStatuses = (report.humanUsers ++ report.machineUsers)
-      .map(_.reportStatus)
-
-    val warnings = reportStatuses.collect({ case Amber(_) => }).size
-    val errors = reportStatuses.collect({
-      case status: Red if !status.reasons.forall(_ == OutdatedKey) =>
-    }).size
-    val others = reportStatuses.collect({ case Blue => }).size
-
-    ReportSummary(warnings, errors, others)
-  }
-
   def exposedKeysSummary(allReports: Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]): Map[AwsAccount, Boolean] = {
     allReports.mapValues {
       case Right(keys) if keys.nonEmpty => true


### PR DESCRIPTION
## What does this change?
We're removing the restriction on which types of IAM credential statuses get reported to cloudwatch (for consumption in our external dashboards.) We are currently excluding outdated credentials from being included in reporting, but since that change we have been working with teams to clean up accounts. We are also not currently actively using the external dashboard as a benchmark for progress, so a sudden increase in critical vulnerabilities reported there is acceptable.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
A step toward better visibility of IAM problems, with an eye on introducing an SLO in this area.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
