### PR TITLE
Restore/revamp Snyk dashboard with vulnerability age indicator

### DIFF
--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -2,13 +2,15 @@ package api
 
 import logic.SnykDisplay
 import model._
+import play.api.Logging
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-object Snyk {
+object Snyk extends Logging {
 
   private def snykRequest(token:SnykToken, url:String, wsClient: WSClient) =
     wsClient.url(url).addHttpHeaders("Authorization" -> s"token ${token.value}")
@@ -28,28 +30,25 @@ object Snyk {
     }
   }
 
-  def getProjectVulnerabilities(projects: List[SnykProject], token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[WSResponse]] = {
-
-    val projectVulnerabilityResponses = projects
-      .map(project => {
-        val snykProjectUrl = s"https://snyk.io/api/v1/org/${project.organisation.get.id}/project/${project.id}/issues"
-        val projectIssuesFilter = Json.obj(
-          "filters" -> Json.obj(
-            "severity" -> JsArray(List(
-              JsString("high"), JsString("medium"), JsString("low")
-            )),
-            "types" -> JsArray(List(
-              JsString("vuln")
-            )),
-            "ignored" -> "false",
-            "patched" -> "false"
-          )
-        )
-        snykRequest(token, snykProjectUrl, wsClient).post(projectIssuesFilter)
-      })
-    Attempt.traverse(projectVulnerabilityResponses) {
-      projectVulnerabilityResponse => handleFuture(projectVulnerabilityResponse, "project vulnerabilities")
-    }
+  def getOrganisationVulnerabilities(organisation: SnykOrganisation, token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[String] = {
+    logger.info(s"grabbing org vulns for ${organisation.name}")
+    val snykIssuesUrl = s"https://snyk.io/api/v1/reporting/issues/latest?sortBy=severity&order=desc&perPage=1000"
+    val orgIssuesFilter = Json.obj(
+      "filters" -> Json.obj(
+        "orgs" -> JsArray(List(
+          JsString(organisation.id))
+        ),
+        "types" -> JsArray(List(
+          JsString("vuln")
+        )),
+        "ignored" -> JsBoolean(false),
+        "patched" -> JsBoolean(false),
+        "isFixed" -> JsBoolean(false)
+      )
+    )
+    val futureResponse = snykRequest(token, snykIssuesUrl, wsClient).post(orgIssuesFilter)
+      .map(response => response.body)
+    handleFuture(futureResponse, "org vulnerabilities")
   }
 
   def handleFuture[A](future: Future[A], label: String)(implicit ec: ExecutionContext): Attempt[A] = Attempt.fromFuture(future) {
@@ -58,22 +57,14 @@ object Snyk {
       FailedAttempt(failure)
   }
 
-  def allSnykRuns(snykConfig: SnykConfig, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[SnykProjectIssues]] = {
+  def allSnykRuns(snykConfig: SnykConfig, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[List[SnykOrganisationIssues]] = {
     for {
       organisationResponse <- Snyk.getSnykOrganisations(snykConfig.snykToken, wsClient)
       organisations <- SnykDisplay.parseOrganisations(organisationResponse.body, snykConfig.snykGroupId)
 
-      projectResponses <- Snyk.getProjects(snykConfig.snykToken, organisations, wsClient)
-      organisationAndProjects <- SnykDisplay.parseProjectResponses(projectResponses)
-      labelledProjects = SnykDisplay.labelOrganisations(organisationAndProjects)
-
-      vulnerabilitiesResponse <- Snyk.getProjectVulnerabilities(labelledProjects, snykConfig.snykToken, wsClient)
-      vulnerabilitiesResponseBodies = vulnerabilitiesResponse.map(a => a.body)
-
-      parsedVulnerabilitiesResponse <- SnykDisplay.parseProjectVulnerabilities(vulnerabilitiesResponseBodies)
-
-      results = SnykDisplay.labelProjects(labelledProjects, parsedVulnerabilitiesResponse)
-    } yield results
+      vulnerabilitiesResponse <- Attempt.labelledTraverse(organisations)(Snyk.getOrganisationVulnerabilities(_, snykConfig.snykToken, wsClient))
+      orgIssues <- SnykDisplay.parseOrganisationVulnerabilities(vulnerabilitiesResponse)
+    } yield orgIssues
   }
 
 }

--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -2,7 +2,6 @@ package api
 
 import logic.SnykDisplay
 import model._
-import play.api.Logging
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
@@ -10,7 +9,7 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
-object Snyk extends Logging {
+object Snyk {
 
   private def snykRequest(token:SnykToken, url:String, wsClient: WSClient) =
     wsClient.url(url).addHttpHeaders("Authorization" -> s"token ${token.value}")
@@ -31,7 +30,6 @@ object Snyk extends Logging {
   }
 
   def getOrganisationVulnerabilities(organisation: SnykOrganisation, token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[String] = {
-    logger.info(s"grabbing org vulns for ${organisation.name}")
     val snykIssuesUrl = s"https://snyk.io/api/v1/reporting/issues/latest?sortBy=severity&order=desc&perPage=1000"
     val orgIssuesFilter = Json.obj(
       "filters" -> Json.obj(

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -28,6 +28,9 @@ object Config {
   val daysBetweenFinalNotificationAndRemediation = 7
   val app = "security-hq"
 
+  val snykMaxAcceptableAgeOfCriticalVulnerabilities = 7
+  val snykMaxAcceptableAgeOfHighVulnerabilities = 14
+
   // TODO fetch the region dynamically from the instance
   val region: Regions = Regions.EU_WEST_1
   val documentationLinks = List (

--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -29,7 +29,7 @@ class SnykController(val config: Configuration,
     attempt {
       for {
         accountAssessmentRuns <- cacheService.getAllSnykResults
-        sorted = SnykDisplay.sortProjects(accountAssessmentRuns)
+        sorted = SnykDisplay.sortOrgs(accountAssessmentRuns)
       } yield Ok(views.html.snyk.snyk(sorted))
     }
   }

--- a/hq/app/logic/SnykDisplay.scala
+++ b/hq/app/logic/SnykDisplay.scala
@@ -59,7 +59,6 @@ object SnykDisplay extends Logging {
 
   def parseOrganisationVulnerabilitiesBody(s: String): Attempt[List[SnykProjectIssues]] =
     parseJsonToObject("project vulnerabilities", s, body => {
-      //logger.info(s"parsing project vulns for ${s}")
       val orgIssuesResult = (Json.parse(body) \ "results").validate[List[SnykProjectIssue]]
       orgIssuesResult.map(groupProjectIssues)
     })

--- a/hq/app/model/Serializers.scala
+++ b/hq/app/model/Serializers.scala
@@ -1,9 +1,14 @@
 package model
 
+import org.joda.time.DateTime
+import org.joda.time.format.ISODateTimeFormat
+import play.api.Logging
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath, Json, Reads}
+import play.api.libs.json._
 
-object Serializers {
+import scala.util.Try
+
+object Serializers extends Logging {
 
   implicit val snykErrorFormat: Reads[SnykError] = Json.reads[SnykError]
 
@@ -15,24 +20,27 @@ object Serializers {
       (JsPath \ "id").read[String]
       and
       (JsPath \ "group").readNullable[SnykGroup]
-    )(SnykOrganisation.apply _)
+    ) (SnykOrganisation.apply _)
 
-  implicit val snykProjectFormat: Reads[SnykProject] = (
-    (JsPath \ "name").read[String]
-      and
-      (JsPath \ "id").read[String]
-      and
-      Reads.pure(None)
-    )(SnykProject.apply _)
+  implicit val snykProjectFormat: Reads[SnykProject] = Json.reads[SnykProject]
 
   implicit val snykIssueReads: Format[SnykIssue] = Json.format[SnykIssue]
 
-  implicit val snykProjectIssuesReads: Reads[SnykProjectIssues] = (
-    Reads.pure(None)
-      and
-      (JsPath \ "ok").read[Boolean]
-      and
-      (JsPath \ "issues" \ "vulnerabilities").read[Set[SnykIssue]]
-    )(SnykProjectIssues.apply _)
+  private val snykDateReads = new Reads[DateTime] {
+    override def reads(json: JsValue): JsResult[DateTime] =
+      Try {
+        ISODateTimeFormat.dateParser().parseDateTime(json.as[String])
+      } fold(
+        _ => JsError("Unable to parse date string from Snyk API"),
+        date => JsSuccess(date)
+      )
+  }
 
+  implicit val snykProjectIssueReads: Reads[SnykProjectIssue] = (
+    (JsPath \ "project").readNullable[SnykProject]
+      and
+      (JsPath \ "introducedDate").read(snykDateReads)
+      and
+      (JsPath \ "issue").read[SnykIssue]
+    ) (SnykProjectIssue.apply _)
 }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -48,7 +48,7 @@ class CacheService(
   private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(startingCache)
   private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(startingCache)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
-  private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.snykDashboardDecomission("cache").attempt)))
+  private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("cache").attempt)))
   private val gcpBox: Box[Attempt[GcpReport]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorGcp("GCP").attempt)))
 
   def getAllPublicBuckets: Map[AwsAccount, Either[FailedAttempt, List[BucketDetail]]] = publicBucketsBox.get()
@@ -177,6 +177,10 @@ class CacheService(
       refreshCredentialsBox()
     }
 
+    val snykSubscription = Observable.interval(initialDelay + 6000.millis, 30.minutes).subscribe { _ =>
+      refreshSnykBox()
+    }
+
     val gcpSubscription = Observable.interval(initialDelay + 6000.millis, 90.minutes).subscribe { _ =>
       logger.info("refreshing the GCP Box now")
       refreshGcpBox()
@@ -187,6 +191,7 @@ class CacheService(
       exposedKeysSubscription.unsubscribe()
       sgSubscription.unsubscribe()
       credentialsSubscription.unsubscribe()
+      snykSubscription.unsubscribe()
       gcpSubscription.unsubscribe()
       Future.successful(())
     }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -48,7 +48,7 @@ class CacheService(
   private val credentialsBox: Box[Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]] = Box(startingCache)
   private val exposedKeysBox: Box[Map[AwsAccount, Either[FailedAttempt, List[ExposedIAMKeyDetail]]]] = Box(startingCache)
   private val sgsBox: Box[Map[AwsAccount, Either[FailedAttempt, List[(SGOpenPortsDetail, Set[SGInUse])]]]] = Box(startingCache)
-  private val snykBox: Box[Attempt[List[SnykProjectIssues]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("cache").attempt)))
+  private val snykBox: Box[Attempt[List[SnykOrganisationIssues]]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorAllAccounts("cache").attempt)))
   private val gcpBox: Box[Attempt[GcpReport]] = Box(Attempt.fromEither(Left(Failure.cacheServiceErrorGcp("GCP").attempt)))
 
   def getAllPublicBuckets: Map[AwsAccount, Either[FailedAttempt, List[BucketDetail]]] = publicBucketsBox.get()
@@ -87,7 +87,7 @@ class CacheService(
     )
   }
 
-  def getAllSnykResults: Attempt[List[SnykProjectIssues]] = snykBox.get()
+  def getAllSnykResults: Attempt[List[SnykOrganisationIssues]] = snykBox.get()
 
   def getGcpReport: Attempt[GcpReport] = gcpBox.get()
 

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -64,12 +64,6 @@ object Failure {
     Failure(details, friendlyMessage, 500)
   }
 
-  def snykDashboardDecomission(cacheContent: String): Failure = {
-    val details = s"Cache service error; unable to retrieve $cacheContent"
-    val friendlyMessage = s"This dashboard has been temporarily closed while we evaluate the best format for this information. Please go to snyk.io directly for information about vulnerabilities in guardian services."
-    Failure(details, friendlyMessage, 500)
-  }
-
   def cacheServiceErrorGcp(cacheContent: String): Failure = {
     val details = s"Cache service error; unable to retrieve $cacheContent"
     val friendlyMessage = s"Oops! We're still loading the $cacheContent data. Please refresh the page shortly."

--- a/hq/app/views/snyk/snyk.scala.html
+++ b/hq/app/views/snyk/snyk.scala.html
@@ -1,13 +1,13 @@
 @import logic.SnykDisplay._
 @import model._
 
-@(results: List[SnykProjectIssues])(implicit assets: AssetsFinder)
+@(results: List[SnykOrganisationIssues])(implicit assets: AssetsFinder)
 
 @main(List("Snyk")) { @* Header *@
     <div class="hq-sub-header">
         <div class="container hq-sub-header__row">
             <div class="hq-sub-header__name">
-                <h4 class="header light grey-text text-lighten-5">Snyk Results</h4>
+                <h4 class="header light grey-text text-lighten-5">Snyk Code Scanning</h4>
             </div>
         </div>
     </div>
@@ -15,54 +15,43 @@
 } { @* Main content *@
 
     <div class="container">
-
-        <table class="striped responsive-table filterable-table">
-            <thead>
-                <tr>
-                    <th>Project Name</th>
-                    <th>High</th>
-                    <th>Medium</th>
-                    <th>Low</th>
-                </tr>
-            </thead>
-
-            <tbody>
-            @for(projectIssues <- results) {
-                @projectIssues.project match {
-                    case Some(snykProject) => {
-                        <tr>
-                            <td>
-                                <a target="_blank" rel="noopener noreferrer" href="@linkToSnykProject(projectIssues, None)">
-                                    @snykProject.name
-                                    <i class="material-icons link_new_tab">open_in_new</i>
-                                </a>
-                            </td>
-                            <td>
-                                <a target="_blank" href="@{linkToSnykProject(projectIssues, Some("?disclosure=all&severity=high"))}">
-                                    @projectIssues.high
-                                </a>
-                            </td>
-                            <td>
-                                <a target="_blank" href="@{linkToSnykProject(projectIssues, Some("?disclosure=all&severity=medium"))}">
-                                    @projectIssues.medium
-                                </a>
-                            </td>
-                            <td>
-                                <a target="_blank" href="@{linkToSnykProject(projectIssues, Some("?disclosure=all&severity=low"))}">
-                                    @projectIssues.low
-                                </a>
-                            </td>
-                        </tr>
-                    }
-                    case None => { }
-                }
-
-
+        <div class="row">
+            <div class="card-panel">
+                <span>
+                    Report refreshed every hour. Results are based on the 1000 highest severity issues in each Snyk organisation.
+                </span>
+            </div>
+        </div>
+        <div class="row">
+            <ul class="collapsible" data-collapsible="accordion">
+            @for(orgIssues <- results) {
+                <li>
+                    <div class="collapsible-header" tabindex="22">
+                        <i class="material-icons">keyboard_arrow_down</i>
+                        <span class="iam-header__name">@orgIssues.organisation.name</span>
+                        @if(orgIssues.critical > 0) {
+                            <span class="icon-count">@orgIssues.critical</span>
+                            <i class="material-icons red-text">error</i>
+                        }
+                        @if(orgIssues.high > 0) {
+                            <span class="icon-count">@orgIssues.high</span>
+                            <i class="material-icons red-text">error_outline</i>
+                        }
+                        @if(orgIssues.medium > 0) {
+                            <span class="icon-count">@orgIssues.medium</span>
+                            <i class="material-icons amber-text">warning</i>
+                        }
+                        @if(orgIssues.low > 0) {
+                            <span class="icon-count">@orgIssues.low</span>
+                            <i class="material-icons grey-text">info</i>
+                        }
+                    </div>
+                    <div class="collapsible-body">
+                        @views.html.snyk.snykOrgProjects(orgIssues)
+                    </div>
+                </li>
             }
-
-        </table>
-
+            </ul>
+        </div>
     </div>
-    </div>
-
 }

--- a/hq/app/views/snyk/snykOrgProjects.scala.html
+++ b/hq/app/views/snyk/snykOrgProjects.scala.html
@@ -1,0 +1,82 @@
+@import logic.SnykDisplay._
+@import model._
+
+@(orgIssues: SnykOrganisationIssues)(implicit assets: AssetsFinder)
+
+@topProjects() = {
+    <div class="col s6">
+        <h5>Top 5 vulnerable projects</h5>
+        <table class="striped responsive-table">
+            <thead>
+                <tr>
+                    <th>Project</th>
+                    <th>Critical</th>
+                    <th>High</th>
+                    <th>Medium</th>
+                    <th>Low</th>
+                </tr>
+            </thead>
+            <tbody>
+            @for(project <- sortProjects(orgIssues.projectIssues).take(5)) {
+                <tr>
+                    <td>
+                        <a target="_blank" rel="noopener noreferrer" href="@linkToSnykProject(project, orgIssues.organisation, None)">@project.project.fold("")(_.name)</a>
+                    </td>
+                    <td>@project.critical</td>
+                    <td>@project.high</td>
+                    <td>@project.medium</td>
+                    <td>@project.low</td>
+            <tr>
+            }
+            </tbody>
+        </table>
+    </div>
+}
+
+<div class="row">
+    <div class="col s12">
+        @defining(longLivedHighVulnerabilities(orgIssues), longLivedCriticalVulnerabilities(orgIssues)) { case (longLivedHighVulnerabilities, longLivedCriticalVulnerabilities) =>
+          @if(longLivedHighVulnerabilities.size > 0 || longLivedCriticalVulnerabilities.size > 0) {
+              <div class="card-panel">
+                  <i class="material-icons left red-text">warning</i>
+                  <span>This organisation contains critical or high severity vulnerabilities older than the maximum permitted age</span>
+                  <a target="_blank" rel="noopener noreferrer" href="@{s"https://snyk.io/org/${orgIssues.organisation.name}/reports/issues"}">
+                      <i class="material-icons right">open_in_new</i>
+                  </a>
+              </div>
+          }
+        }
+    </div>
+</div>
+<div class="row valign-wrapper">
+    @if(orgIssues.projectIssues.isEmpty) {
+        <div class="col s12">
+            <div class="card-panel">
+                <i class="material-icons left green-text">check_circle</i>
+                <span>This organisation contains no vulnerable projects</span>
+            </div>
+        </div>
+    } else {
+        @topProjects()
+        <div class="col s3">
+            <div class="row center-align">
+                <div class="snyk-summary__count red-text">@orgIssues.critical</div>
+                <div class="snyk-summary__count-label">Critical</div>
+            </div>
+            <div class="row center-align">
+                <div class="snyk-summary__count amber-text">@orgIssues.medium</div>
+                <div class="snyk-summary__count-label">Medium</div>
+            </div>
+        </div>
+        <div class="col s3">
+            <div class="row center-align">
+                <div class="snyk-summary__count red-text">@orgIssues.high</div>
+                <div class="snyk-summary__count-label">High</div>
+            </div>
+            <div class="row center-align">
+                <div class="snyk-summary__count">@orgIssues.low</div>
+                <div class="snyk-summary__count-label">Low</div>
+            </div>
+        </div>
+    }
+</div>

--- a/hq/public/stylesheets/main.css
+++ b/hq/public/stylesheets/main.css
@@ -419,8 +419,13 @@ table.iam-report__table th {
 
 /* Snyk */
 
-.filter-table {
-  display: flex;
+.snyk-summary__count {
+  font-size: 5rem;
+  line-height: 1;
+}
+
+.snyk-summary__count-label {
+  font-size: 1.2rem;
 }
 
 /* footer */

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -1,7 +1,9 @@
 package logic
 
 import model.{SnykIssue, SnykOrganisation, _}
+import org.joda.time.DateTime
 import utils.attempt.AttemptValues
+
 import scala.io.Source
 import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.freespec.AnyFreeSpec
@@ -75,141 +77,211 @@ class SnykDisplayTest extends AnyFreeSpec with Matchers with AttemptValues {
     }
   }
 
+  val dummyOrg = SnykOrganisation("dummy", "dummy", None)
   "fail to find project list" - {
     "bad response" in {
-      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), s"""response is not json!""")))
+      val projects = SnykDisplay.parseProjectResponses(List((dummyOrg, s"""response is not json!""")))
       projects.isFailedAttempt() shouldBe true
       projects.getFailedAttempt().failures.head.friendlyMessage shouldBe "Could not read Snyk response (response is not json!)"
     }
     "fail to find project id list (nice) - fails" in {
-      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((dummyOrg, mockBadResponseWithMessage)))
       projects.isFailedAttempt() shouldBe true
     }
     "fail to find project id list (nice) - has message" in {
-      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((dummyOrg, mockBadResponseWithMessage)))
       projects.getFailedAttempt().failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
     }
     "fail to find project id list (not nice) - fails" in {
-      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((dummyOrg, mockBadResponseWithoutMessage)))
       projects.isFailedAttempt() shouldBe true
     }
     "fail to find project id list (not nice) - has message" in {
-      val projects = SnykDisplay.parseProjectResponses(List((SnykOrganisation("dummy", "dummy", None), mockBadResponseWithoutMessage)))
+      val projects = SnykDisplay.parseProjectResponses(List((dummyOrg, mockBadResponseWithoutMessage)))
       projects.getFailedAttempt().failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
     }
   }
 
