### PR TITLE
Make Snyk reports by team individually addressable.

### DIFF
--- a/hq/app/controllers/SnykController.scala
+++ b/hq/app/controllers/SnykController.scala
@@ -34,4 +34,15 @@ class SnykController(val config: Configuration,
     }
   }
 
+  def snykOrg(snykOrg: String) = authAction.async {
+    attempt {
+      for {
+        maybeSnykOrgResult <- cacheService.getSnykOrgResults(snykOrg)
+      } yield maybeSnykOrgResult match {
+        case Some(snykOrgResult) => Ok(views.html.snyk.snykOrg(snykOrgResult))
+        case None => NotFound
+      }
+    }
+  }
+
 }

--- a/hq/app/services/CacheService.scala
+++ b/hq/app/services/CacheService.scala
@@ -91,6 +91,9 @@ class CacheService(
 
   def getAllSnykResults: Attempt[List[SnykOrganisationIssues]] = snykBox.get()
 
+  def getSnykOrgResults(orgName: String): Attempt[Option[SnykOrganisationIssues]] =
+    snykBox.get().map { _.find(_.organisation.name ==orgName) }
+
   def getGcpReport: Attempt[GcpReport] = gcpBox.get()
 
   def refreshCredentialsBox(): Unit = {

--- a/hq/app/views/snyk/snykOrg.scala.html
+++ b/hq/app/views/snyk/snykOrg.scala.html
@@ -1,0 +1,19 @@
+@import logic.SnykDisplay._
+@import model._
+
+@(orgIssues: SnykOrganisationIssues)(implicit assets: AssetsFinder)
+
+@main(List("Snyk")) { @* Header *@
+    <div class="hq-sub-header">
+        <div class="container hq-sub-header__row">
+            <div class="hq-sub-header__name">
+                <h4 class="header light grey-text text-lighten-5">Snyk - Dependency Vulnerabilities - @orgIssues.organisation.name</h4>
+            </div>
+        </div>
+    </div>
+
+} { @* Main content *@
+    <div class="container">
+    @views.html.snyk.snykOrgProjects(orgIssues)
+    </div>
+}

--- a/hq/conf/routes
+++ b/hq/conf/routes
@@ -17,6 +17,7 @@ GET        /security-groups                           controllers.SecurityGroups
 GET        /security-groups/:accountId                controllers.SecurityGroupsController.securityGroupsAccount(accountId)
 
 GET        /snyk                                      controllers.SnykController.snyk
+GET        /snyk/:snykOrg                             controllers.SnykController.snykOrg(snykOrg)
 
 GET        /login                                     controllers.AuthController.login
 GET        /loginError                                controllers.AuthController.loginError


### PR DESCRIPTION
## What does this change?

This change adds a `snykOrg` view and controller function that allows requests to `/snyk/:snykOrk` to be routed to individual organisation pages.

<img width="1300" alt="Screenshot 2022-10-18 at 17 34 35" src="https://user-images.githubusercontent.com/953792/196491366-87e7b0ed-7326-428b-b024-7c963b2cac00.png">

## What is the value of this?

The motivation for this change is to allow teams to be given links to their own page on Security HQ to provide a more focussed view of their issues.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Will this require changes to config?

No.

## Any additional notes?

There is no route from from the `/snyk` page to the `/snyk/:snykOrg` page, there should probably be one but it doesn't have to be in this PR and doesn't prevent handing a link to an org/team page out now.
