### PR TITLE
WIP: Only publish artifact to riff raff on non-dependabot builds

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -25,6 +25,7 @@ jobs:
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
       - uses: aws-actions/configure-aws-credentials@v1
+        if: github.actor != 'dependabot[bot]'
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
@@ -57,4 +58,4 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=1265
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          ./script/ci
+          ./script/ci ${{ github.actor }}

--- a/script/ci
+++ b/script/ci
@@ -7,4 +7,8 @@ set -e
     ./script/ci
 )
 
-./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'
+./sbt --no-conf '; project hq; clean; compile'
+# Only publish artifact if this isn't a build triggered by dependabot
+if [[ "$1" != "dependabot[bot]" ]]; then
+  ./sbt --no-conf 'riffRaffAddManifest; riffRaffUpload'
+fi


### PR DESCRIPTION
## What does this change?


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
