### PR TITLE
chore: Update local running DX

### DIFF
--- a/sbt
+++ b/sbt
@@ -2,7 +2,6 @@
 
 # Debug option
 DEBUG_PARAMS=""
-TC_PARAMS=""
 COLOUR_PARAMS=""
 
 CONF_PARAMS="-Dconfig.file=$HOME/.gu/security-hq.local.conf"
@@ -18,28 +17,16 @@ do
       CONF_PARAMS=""
       shift
     fi
-    if [ "$arg" == ""--ship-logs"" ]; then
+    if [ "$arg" == "--ship-logs" ]; then
       export LOCAL_LOG_SHIPPING=true
       shift
     fi
 done
-
-if [ $TEAMCITY_BUILD_PROPERTIES_FILE ]; then
-  if [ -f $TEAMCITY_BUILD_PROPERTIES_FILE ]; then
-    f=$(grep '^teamcity.configuration.properties.file' "$TEAMCITY_BUILD_PROPERTIES_FILE" | cut -d'=' -f 2)
-    TC_PARAMS="-Dteamcity.configuration.properties.file=$f"
-    echo "Adding team city property: $TC_PARAMS"
-  else
-    echo "Unable to locate Team City build properties file $TEAMCITY_BUILD_PROPERTIES_FILE"
-  fi
-  COLOUR_PARAMS="-Dsbt.log.noformat=true"
-fi
 
 java $DEBUG_PARAMS \
     -Xms1024M -Xmx4096M \
     -Xss1M \
     -XX:+CMSClassUnloadingEnabled \
     $CONF_PARAMS \
-    $TC_PARAMS \
     $COLOUR_PARAMS \
     -jar bin/sbt-launch.jar "$@"

--- a/script/start
+++ b/script/start
@@ -5,4 +5,4 @@ set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR="${DIR}/.."
 
-"$ROOT_DIR/sbt" "project hq; run"
+"$ROOT_DIR/sbt" "$*" "project hq; run"


### PR DESCRIPTION
## What does this change?
Updates the start script to forward flags to the sbt script, allowing you to run `./script/start --debug`, for example.

Also removes some redundant TeamCity based logic as we've moved to GitHub Actions for CI.