### PR TITLE
chore: Resolve Riff-Raff warning

### DIFF
--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -6,8 +6,6 @@ deployments:
 
   security-hq:
     type: autoscaling
-    parameters:
-      bucket: security-dist
     dependencies: [security-hq-cfn]
 
   security-hq-cfn:


### PR DESCRIPTION
Updates `riff-raff.yaml` to resolve a warning message seen during deployment.

See https://github.com/guardian/riff-raff/pull/884.