### PR TITLE
update only every 30 days

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+pullRequests.frequency = "30 days"


### PR DESCRIPTION
## What does this change?

Scala steward will now only create a PR every 30 days or so

<!-- Why are these changes being made? -->

To reduce noise/admin tasks