### PR TITLE
Workaround for CI build failing

### DIFF
--- a/cdk/script/ci
+++ b/cdk/script/ci
@@ -4,7 +4,7 @@ set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-yarn install --frozen-lockfile # prevent updates
+yarn install --network-concurrency 1 --frozen-lockfile # prevent updates
 yarn lint
 yarn test
 


### PR DESCRIPTION
## What does this change?


This disables network concurrency during the `yarn install` step of the cdk cli script

I tried a bunch of work arounds mentioned in the corresponding yarn issues, but this was the one I found worked
* https://github.com/yarnpkg/yarn/issues/6312
* https://github.com/yarnpkg/yarn/issues/2629
## What is the value of this?


Fixing builds

## Will this require CloudFormation and/or updates to the AWS StackSet?

No
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?

No
<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
