### PR TITLE
Update google-cloud-securitycenter to 2.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ lazy val hq = (project in file("hq"))
       "io.reactivex" %% "rxscala" % "0.27.0",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-      "com.google.cloud" % "google-cloud-securitycenter" % "1.3.6",
+      "com.google.cloud" % "google-cloud-securitycenter" % "2.5.1",
       "org.scalatest" %% "scalatest" % "3.2.11" % Test,
       "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test,
       "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,


### PR DESCRIPTION
## What does this change?
Updates google-cloud-securitycenter to the latest version. There was only one breaking change since our last update and it doesn't seem relevant to us.