### PR TITLE
Remove restriction on scala-steward logback updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,8 +155,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "org.scalatest" %% "scalatest" % "3.2.14" % Test,
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-      // Not upgradeable until Play moves to 1.3+ as well. It depends on slf4j 2, which has breaking changes
-      "ch.qos.logback" % "logback-classic" % "1.2.11", // scala-steward:off,
+      "ch.qos.logback" % "logback-classic" % "1.2.11",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     )
   )


### PR DESCRIPTION
## What does this change?
Play 2.8.17 is compatible with logback 1.3+, so in theory removing this restriction means next month both dependencies will be bumped and everything will work.