### PR TITLE
Upgrade test dependencies for scala 2.13 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,9 +54,9 @@ lazy val hq = (project in file("hq"))
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
-      "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
-      "org.scalacheck" %% "scalacheck" % "1.13.4" % Test,
-      "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % "1.1.6" % Test,
+      "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
+      "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0" % Test,
       "com.gu" % "anghammarad-client_2.12" % "1.1.2",
 
       // logstash-logback-encoder brings in version 2.11.0
@@ -152,7 +152,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
-      "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.11" % Test,
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
       "ch.qos.logback" %  "logback-classic" % "1.2.3",

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ lazy val hq = (project in file("hq"))
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
       "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
+      "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test,
       "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0" % Test,
       "com.gu" % "anghammarad-client_2.12" % "1.1.2",

--- a/hq/test/aws/AWSTest.scala
+++ b/hq/test/aws/AWSTest.scala
@@ -2,12 +2,12 @@ package aws
 
 import com.amazonaws.regions.Regions
 import com.typesafe.config.ConfigFactory
-import org.scalatest.prop.{Checkers, PropertyChecks}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
 import play.api.Configuration
 import utils.attempt.AttemptValues
+import org.scalatest.matchers.should.Matchers
 
-class AWSTest extends FreeSpec with Matchers with Checkers with PropertyChecks with AttemptValues {
+class AWSTest extends AnyFreeSpec with Matchers with AttemptValues {
 
   "real clients" - {
 

--- a/hq/test/aws/cloudformation/CloudFormationTest.scala
+++ b/hq/test/aws/cloudformation/CloudFormationTest.scala
@@ -3,9 +3,10 @@ package aws.cloudformation
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudformation.model.Stack
 import model.AwsStack
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class CloudFormationTest extends FreeSpec with Matchers {
+class CloudFormationTest extends AnyFreeSpec with Matchers {
 
   "parseStacks" - {
     val stackId = "arn:aws:cloudformation:eu-west-1:123456789123:stack/stack-name/8a123bc0-222d-33e4-5fg6-77aa88b12345"

--- a/hq/test/aws/ec2/EC2Test.scala
+++ b/hq/test/aws/ec2/EC2Test.scala
@@ -9,8 +9,9 @@ import org.scalacheck.Gen
 import org.scalacheck.Prop._
 import org.scalacheck.ScalacheckShapeless._
 import org.scalatest.exceptions.TestFailedException
-import org.scalatest.prop.{Checkers, PropertyChecks}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatestplus.scalacheck.{Checkers, ScalaCheckPropertyChecks}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.freespec.AnyFreeSpec
 import utils.attempt.{Attempt, AttemptValues}
 
 import scala.collection.JavaConverters._
@@ -18,7 +19,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Random
 
 
-class EC2Test extends FreeSpec with Matchers with Checkers with PropertyChecks with AttemptValues {
+class EC2Test extends AnyFreeSpec with Matchers with Checkers with ScalaCheckPropertyChecks with AttemptValues {
   "parseNetworkInterface" - {
     "parses an ELB" in {
       EC2.parseNetworkInterface(elb("test-elb")) shouldEqual ELB("test-elb")

--- a/hq/test/aws/ec2/EFSTest.scala
+++ b/hq/test/aws/ec2/EFSTest.scala
@@ -2,11 +2,12 @@ package aws.ec2
 
 import com.amazonaws.services.elasticfilesystem.model.DescribeMountTargetSecurityGroupsResult
 import model.{EfsVolume, SGInUse, UnknownUsage}
-import org.scalatest.{FreeSpec, Matchers}
-import org.scalatest.prop.{Checkers, PropertyChecks}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.{Checkers, ScalaCheckPropertyChecks}
 import utils.attempt.AttemptValues
 
-class EFSTest extends FreeSpec with Matchers with Checkers with PropertyChecks with AttemptValues {
+class EFSTest extends AnyFreeSpec with Matchers with Checkers with ScalaCheckPropertyChecks with AttemptValues {
   "getsEfsSecurityGroups" - {
     "getEfsSecurityGroupResult" in {
       val describeSecGrpResultOne = new DescribeMountTargetSecurityGroupsResult().withSecurityGroups("sg-12345")

--- a/hq/test/aws/iam/CredentialsReportTest.scala
+++ b/hq/test/aws/iam/CredentialsReportTest.scala
@@ -4,12 +4,14 @@ import aws.iam.CredentialsReport.credentialsReportReadyForRefresh
 import com.amazonaws.regions.{Region, Regions}
 import model.{AwsStack, CredentialReportDisplay, IAMCredential, IAMCredentialsReport}
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
 import utils.attempt.{AttemptValues, FailedAttempt, Failure}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class CredentialsReportTest extends FreeSpec with Matchers with OptionValues with AttemptValues {
+class CredentialsReportTest extends AnyFreeSpec with Matchers with OptionValues with AttemptValues {
 
   "credentialsReportNeedsRefreshing" - {
     "when the report is at least 4 hours old" - {

--- a/hq/test/aws/support/TrustedAdvisorExposedIAMKeysTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorExposedIAMKeysTest.scala
@@ -1,14 +1,15 @@
 package aws.support
 
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
-import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class TrustedAdvisorExposedIAMKeysTest extends FreeSpec with Matchers with AttemptValues {
+class TrustedAdvisorExposedIAMKeysTest extends AnyFreeSpec with Matchers with AttemptValues {
   "parseRDSSGDetail" - {
     val metadata = List("key-id", "username", "fraud-type", "case-id", "last-updated", "location", "deadline", "usage")
     val detail = new TrustedAdvisorResourceDetail()

--- a/hq/test/aws/support/TrustedAdvisorRDSSGsTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorRDSSGsTest.scala
@@ -1,14 +1,15 @@
 package aws.support
 
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
-import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class TrustedAdvisorRDSSGsTest extends FreeSpec with Matchers with AttemptValues {
+class TrustedAdvisorRDSSGsTest extends AnyFreeSpec with Matchers with AttemptValues {
   "parseRDSSGDetail" - {
     val metadata = List("eu-west-1", "rds-sg-123456", "sg-12345a", "Yellow")
     val detail = new TrustedAdvisorResourceDetail()

--- a/hq/test/aws/support/TrustedAdvisorSGOpenPortsTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorSGOpenPortsTest.scala
@@ -3,15 +3,16 @@ package aws.support
 import com.amazonaws.services.support.model.TrustedAdvisorResourceDetail
 import model._
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import utils.attempt.AttemptValues
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 
-class TrustedAdvisorSGOpenPortsTest extends FreeSpec with Matchers with AttemptValues with PropertyChecks  {
+class TrustedAdvisorSGOpenPortsTest extends AnyFreeSpec with Matchers with AttemptValues with ScalaCheckPropertyChecks  {
   "parsing details" - {
     "works on example data" in {
       val metadata = List("eu-west-1", "launch-wizard-1", "sg-12345a (vpc-789abc)", "tcp", "Yellow", "22")

--- a/hq/test/aws/support/TrustedAdvisorTest.scala
+++ b/hq/test/aws/support/TrustedAdvisorTest.scala
@@ -1,10 +1,12 @@
 package aws.support
 
 import com.amazonaws.services.support.model.{DescribeTrustedAdvisorChecksResult, TrustedAdvisorCheckDescription}
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class TrustedAdvisorTest extends FreeSpec with Matchers with OptionValues {
+class TrustedAdvisorTest extends AnyFreeSpec with Matchers with OptionValues {
   "parseTrustedAdvisorChecksResult" - {
     val result = new DescribeTrustedAdvisorChecksResult().withChecks(
       new TrustedAdvisorCheckDescription()

--- a/hq/test/db/IamRemediationDbTest.scala
+++ b/hq/test/db/IamRemediationDbTest.scala
@@ -1,6 +1,6 @@
 package db
 
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import db.IamRemediationDb.{N, S, deserialiseIamRemediationActivity, lookupScanRequest, writePutRequest}
 import model.{FinalWarning, IamRemediationActivity, OutdatedCredential}
@@ -9,8 +9,10 @@ import utils.attempt.AttemptValues
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.JavaConverters._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class IamRemediationDbTest extends FreeSpec with Matchers with AttemptValues with OptionValues {
+class IamRemediationDbTest extends AnyFreeSpec with Matchers with AttemptValues with OptionValues {
 
   val tableName = "testTable"
   val accountId = "testAccountId"

--- a/hq/test/logic/CredentialsReportDisplayTest.scala
+++ b/hq/test/logic/CredentialsReportDisplayTest.scala
@@ -2,13 +2,14 @@ package logic
 
 import model._
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
 import CredentialsReportDisplay._
 import IamUnrecognisedUsers.USERNAME_TAG_KEY
 import utils.attempt.{FailedAttempt, Failure}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class CredentialsReportDisplayTest extends FreeSpec with Matchers {
+class CredentialsReportDisplayTest extends AnyFreeSpec with Matchers {
 
   "display logic" - {
     val now = DateTime.now()

--- a/hq/test/logic/DateUtilsTest.scala
+++ b/hq/test/logic/DateUtilsTest.scala
@@ -1,9 +1,10 @@
 package logic
 
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class DateUtilsTest extends FreeSpec with Matchers {
+class DateUtilsTest extends AnyFreeSpec with Matchers {
 
   "datetutils" - {
 

--- a/hq/test/logic/DocumentUtilTest.scala
+++ b/hq/test/logic/DocumentUtilTest.scala
@@ -1,9 +1,10 @@
 package logic
 
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class DocumentUtilTest extends FreeSpec with Matchers {
+class DocumentUtilTest extends AnyFreeSpec with Matchers {
   "replaceSnykSSOUrl" - {
     "replaces placeholder with provided string" in {
       val template =

--- a/hq/test/logic/IamOutdatedCredentialsTest.scala
+++ b/hq/test/logic/IamOutdatedCredentialsTest.scala
@@ -6,12 +6,14 @@ import logic.IamOutdatedCredentials._
 import model._
 import org.joda.time.DateTime
 import org.scalatest.Inside.inside
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
 import utils.attempt.{AttemptValues, FailedAttempt, Failure}
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class IamOutdatedCredentialsTest extends FreeSpec with Matchers with OptionValues with AttemptValues {
+class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionValues with AttemptValues {
   val date = new DateTime(2021, 1, 1, 1, 1)
   val humanAccessKeyOldAndEnabled1 = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))
   val humanAccessKeyOldAndEnabled2 = AccessKey(AccessKeyEnabled, Some(date.minusMonths(4)))

--- a/hq/test/logic/PublicBucketsDisplayTest.scala
+++ b/hq/test/logic/PublicBucketsDisplayTest.scala
@@ -2,10 +2,11 @@ package logic
 
 import logic.PublicBucketsDisplay._
 import model._
-import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.Failure
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class PublicBucketsDisplayTest extends FreeSpec with Matchers {
+class PublicBucketsDisplayTest extends AnyFreeSpec with Matchers {
 
   def createExampleBuckets(id: Int): List[BucketDetail] = {
     List(

--- a/hq/test/logic/RetryTest.scala
+++ b/hq/test/logic/RetryTest.scala
@@ -1,12 +1,13 @@
 package logic
 
-import org.scalatest.{Matchers, WordSpec}
 import utils.attempt.{Attempt, AttemptValues}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RetryTest extends WordSpec with Matchers with AttemptValues {
+class RetryTest extends AnyWordSpec with Matchers with AttemptValues {
   "looped attempt" should {
     val failMessage = "Retry failed"
     val InProgress = "INPROGRESS"

--- a/hq/test/logic/SecurityGroupDisplayTest.scala
+++ b/hq/test/logic/SecurityGroupDisplayTest.scala
@@ -1,11 +1,12 @@
 package logic
 
 import model._
-import org.scalatest.{FreeSpec, Matchers}
 import SecurityGroupDisplay._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class SecurityGroupDisplayTest extends FreeSpec with Matchers {
+class SecurityGroupDisplayTest extends AnyFreeSpec with Matchers {
   "resourceIcons" - {
     "returns zeros when there are no resources in use" in {
       val usages = List[SGInUse]()

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -1,12 +1,13 @@
 package logic
 
 import model.{SnykIssue, SnykOrganisation, _}
-import org.scalatest.{FreeSpec, Matchers}
 import utils.attempt.AttemptValues
 import scala.io.Source
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class SnykDisplayTest extends FreeSpec with Matchers with AttemptValues {
+class SnykDisplayTest extends AnyFreeSpec with Matchers with AttemptValues {
 
   private def readFile(filename:String) = Source.fromResource(s"logic/SnykDisplayTestResources/$filename.json").getLines.mkString
 

--- a/hq/test/logic/VulnerableAccessKeysTest.scala
+++ b/hq/test/logic/VulnerableAccessKeysTest.scala
@@ -3,10 +3,11 @@ package logic
 import logic.VulnerableAccessKeys._
 import model.{AccessKey, AccessKeyDisabled, AccessKeyEnabled}
 import org.joda.time.DateTime
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class VulnerableAccessKeysTest extends FreeSpec with Matchers {
+class VulnerableAccessKeysTest extends AnyFreeSpec with Matchers {
   def accessKey(daysOld: Int, active: Boolean) = {
     AccessKey(
       if (active) AccessKeyEnabled else AccessKeyDisabled,

--- a/hq/test/model/TagTest.scala
+++ b/hq/test/model/TagTest.scala
@@ -1,9 +1,10 @@
 package model
 
 import com.gu.anghammarad.models.{App, Stack, Stage => AnghammaradStage}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class TagTest extends FreeSpec with Matchers {
+class TagTest extends AnyFreeSpec with Matchers {
   val tagsListWithStack = List(Tag("stAck", "pawnee"), Tag("department", "parks and recreation"))
   val tagsListWithStackStageApp = List(Tag("stack", "pawnee"), Tag("stage", "enquiry"), Tag("app", "the-pit"))
 

--- a/hq/test/schedule/unrecognised/IamUnrecognisedUsersTest.scala
+++ b/hq/test/schedule/unrecognised/IamUnrecognisedUsersTest.scala
@@ -4,14 +4,15 @@ import com.gu.janus
 import com.gu.janus.model.{ACL, JanusData, SupportACL}
 import model._
 import org.joda.time.{DateTime, Seconds}
-import org.scalatest.{FreeSpec, Matchers}
 import logic.IamUnrecognisedUsers._
 import logic.IamUnrecognisedUsers.{USERNAME_TAG_KEY, getCredsReportDisplayForAccount, getJanusUsernames, isTaggedForUnrecognisedUser, unrecognisedUsersForAllowedAccounts}
 import utils.attempt.{FailedAttempt, Failure}
 
 import scala.io.Source
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class IamUnrecognisedUsersTest extends FreeSpec with Matchers {
+class IamUnrecognisedUsersTest extends AnyFreeSpec with Matchers {
   val humanUser1 = HumanUser("ade.bimbola", true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, List(Tag(USERNAME_TAG_KEY, "ade.bimbola")))
   val humanUser2 = humanUser1.copy(username = "john.akindele", tags = List(Tag(USERNAME_TAG_KEY, "john.akindele")))
   val humanUser3 = humanUser1.copy(username = "khadija.omodara", tags = List(Tag(USERNAME_TAG_KEY, "khadija.omodara")))

--- a/hq/test/utils/attempt/AttemptTest.scala
+++ b/hq/test/utils/attempt/AttemptTest.scala
@@ -1,13 +1,15 @@
 package utils.attempt
 
-import org.scalatest.{EitherValues, FreeSpec, Matchers}
+import org.scalatest.EitherValues
 import Attempt.{Left, Right}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class AttemptTest extends FreeSpec with Matchers with EitherValues {
+class AttemptTest extends AnyFreeSpec with Matchers with EitherValues {
   import scala.concurrent.ExecutionContext.Implicits.global
 
   "traverse" - {

--- a/hq/test/utils/attempt/AttemptValues.scala
+++ b/hq/test/utils/attempt/AttemptValues.scala
@@ -2,11 +2,11 @@ package utils.attempt
 
 import java.io.{ByteArrayOutputStream, PrintWriter}
 
-import org.scalatest.Matchers
 import org.scalatest.exceptions.TestFailedException
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import org.scalatest.matchers.should.Matchers
 
 
 trait AttemptValues extends Matchers {

--- a/lambda/common/src/test/scala/com/gu/hq/lambda/JsonParsingTest.scala
+++ b/lambda/common/src/test/scala/com/gu/hq/lambda/JsonParsingTest.scala
@@ -4,11 +4,13 @@ import com.gu.hq.lambda.fixtures.Common
 import com.gu.hq.lambda.fixtures.Events._
 import com.gu.hq.lambda.fixtures.SecurityGroups._
 import org.joda.time.{DateTime, DateTimeZone}
-import org.scalatest.{EitherValues, FreeSpec, Matchers, OptionValues}
+import org.scalatest.{EitherValues, OptionValues}
 import play.api.libs.json.JsNull
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class JsonParsingTest extends FreeSpec with Matchers with OptionValues with EitherValues {
+class JsonParsingTest extends AnyFreeSpec with Matchers with OptionValues with EitherValues {
 
   "eventDetails" - {
     "parses the JSON out of an example configEvent" in {

--- a/lambda/common/src/test/scala/com/gu/hq/lambda/model/JSONTest.scala
+++ b/lambda/common/src/test/scala/com/gu/hq/lambda/model/JSONTest.scala
@@ -1,13 +1,15 @@
 package com.gu.hq.lambda.model
 
 import com.gu.hq.lambda.model.JSON._
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
 import play.api.libs.json.Json
 
 import scala.io.Source
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class JSONTest extends FreeSpec with Matchers with OptionValues {
+class JSONTest extends AnyFreeSpec with Matchers with OptionValues {
   "parse config event" - {
     "can parse an event triggered by a change" - {
       val irrelevantEventJson = loadJsonResource("config_event_with_irrelevant_update")

--- a/lambda/security-groups/src/test/scala/com/gu/hq/EventsTest.scala
+++ b/lambda/security-groups/src/test/scala/com/gu/hq/EventsTest.scala
@@ -3,12 +3,13 @@ package com.gu.hq
 import com.gu.hq.Events.{NotRelevant, Relevant}
 import com.gu.hq.lambda.model.InvokingEvent
 import com.gu.hq.lambda.model.JSON._
-import org.scalatest.{FreeSpec, Matchers}
 import play.api.libs.json.Json
 
 import scala.io.Source
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class EventsTest extends FreeSpec with Matchers {
+class EventsTest extends AnyFreeSpec with Matchers {
 
   "parse config event" - {
     def loadJsonResource(filename: String) = Source.fromResource(s"$filename.json").getLines.mkString

--- a/lambda/security-groups/src/test/scala/com/gu/hq/NotifierTest.scala
+++ b/lambda/security-groups/src/test/scala/com/gu/hq/NotifierTest.scala
@@ -4,10 +4,12 @@ import com.gu.anghammarad.models.{App, AwsAccount, Stack}
 import com.gu.hq.Events.{NotRelevant, Relevant}
 import com.gu.hq.SecurityGroups._
 import com.gu.hq.lambda.model.Tag
-import org.scalatest.{FreeSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class NotifierTest extends FreeSpec with Matchers with OptionValues {
+class NotifierTest extends AnyFreeSpec with Matchers with OptionValues {
   import Notifier._
 
   "shouldNotify" - {

--- a/lambda/security-groups/src/test/scala/com/gu/hq/SecurityGroupsTest.scala
+++ b/lambda/security-groups/src/test/scala/com/gu/hq/SecurityGroupsTest.scala
@@ -2,9 +2,10 @@ package com.gu.hq
 
 import com.amazonaws.services.elasticloadbalancing.model.{DescribeLoadBalancersResult, LoadBalancerDescription}
 import com.gu.hq.lambda.model.{IpPermission, SGConfiguration, UserIdGroupPair}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class SecurityGroupsTest extends FreeSpec with Matchers {
+class SecurityGroupsTest extends AnyFreeSpec with Matchers {
   "openToWorld" - {
     "returns true for a SecurityGroup that is open" in {
       val openPermissions = List(


### PR DESCRIPTION
## What does this change?
Upgrades the testing-related dependencies that are currently on versions that were not built for scala 2.13.

This is not a trivial change, mainly due to the movement of entities in scalatest 3.1.0 described here: https://www.scalatest.org/release_notes/3.1.0.

I have split it into 3 commits:
1. Bump the existing dependencies in 673df1a9a7bad489822f0b8b752efa80cb07bed7
2. Autofix the renames/moves using [this procedure](https://github.com/scalatest/autofix/tree/master/3.1.x) in d4a1585fe98ddddebe51c880af07215ada2a174c. As this was automated, it can be largely ignored for review purposes.
3. Introduce scalatestplus scalacheck in 62e45598feae1423b802bc93de5d809f977737a6, which is the new separate library for combining scalatest and scalacheck. Previously this functionality was in scalatest itself.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Prepares us for scala 2.13 and keeps deps up to date.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
I had some trouble with my IDE recognising these changes or displaying unrelated errors during development, but that might've been a local problem to me. (It appears to be ok now FWIW)

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
