### PR TITLE
Upgrade Scala version to 2.13.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ import scala.concurrent.duration.DurationInt
 // common settings (apply to all projects)
 ThisBuild / organization := "com.gu"
 ThisBuild / version := "0.2.0"
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 
 resolvers += DefaultMavenRepository


### PR DESCRIPTION
## What does this change?

This follows out own advice and upgrade to 2.13.10 to avoid the vulnerability:

https://www.cve.org/CVERecord?id=CVE-2022-36944