### PR TITLE
fix: resolve git.io url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,4 +27,4 @@
 
 <!-- Have CSS or JS changes been checked and fixed by Prettier? -->
 
-<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
+<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->


### PR DESCRIPTION
## What does this change?

Resolve the git.io url, as these will be [deprecated from Friday](https://github.blog/changelog/2022-04-25-git-io-deprecation)

## What is the value of this?

Evergreen content.

## Any additional notes?

Found [via a little script I made](https://gist.github.com/mxdvl/db5f781599931631235373d015e7c720).