-  "find vulnerability list" - {
-    "find ok for empty list" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(readFile("goodAndNotVulnerableResponse")))
-      projects.value().head.ok shouldBe true
+  "Parsing results for organisation vulnerabilities" - {
+    "find no results for an org with no vulnerabilities" in {
+      val organisations = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, readFile("goodAndNotVulnerableResponse"))))
+      organisations.value().head.projectIssues shouldBe empty
     }
-  }
-
-  "find results from good vulnerability response" - {
 
     val mockGoodButVulnerableResponse = readFile("goodButVulnerableResponse")
 
-    "find ok for non-empty list" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockGoodButVulnerableResponse))
-      projects.value().head.ok shouldBe false
-    }
     "find high count for non-empty list" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockGoodButVulnerableResponse))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, mockGoodButVulnerableResponse)))
       projects.value().head.high shouldBe 1
     }
     "find medium count for non-empty list" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockGoodButVulnerableResponse))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, mockGoodButVulnerableResponse)))
       projects.value().head.medium shouldBe 0
     }
     "find low count for non-empty list" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockGoodButVulnerableResponse))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, mockGoodButVulnerableResponse)))
       projects.value().head.low shouldBe 0
     }
   }
 
   "fail to find vulnerability list" - {
     "bad response" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(s"""response is not json!"""))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, """response is not json!""")))
       projects.isFailedAttempt() shouldBe true
       projects.getFailedAttempt().failures.head.friendlyMessage shouldBe "Could not read Snyk response (response is not json!)"
     }
     "fail to find vulnerability list with error message - fails" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockBadResponseWithMessage))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, mockBadResponseWithMessage)))
       projects.isFailedAttempt() shouldBe true
     }
     "fail to find vulnerability list with error message - has message" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockBadResponseWithMessage))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, mockBadResponseWithMessage)))
       projects.getFailedAttempt().failures.head.friendlyMessage shouldBe "Could not read Snyk response (some nice error)"
     }
     "fail to find vulnerability list without error message - fails" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockBadResponseWithoutMessage))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, mockBadResponseWithoutMessage)))
       projects.isFailedAttempt() shouldBe true
     }
     "fail to find vulnerability list without error message - has message" in {
-      val projects = SnykDisplay.parseProjectVulnerabilities(List(mockBadResponseWithoutMessage))
+      val projects = SnykDisplay.parseOrganisationVulnerabilities(List((dummyOrg, mockBadResponseWithoutMessage)))
       projects.getFailedAttempt().failures.head.friendlyMessage shouldBe """Could not read Snyk response ({"toughluck": "no use"})"""
     }
   }
 
