### PR TITLE
Update markdown docs on commmon vulnerabilities

### DIFF
--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -13,11 +13,11 @@ tasks that can't easily be automated, or we haven't got round to automating yet.
 There are 5 tools to focus on in this section. They are in rough order of priority. There are also some **critical vulnerabilities**
 which should always be addressed first. These are:
 
- - Unnecessarily exposed security groups (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#1-security-hq))
- - IAM users with a password but no multi factor authentication (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#1-security-hq))
- - IAM users with permanent credentials - these should be regularly rotated or deleted (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#1-security-hq))
- - Critical vulnerabilities identified by [AWS Security Hub](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#4-aws-security-hub)
- - Out of date AMIs (audit via [amiable](https://amiable.gutools.co.uk)) - some details [below](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#2-operating-system-patches)
+ - Unnecessarily exposed security groups (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management#1-security-hq))
+ - IAM users with a password but no multi factor authentication (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management#1-security-hq))
+ - IAM users with permanent credentials - these should be regularly rotated or deleted (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management#1-security-hq))
+ - Critical vulnerabilities identified by [AWS Security Hub](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management#4-aws-security-hub)
+ - Out of date AMIs (audit via [amiable](https://amiable.gutools.co.uk)), [operating systems patches](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management#2-operating-system-patches)
 
 
 ### 1. Security HQ
@@ -69,7 +69,7 @@ needs to be some kind of process, even if it's just a manual step when AMIable e
 Security Hub has a LOT of information. Right now we're only interested in the [AWS Foundational Security Best Practices](https://eu-west-1.console.aws.amazon.com/securityhub/home?region=eu-west-1#/standards/aws-foundational-security-best-practices-1.0.0)
 section, with a focus on 'Critical' and 'High' severity vulnerabilities.
 
-We've documented a fair few of the common Security Hub issues [here](./guardduty-sechub-common-problems.md). 
+We've documented a fair few of the [common Security Hub issues](./guardduty-sechub-common-problems). 
 If something's missing please tell us: devx@theguardian.com
 
 :exclamation: Security Hub raises a large number of issues. For now focus only on 'High' and 'Critical' severity issues
@@ -85,7 +85,7 @@ for instance in the deploy tools account it flagged a load of instances as havin
 network, but it turns out those instances are the ones we use for secure drop! So take it with some scepticism but 
 there's likely to be a fair number things to address here. 
 
-Common problems raised by GuardDuty - and what you do to resolve them will be documented [here](./guardduty-sechub-common-problems.md)
+Common problems raised by GuardDuty, [documentation on what you do to resolve them](./guardduty-sechub-common-problems).
 
 :exclamation: GuardDuty raises a large number of issues. For now focus only on 'High' severity issues
 
@@ -120,7 +120,7 @@ scanner installed - this should be possible to do in a few clicks in the Snyk/Gi
 #### Snyk
 The Guardian has an enterprise account with Snyk, which will scan your repo for vulnerabilities and open PRs where possible
 to resolve them. This is the recommended tool for Scala projects. We have unlimited scans with Snyk so you shouldn't
-hesitate to enable it in your project. Full documentation exists [here](./snyk.md). For a summary of all Snyk vulnerabilities
+hesitate to enable it in your project. See the [full documentation](./snyk). For a summary of all Snyk vulnerabilities
 at The Guardian in one place you can head to the [Snyk dashboard on Security HQ](https://security-hq.gutools.co.uk/snyk) 
 (VPN required).
 
@@ -147,7 +147,7 @@ perfectly reasonable to not fix something if you have a justification.
 
 ### 3. Fix them!
 
-This can be the sloow, hard part! In future, there might be links to docs on dealing with e.g. awkward play upgrades,
+This can be the slow, hard part! In future, there might be links to docs on dealing with e.g. awkward play upgrades,
 dodgy AWS SDK dependencies, but for now all we can say is 
 
 ![good luck](https://github.com/guardian/security-hq/raw/main/hq/markdown/images/good-luck.gif)


### PR DESCRIPTION
## What does this change?

Remove the unnecessary `./md` in some links which causes pages to be not found when viewed in Security HQ, & rephrase some links to be be semantically a bit nicer.

## What is the value of this?

Less broken links :)