### PR TITLE
Try dependency update workflow including granular CI

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -3,8 +3,6 @@ name: CI
 
 on:
   pull_request:
-    branches-ignore:
-      - dependency-updates
       
   # Manual invocation.
   workflow_dispatch:


### PR DESCRIPTION
## What does this change?
Re-enables CI on the `dependency-updates` branch in order to try out a workflow that requires CI to complete successfully before update PRs are merged.