-  "label organisation" - {
-    val goodOrganisation = SnykOrganisation("name0", "id0", None)
-    val goodProjects = List(
-      ((goodOrganisation, ""),
+  "sort orgs" - {
+    "All equal except number of high risk issues" in {
+      SnykDisplay.sortOrgs(
         List(
-          SnykProject("name1", "id1", None),
-          SnykProject("name2", "id2", None)
+          SnykOrganisationIssues(
+            SnykOrganisation("org", "1", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low"))
+                )
+              )
+            )
+          ),
+          SnykOrganisationIssues(
+            SnykOrganisation("org", "2", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "2", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "4", "low"))
+                )
+              )
+            )
+          )
         )
-      )
-    )
-
-    "label organisation - first id" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects)
-      results.head.organisation.get.id shouldBe "id0"
-    }
-    "label organisation - first name" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects)
-      results.head.organisation.get.name shouldBe "name0"
-    }
-    "label organisation - second id" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects)
-      results.tail.head.organisation.get.id shouldBe "id0"
-    }
-    "label organisation - second name" in {
-      val results = SnykDisplay.labelOrganisations(goodProjects)
-      results.tail.head.organisation.get.name shouldBe "name0"
-    }
-  }
-
-  "label projects" - {
-    val goodProjects = List(
-      SnykProject("name1", "id1", None),
-      SnykProject("name2", "id2", None)
-    )
-
-    val goodVulnerabilities = List(
-      SnykProjectIssues(None, ok = false, Set[SnykIssue]()),
-      SnykProjectIssues(None, ok = false, Set[SnykIssue]())
-    )
-
-    "label projects - first id" - {
-      val results = SnykDisplay.labelProjects(goodProjects, goodVulnerabilities)
-      results.head.project.get.id shouldBe "id1"
+      ).map(spi => spi.organisation.id) shouldBe List[String]("2", "1")
     }
 
