### PR TITLE
Configure dependabot to target non-default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "dependency-updates"
+  - package-ecosystem: "npm"
+    directory: "/cdk"
+    schedule:
+      interval: "weekly"
+    target-branch: "dependency-updates"


### PR DESCRIPTION
## What does this change?
Adds dependabot configuration for dependency updates that target the `dependency-updates` branch. We use this branch to batch together multiple updates for ease of review/test.

## What is the value of this?
Dependabot updates are easier to manage.
