### PR TITLE
fix(snyk): Only show issues for active projects on the dashboard

### DIFF
--- a/hq/app/api/Snyk.scala
+++ b/hq/app/api/Snyk.scala
@@ -30,7 +30,7 @@ object Snyk {
   }
 
   def getOrganisationVulnerabilities(organisation: SnykOrganisation, token: SnykToken, wsClient: WSClient)(implicit ec: ExecutionContext): Attempt[String] = {
-    val snykIssuesUrl = s"https://snyk.io/api/v1/reporting/issues/latest?sortBy=severity&order=desc&perPage=1000"
+    val snykIssuesUrl = s"https://snyk.io/api/v1/reporting/issues/latest?sortBy=priorityScore&order=desc&perPage=1000"
     val orgIssuesFilter = Json.obj(
       "filters" -> Json.obj(
         "orgs" -> JsArray(List(


### PR DESCRIPTION
## What does this change?

A Snyk severity level is defined as:

> A severity level is applied to a vulnerability, to indicate the risk for that vulnerability in an application.
>   – https://docs.snyk.io/features/fixing-and-prioritizing-issues/issue-management/severity-levels

A Snyk priority score is defined as:

> Snyk created a Priority Score to make the prioritization of issues as quick and easy as possible, ensuring the highest-risk issues have the highest score.
> – https://docs.snyk.io/features/fixing-and-prioritizing-issues/issue-management/priority-score

The priority score is calculated using a number of signals including:
  - severity levels
  - exploit maturity
  - reachability
  - fixability
  - time
  - social trends
  - malicious packages

That is the severity level could be considered a subset of the priority score, and issues should be triaged in order of their priority score.

In this change we update the request we make to the [latest issues API](https://snyk.docs.apiary.io/#reference/reporting-api/get-list-of-latest-issues), ordering by `priorityScore` instead of `severity`.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?
This change has two effects:
  1. An improved ordering to open issues, showing the most important first.
  2. Removes invalid projects from the response

The second point is quite strange!

It seems that the set of results returned by this API completely changes based on the sortOrder query string, as opposed to the order of the results changing.

The Identity team noticed their Snyk project `guardian/identity-frontend./package.json` on [the dashboard](https://security-hq.local.dev-gutools.co.uk/snyk) linked to an "Invalid Project" in Snyk.

The dashboard is simply a proxy to the Snyk API. That is, the Snyk API is returning this invalid project.

<details>
<summary>Screenshot of invalid project</summary>
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/836140/203757836-af42dfc3-5d8c-4cbf-b0bd-4891f813d48c.png">
</details>

This can be demonstrated with:

```bash
API_KEY=<REDACTED>

ORG_ID=<REDACTED>

PROJECT_NAME="guardian/identity-frontend./package.json"

curl --silent \
  --request POST \
  --header "Content-Type: application/json" \
  --header "Authorization: token $API_KEY" \
  --data "{\"filters\":{\"orgs\":[\"$ORG_ID\"],\"types\":[\"vuln\"],\"ignored\":false,\"patched\":false,\"isFixed\":false}}" \
  "https://snyk.io/api/v1/reporting/issues/latest?sortBy=severity&order=desc&perPage=1000" \
  | jq -r ".results[] | select(.project.name == \"$PROJECT_NAME\") | .project.url" \
  | uniq
```

Changing the `sortBy` query string value to `priorityScore` returns the correct values. That is, only active projects are returned.

This behaviour is also observed when the POST body omits or includes the `priorityScore` field.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?
No.

## Will this require changes to config?
No.

## Any additional notes?
- This updated request does take slightly longer ~1.3s vs. ~0.75s (numbers from curl requests). We cache the values, so there shouldn't be any impact to the dashboard, but one to keep an eye on.
- This has been raised with Snyk.
- Screenshots not included as it would leak information of any unpatched vulnerabilities in our repositories.