-    "label projects - first name" in {
-      val results = SnykDisplay.labelProjects(goodProjects, goodVulnerabilities)
-      results.head.project.get.name shouldBe "name1"
+    "All equal except number of medium risk issues" in {
+      SnykDisplay.sortOrgs(
+        List(
+          SnykOrganisationIssues(
+            SnykOrganisation("org", "1", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low"))
+                )
+              )
+            )
+          ),
+          SnykOrganisationIssues(
+            SnykOrganisation("org", "2", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "2", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "4", "low"))
+                )
+              )
+            )
+          )
+        )
+      ).map(spi => spi.organisation.id) shouldBe List[String]("2", "1")
     }
 
-    "label projects - second id" in {
-      val results = SnykDisplay.labelProjects(goodProjects, goodVulnerabilities)
-      results.tail.head.project.get.id shouldBe "id2"
+    "All equal except number of low risk issues" in {
+      SnykDisplay.sortOrgs(
+        List(
+          SnykOrganisationIssues(
+            SnykOrganisation("org", "1", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low"))
+                )
+              )
+            )
+          ),
+          SnykOrganisationIssues(
+            SnykOrganisation("org", "2", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "2", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "4", "low"))
+                )
+              )
+            )
+          )
+        )
+      ).map(spi => spi.organisation.id) shouldBe List[String]("2", "1")
     }
 
