### PR TITLE
Skip riff raff upload on dependabot PRs

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -19,12 +19,15 @@ jobs:
       # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
+    env:
+      SHOULD_UPLOAD_TO_RIFRAFF: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
 
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
       - uses: aws-actions/configure-aws-credentials@v1
+        if: SHOULD_UPLOAD_TO_RIFRAFF == 'true'
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
@@ -57,4 +60,4 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=1265
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          ./script/ci
+          ./script/ci $SHOULD_UPLOAD_TO_RIFRAFF

--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -20,14 +20,14 @@ jobs:
       id-token: write
       contents: read
     env:
-      SHOULD_UPLOAD_TO_RIFRAFF: ${{ github.actor != 'dependabot[bot]' }}
+      UPLOAD_TO_RIFFRAFF: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
 
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
       - uses: aws-actions/configure-aws-credentials@v1
-        if: env.SHOULD_UPLOAD_TO_RIFRAFF == 'true'
+        if: env.UPLOAD_TO_RIFFRAFF == 'true'
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
@@ -60,4 +60,4 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=1265
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          ./script/ci $SHOULD_UPLOAD_TO_RIFRAFF
+          ./script/ci $UPLOAD_TO_RIFFRAFF

--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -27,7 +27,7 @@ jobs:
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
       - uses: aws-actions/configure-aws-credentials@v1
-        if: SHOULD_UPLOAD_TO_RIFRAFF == 'true'
+        if: env.SHOULD_UPLOAD_TO_RIFRAFF == 'true'
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1

--- a/README.md
+++ b/README.md
@@ -202,6 +202,21 @@ If you have it installed, you can run:
 
 `cfn_nag_scan --input-path cloudformation/*`
 
+### Dependabot
+
+This repo has [dependabot security updates
+enabled])(https://github.com/guardian/security-hq/security/dependabot), which
+means dependabot will open PRs to fix security vulnerabilities in JS prod and dev
+dependencies. Note that this is different from the dependabot dependency updates
+feature, which auto-updates all dependencies to their latest versions, which
+this repo does not have enabled.
+
+The dependabot PRs are built as usual, except for the fact that the builds are not uploaded
+to riff raff. This is due to them not having access to the repo secrets. If you'd like to
+deploy a dependabot PR to test before merging, you'll need to manually trigger a
+build yourself. This will provide the build environment access to the necessary
+secrets.
+
 ## Introduction to Security HQ's features
 
 ### Credentials Reaper

--- a/script/ci
+++ b/script/ci
@@ -2,14 +2,14 @@
 
 set -e
 
-SHOULD_UPLOAD_TO_RIFFRAFF="$1"
+UPLOAD_TO_RIFFRAFF="$1"
 
 (
     cd cdk
     ./script/ci
 )
 
-if [ "$SHOULD_UPLOAD_TO_RIFFRAFF" = "true" ]; then
+if [ "$UPLOAD_TO_RIFFRAFF" = "true" ]; then
     ./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'
 else
     ./sbt --no-conf '; project hq; clean; compile'

--- a/script/ci
+++ b/script/ci
@@ -2,9 +2,15 @@
 
 set -e
 
+SHOULD_UPLOAD_TO_RIFFRAFF="$1"
+
 (
     cd cdk
     ./script/ci
 )
 
-./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'
+if [ "$SHOULD_UPLOAD_TO_RIFFRAFF" = "true" ]; then
+    ./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'
+else
+    ./sbt --no-conf '; project hq; clean; compile'
+fi


### PR DESCRIPTION
## What does this change?

With this patch, the ci workflow only uploads builds to riff raff (and, more importantly, only has _permissions_ to upload) on PRs opened by devs. For PRs opened by dependabot, the riff raff steps are skipped.

## What is the value of this?

This will make builds for dependabot PRs green. They currently fail because they do not have access to the necessary permissions. This is due to a security measure implemented by github on march 2021, where the ci build environment offered to dependabot no longer has access to secrets to prevent malicious dependencies from syphoning them off or using them as an attack vector. See https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-852541544

## Will this require CloudFormation and/or updates to the AWS StackSet?

No
<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?

No
<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->
