### PR TITLE
Make security-hq available to the whole internet

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -33,7 +33,6 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
-      "GuSecurityGroup",
       "GuCname",
       "GuHttpsEgressSecurityGroup",
       "GuStringParameter",
@@ -590,27 +589,6 @@ dpkg -i /tmp/installer.deb",
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
-    "GuHttpsEgressSecurityGroupSecurityhqfromsecurityhqRestrictedIngressSecurityGroupSecurityhq2DC7AECE90009FDEBE14": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupSecurityhqCA18D247",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
     "GuHttpsEgressSecurityGroupSecurityhqfromsecurityhqidpaccessSecurityhqE586B5AB900017582D17": {
       "Properties": {
         "Description": "Load balancer to target",
@@ -798,12 +776,6 @@ dpkg -i /tmp/installer.deb",
           },
           {
             "Fn::GetAtt": [
-              "RestrictedIngressSecurityGroupSecurityhqCA18D247",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
               "idpaccessSecurityhq802D3912",
               "GroupId",
             ],
@@ -841,6 +813,15 @@ dpkg -i /tmp/installer.deb",
     "LoadBalancerSecurityhqSecurityGroup66272916": {
       "Properties": {
         "GroupDescription": "Automatically created Security Group for ELB securityhqLoadBalancerSecurityhq4820B44E",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -1030,67 +1011,6 @@ dpkg -i /tmp/installer.deb",
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
-    },
-    "RestrictedIngressSecurityGroupSecurityhqCA18D247": {
-      "Properties": {
-        "GroupDescription": "Allow restricted ingress from CIDR ranges",
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "192.168.1.1/22",
-            "Description": "Allow access on port 443 from 192.168.1.1/22",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "RestrictedIngressSecurityGroupSecurityhqtosecurityhqGuHttpsEgressSecurityGroupSecurityhqFDD8E89C9000A501F165": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "RestrictedIngressSecurityGroupSecurityhqCA18D247",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "S3AuditRead9DF4AE59": {
       "Properties": {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -20,7 +20,6 @@ import {
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuAnghammaradSenderPolicy } from '@guardian/cdk/lib/constructs/iam/policies/anghammarad';
 import { GuSnsTopic } from '@guardian/cdk/lib/constructs/sns';
-import { GuardianPublicNetworks } from '@guardian/private-infrastructure-config';
 import { Duration, RemovalPolicy, SecretValue } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
 import {
@@ -33,7 +32,6 @@ import {
   InstanceClass,
   InstanceSize,
   InstanceType,
-  Peer,
 } from 'aws-cdk-lib/aws-ec2';
 import { ListenerAction, UnauthenticatedAction } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
@@ -84,8 +82,7 @@ export class SecurityHQ extends GuStack {
 
     const ec2App = new GuEc2App(this, {
       access: {
-        scope: AccessScope.RESTRICTED,
-        cidrRanges: [Peer.ipv4(GuardianPublicNetworks.London)],
+        scope: AccessScope.PUBLIC
       },
       app: 'security-hq',
       applicationPort: 9000,


### PR DESCRIPTION
## What does this change?

<!-- Screenshots may be helpful to demonstrate -->
Now #775 is merged and tested this makes the follow up change to make the service available to everyone again.

## What is the value of this?

<!-- Why are these changes being made? -->
People will again be able to analyse the security of their AWS accounts and other resources.