-    "label projects - second name" in {
-      val results = SnykDisplay.labelProjects(goodProjects, goodVulnerabilities)
-      results.tail.head.project.get.name shouldBe "name2"
+    "All equal except org name" in {
+      SnykDisplay.sortOrgs(
+        List(
+          SnykOrganisationIssues(
+            SnykOrganisation("orgB", "1", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low"))
+                )
+              )
+            )
+          ),
+          SnykOrganisationIssues(
+            SnykOrganisation("orgA", "2", None),
+            List(
+              SnykProjectIssues(
+                Some(SnykProject("X", "a")),
+                List(
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "2", "medium")),
+                  SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low"))
+                )
+              )
+            )
+          )
+        )
+      ).map(spi => spi.organisation.id) shouldBe List[String]("2", "1")
     }
   }
 
@@ -218,22 +290,20 @@ class SnykDisplayTest extends AnyFreeSpec with Matchers with AttemptValues {
       SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "medium"),
-              SnykIssue("Issue2", "3", "low")
+            Some(SnykProject("X", "b")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low"))
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "high"),
-              SnykIssue("Issue2", "3", "medium"),
-              SnykIssue("Issue2", "3", "low")
+            Some(SnykProject("X", "a")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "3", "low"))
             )
           )
         )
@@ -243,22 +313,20 @@ class SnykDisplayTest extends AnyFreeSpec with Matchers with AttemptValues {
       SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "medium"),
