### PR TITLE
Fix log shipping - avoid unnecessary setter usage

### DIFF
--- a/hq/app/logging/LogConfig.scala
+++ b/hq/app/logging/LogConfig.scala
@@ -96,7 +96,6 @@ object LogConfig {
             appender.setStreamName(streamName)
             appender.setContext(context)
             appender.setLayout(layout)
-            appender.setRoleToAssumeArn(stsRole)
             appender.setCredentialsProvider(buildCredentialsProvider(stsRole, config))
             appender.start()
             rootLogger.addAppender(appender)


### PR DESCRIPTION
## What does this change?
Fixes remote log shipping via the kinesis logback appender.

Log shipping via kinesis was updated to use AWS SDK v2 (via the kinesis logback appender v2), but that included a change in the SDK that validated the existence of an STS client when `.setRoleToAssumeArn(role)` is called. This setter is unnecessary, as `setCredentialsProvider` is preferred for our usage, which appears to now be (strictly) mutually exclusive.

Verified locally.

The exception encountered was:

```
java.lang.NullPointerException: STS client must not be null.
        at software.amazon.awssdk.utils.Validate.notNull(Validate.java:119)
        at software.amazon.awssdk.services.sts.auth.StsCredentialsProvider.<init>(StsCredentialsProvider.java:70)
        at software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider.<init>(StsAssumeRoleCredentialsProvider.java:54)
        at software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider.<init>(StsAssumeRoleCredentialsProvider.java:45)
        at software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider$Builder.lambda$new$0(StsAssumeRoleCredentialsProvider.java:95)
        at software.amazon.awssdk.services.sts.auth.StsCredentialsProvider$BaseBuilder.build(StsCredentialsProvider.java:212)
        at software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider$Builder.build(StsAssumeRoleCredentialsProvider.java:137)
        at com.gu.logback.appender.kinesis.BaseKinesisAppender.setRoleToAssumeArn(BaseKinesisAppender.java:375)
```