### PR TITLE
ci: Remove unnecessary Snyk schedule

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,8 +1,6 @@
 name: Snyk
 
 on:
-  schedule:
-    - cron: '0 6 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this change?

Removes the Snyk schedule, which is unnecessary and will cause the workflow to become suspended after 60 days of inactivity on the repo!