-              SnykIssue("Issue3", "3", "low")
+            Some(SnykProject("X", "b")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue3", "3", "low"))
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "medium"),
-              SnykIssue("Issue3", "3", "medium"),
-              SnykIssue("Issue4", "4", "low")
+            Some(SnykProject("X", "a")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue3", "3", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue4", "4", "low"))
             )
           )
         )
@@ -268,22 +336,20 @@ class SnykDisplayTest extends AnyFreeSpec with Matchers with AttemptValues {
       SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("X", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "medium"),
-              SnykIssue("Issue3", "3", "low")
+            Some(SnykProject("X", "b")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue3", "3", "low"))
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "medium"),
-              SnykIssue("Issue3", "3", "low"),
-              SnykIssue("Issue4", "4", "low")
+            Some(SnykProject("X", "a")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue3", "3", "low")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue4", "4", "low"))
             )
           )
         )
@@ -293,21 +359,19 @@ class SnykDisplayTest extends AnyFreeSpec with Matchers with AttemptValues {
       SnykDisplay.sortProjects(
         List(
           SnykProjectIssues(
-            Some(SnykProject("Y", "b", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "medium"),
-              SnykIssue("Issue3", "3", "low")
+            Some(SnykProject("Y", "b")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue3", "3", "low"))
             )
           ),
           SnykProjectIssues(
-            Some(SnykProject("X", "a", Some(SnykOrganisation("guardian", "guardian", None)))),
-            ok = true,
-            Set(
-              SnykIssue("Issue1", "1", "high"),
-              SnykIssue("Issue2", "2", "medium"),
-              SnykIssue("Issue3", "3", "low")
+            Some(SnykProject("X", "a")),
+            List(
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue1", "1", "high")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue2", "2", "medium")),
+              SnykProjectIssue(None, DateTime.now(), SnykIssue("Issue3", "3", "low"))
             )
           )
         )

--- a/hq/test/logic/SnykDisplayTest.scala
+++ b/hq/test/logic/SnykDisplayTest.scala
@@ -379,4 +379,60 @@ class SnykDisplayTest extends AnyFreeSpec with Matchers with AttemptValues {
     }
   }
 
+  "Determining long-lived issues" - {
+    "find only old-enough high severity issues" in {
+      val vulns = SnykDisplay.longLivedHighVulnerabilities(
+        SnykOrganisationIssues(dummyOrg,
+          List(
+            SnykProjectIssues(None,
+              List(
+                SnykProjectIssue(None,
+                  DateTime.now().minusDays(365),
+                  SnykIssue("an old vulnerability", "1", "high")
+                ),
+                SnykProjectIssue(None,
+                  DateTime.now().minusDays(1),
+                  SnykIssue("a new vulnerability", "2", "high")
+                ),
+                SnykProjectIssue(None,
+                  DateTime.now().minusDays(365),
+                  SnykIssue("an old low-severity vulnerability", "3", "low")
+                ),
+              )
+            )
+          )
+        )
+      )
+      vulns should have length 1
+      vulns.head.issue should have(Symbol("id")("1"))
+    }
+
+    "find only old-enough critical severity issues" in {
+      val vulns = SnykDisplay.longLivedCriticalVulnerabilities(
+        SnykOrganisationIssues(dummyOrg,
+          List(
+            SnykProjectIssues(None,
+              List(
+                SnykProjectIssue(None,
+                  DateTime.now().minusDays(365),
+                  SnykIssue("an old vulnerability", "1", "critical")
+                ),
+                SnykProjectIssue(None,
+                  DateTime.now().minusDays(1),
+                  SnykIssue("a new vulnerability", "2", "critical")
+                ),
+                SnykProjectIssue(None,
+                  DateTime.now().minusDays(365),
+                  SnykIssue("an old low-severity vulnerability", "3", "high")
+                ),
+              )
+            )
+          )
+        )
+      )
+      vulns should have length 1
+      vulns.head.issue should have(Symbol("id")("1"))
+    }
+  }
+
 }

