### PR TITLE
Add credential expiry date to email subject

### DIFF
--- a/hq/app/notifications/AnghammaradNotifications.scala
+++ b/hq/app/notifications/AnghammaradNotifications.scala
@@ -55,15 +55,16 @@ object AnghammaradNotifications extends Logging {
   }
 
   def outdatedCredentialFinalWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime, now: DateTime): Notification = {
+    val deadline = printDay(now.plusDays(daysBetweenFinalNotificationAndRemediation))
     val message =
       s"""
          |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
          |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
          |(if you're already planning on doing this, please ignore this message).
-         |If this is not rectified before ${printDay(now.plusDays(daysBetweenFinalNotificationAndRemediation))},
+         |If this is not rectified before $deadline,
          |Security HQ will automatically disable this user at the next opportunity.
          |""".stripMargin
-    val subject = s"Action required: vulnerable credential in ${awsAccount.name} will be disabled soon"
+    val subject = s"Action required by $deadline: vulnerable credential in ${awsAccount.name} will be disabled soon"
     Notification(subject, message + genericOutdatedCredentialText, Nil, notificationTargets(awsAccount, iamUser), channel, sourceSystem)
   }
 

--- a/hq/app/notifications/AnghammaradNotifications.scala
+++ b/hq/app/notifications/AnghammaradNotifications.scala
@@ -42,15 +42,16 @@ object AnghammaradNotifications extends Logging {
     Tag.tagsToAnghammaradTargets(iamUser.tags) :+ Account(awsAccount.accountNumber)
 
   def outdatedCredentialWarning(awsAccount: AwsAccount, iamUser: IAMUser, problemCreationDate: DateTime, now: DateTime): Notification = {
+    val deadline = printDay(now.plusDays(daysBetweenWarningAndFinalNotification + daysBetweenFinalNotificationAndRemediation))
     val message =
       s"""
          |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
          |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
          |(if you're already planning on doing this, please ignore this message).
-         |If this is not rectified before ${printDay(now.plusDays(daysBetweenWarningAndFinalNotification + daysBetweenFinalNotificationAndRemediation))},
+         |If this is not rectified before $deadline,
          |Security HQ will automatically disable this user at the next opportunity.
          |""".stripMargin
-    val subject = s"Action required: vulnerable credential detected in ${awsAccount.name}"
+    val subject = s"Action required by $deadline: vulnerable credential detected in ${awsAccount.name}"
     Notification(subject, message + genericOutdatedCredentialText, Nil, notificationTargets(awsAccount, iamUser), channel, sourceSystem)
   }
 


### PR DESCRIPTION
## What does this change?

Updates the subject of the vulnerable credential email from:

```
Action required: vulnerable credential in Media Service will be disabled soon
```

to:

```
Action required by 25/12/2022: vulnerable credential in Media Service will be disabled soon
```

This is an effort to draw more attention to the deadline as the email body doesn't have formatting (e.g. bolded text).


## What is the value of this?

Hopefully, it is easier to understand deadline days.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No.

## Will this require changes to config?

No.

## Any additional notes?

No.