### PR TITLE
fix: resolve git.io url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,4 +27,4 @@
 
 <!-- Have CSS or JS changes been checked and fixed by Prettier? -->
 
-<!-- Does this PR meet the contributing guidelines? https://git.io/vNUJt -->
+<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->


### PR DESCRIPTION
Supersedes https://github.com/guardian/security-hq/pull/451 to remove git.io references after its deprecation. The original PR was assumed to be failing due to being from a fork (without build logs I can't investigate that so this is simpler)