--- a/hq/test/resources/logic/SnykDisplayTestResources/goodAndNotVulnerableResponse.json
+++ b/hq/test/resources/logic/SnykDisplayTestResources/goodAndNotVulnerableResponse.json
@@ -1,9 +1,4 @@
 {
-  "ok": true,
-  "issues": {
-    "vulnerabilities": [],
-    "licenses": []
-  },
-  "dependencyCount": 0,
-  "packageManager": "sbt"
+  "results": [],
+  "total": 0
 }

--- a/hq/test/resources/logic/SnykDisplayTestResources/goodButVulnerableResponse.json
+++ b/hq/test/resources/logic/SnykDisplayTestResources/goodButVulnerableResponse.json
@@ -1,66 +1,74 @@
 {
-  "ok": false,
-  "issues": {
-    "vulnerabilities": [
+   "results": [
       {
-        "id": "4444444444",
-        "url": "https://snyk.io/vuln/4444444444",
-        "title": "The Title",
-        "type": "vuln",
-        "description": "The description",
-        "from": [
-          "from1",
-          "from2",
-          "from3"
-        ],
-        "package": "The package",
-        "version": "The version",
-        "severity": "high",
-        "language": "The language",
-        "packageManager": "the package manager",
-        "semver": {
-          "unaffected": ">=the version",
-          "vulnerable": "<the version"
-        },
-        "publicationTime": "2015-11-06T02:09:36.182Z",
-        "disclosureTime": "2015-11-03T07:15:12.900Z",
-        "isUpgradable": true,
-        "isPatchable": true,
-        "identifiers": {
-          "CVE": [],
-          "CWE": [],
-          "NSP": 57,
-          "ALTERNATIVE": [
-            "5555555555"
+        "issue": {
+          "url": "https://snyk.io/vuln/4444444444",
+          "id": "4444444444",
+          "title": "The Title",
+          "type": "vuln",
+          "package": "The package",
+          "version": "The version",
+          "severity": "high",
+          "originalSeverity": "",
+          "uniqueSeveritiesList": [],
+          "exploitMaturity": "",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "jiraIssueUrl": "",
+          "publicationTime": "2015-11-06T02:09:36.182Z",
+          "disclosureTime": "2015-11-03T07:15:12.900Z",
+          "language": "",
+          "packageManager": "",
+          "identifiers": {
+            "CVE": [],
+            "CWE": [],
+            "OSVDB": []
+          },
+          "credit": [],
+          "CVSSv3": "",
+          "priorityScore": 0,
+          "cvssScore": "",
+          "patches": [
+            {
+              "id": "6666666666",
+              "urls": [
+                "https://example.com/6666666666.patch"
+              ],
+              "version": "<the version >=minversion",
+              "comments": [
+                "https://example.com/7777777777.patch"
+              ],
+              "modificationTime": "2015-11-17T09:29:10.000Z"
+            }
+          ],
+          "isIgnored": false,
+          "isPatched": false,
+          "semver": {
+            "vulnerable": "",
+            "unaffected": ""
+          },
+          "ignored": [
+            {
+              "reason": "",
+              "expires": "",
+              "source": "cli"
+            }
           ]
         },
-        "credit": [
-          "Mickey Mouse"
-        ],
-        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
-        "cvssScore": 7.5,
-        "patches": [
-          {
-            "id": "6666666666",
-            "urls": [
-              "https://example.com/6666666666.patch"
-            ],
-            "version": "<the version >=minversion",
-            "comments": [
-              "https://example.com/7777777777.patch"
-            ],
-            "modificationTime": "2015-11-17T09:29:10.000Z"
-          }
-        ],
-        "upgradePath": [
-          true,
-          "the first upgrade",
-          "the second upgrade"
-        ]
+        "project": {
+          "url": "",
+          "id": "",
+          "name": "",
+          "source": "",
+          "packageManager": "",
+          "targetFile": ""
+        },
+        "isFixed": false,
+        "introducedDate": "2021-11-06",
+        "patchedDate": "",
+        "fixedDate": ""
       }
     ],
-    "licenses": []
-  },
-  "dependencyCount": 0,
-  "packageManager": "the package manager"
+    "total": 1
 }


### PR DESCRIPTION
## What does this change?
This PR restores the previously disabled Snyk dashboard. The main motivation for this is to experiment with introducing an SLO for 3rd party vulnerabilities, which requires providing relevant metrics to users.  This PR implements a basic warning in that area that an organisation contains long-lived high/critical severity vulnerabilities.

We have deviated significantly from the previous functionality/API usage.  Previously we would work on a per-project basis and make API calls for each of those (all 400+ 😱 ). Now we are utilising the reporting API at the organisation level (i.e. per team) to gather the information we need, which makes the density of requests much more manageable.

There are certainly improvements to be made still, but this PR is already large. Namely we could:
- Surface more information about specific vulnerabilities (and which ones are breaching the SLO!)
- Provide a time-series graph view of vulnerabilities and number of projects
- Preferably indicate how many projects are integrated in the recommended manner (i.e. CLI) 
- Add paging to the API usage to work around the current 1000 result limit
- Fix the generated links by using the `slug` field from the API instead of `name`
- Add some explanation or specifics regarding the SLO
-  Link more things to Snyk!

![image](https://user-images.githubusercontent.com/8754692/159513734-47941f25-2937-468b-a356-1c5b57822cf4.png)
Redacted parts look like this, but these numbers are made up:
<img width="320" alt="image" src="https://user-images.githubusercontent.com/8754692/159514023-5fe10883-1df8-4b74-8d3d-836c6979095f.png">
Accordion contents look like:
![image](https://user-images.githubusercontent.com/8754692/159514643-311346f0-6641-485e-a64d-ae1032354947.png)

(Happy to screen share the full changes, if the redaction is too disruptive)
<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
We start to surface relevant metrics on age of critical/high severity vulnerabilities to teams, which will be the basis of an SLO.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
No

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
