### PR TITLE
Remove CI stability workaround

### DIFF
--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@aws-cdk/assert": "1.140.0",
     "@guardian/eslint-config-typescript": "^0.7.0",
-    "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.0",
+    "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.1",
     "@types/jest": "^26.0.20",
     "@types/node": "14.14.37",
     "aws-cdk": "1.140.0",

--- a/cdk/script/ci
+++ b/cdk/script/ci
@@ -4,7 +4,7 @@ set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-yarn install --network-concurrency 1 --frozen-lockfile # prevent updates
+yarn install --frozen-lockfile # prevent updates
 yarn lint
 yarn test
 

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -1243,9 +1243,9 @@
     eslint-plugin-import "2.24.0"
     eslint-plugin-prettier "3.4.0"
 
-"@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.0":
-  version "1.1.3"
-  resolved "git+ssh://git@github.com:guardian/private-infrastructure-config.git#c1789051594a2dc5a21fd49f1bd571613131403b"
+"@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.1":
+  version "1.2.0"
+  resolved "git+ssh://git@github.com:guardian/private-infrastructure-config.git#c4cb5466ab2918448128c8d87b3029e1e77f821c"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
## What does this change?
We introduced a workaround for CI instability in #433 which we believe was caused by yarn's handling of `prepare` scripts. We've now moved the `private-infrastructure-config` repo to adopt a different method (doing `tsc` in a pre-commit hook.)

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
Removes workaround for clearer, idiomatic CI scripting and should improve build speed

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No

<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?
No

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?
I'm not planning to do a full rigorous test of this change, with yarn cache purging and multiple pushes. If there continues to be problems they will become apparent and it will be a simple revert to fix.

<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
