### PR TITLE
Updated the new public URLs for security reports

### DIFF
--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -17,11 +17,11 @@ which should always be addressed first. These are:
  - IAM users with a password but no multi factor authentication (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#1-security-hq))
  - IAM users with permanent credentials - these should be regularly rotated or deleted (audit via [Security HQ](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#1-security-hq))
  - Critical vulnerabilities identified by [AWS Security Hub](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#4-aws-security-hub)
- - Out of date AMIs (audit via [amiable](https://amiable.gutools.co.uk)), [operating systems patches](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#2-operating-system-patches)
+ - Out of date AMIs (audit via [amiable](https://public.amiable.gutools.co.uk)), [operating systems patches](https://github.com/guardian/security-hq/blob/main/hq/markdown/vulnerability-management.md#2-operating-system-patches)
 
 
 ### 1. Security HQ
-The first step of your long journey to the fountain of security involves a visit to [Security HQ](https://security-hq.gutools.co.uk).
+The first step of your long journey to the fountain of security involves a visit to [Security HQ](https://public.security-hq.gutools.co.uk).
 Here, you can review Security Groups, S3 buckets and IAM credentials for your account, and check to see if there are any
 problems. *Fix these first*.  
 
@@ -54,7 +54,7 @@ Credentials without a password and with access keys only are typically for machi
 In the case that Permanent IAM credentials are required, they must be rotated regularly; at least 90 days for human users (users with a password) and 365 days for machine users. Also, all human users must enable MFA.
 Ideally, users should not exist with both password and access key access.
 
-Security HQ will automatically disable active access keys and remove the passwords of permanent IAM credentials which do not meet these requirements. To avoid any unwanted disablements, please regularly check [Security HQ's IAM dashboard]((https://security-hq.gutools.co.uk/iam)) and rectify any warnings.
+Security HQ will automatically disable active access keys and remove the passwords of permanent IAM credentials which do not meet these requirements. To avoid any unwanted disablements, please regularly check [Security HQ's IAM dashboard]((https://public.security-hq.gutools.co.uk/iam)) and rectify any warnings.
 Also, ensure that [Anghammarad's mapping](https://github.com/guardian/anghammarad#mappings) between your AWS account and the email address attached to it is correct. This means that you'll receive email notifications from Security HQ before it disables any vulnerable users in your account.
 
 
@@ -121,7 +121,7 @@ scanner installed - this should be possible to do in a few clicks in the Snyk/Gi
 The Guardian has an enterprise account with Snyk, which will scan your repo for vulnerabilities and open PRs where possible
 to resolve them. This is the recommended tool for Scala projects. We have unlimited scans with Snyk so you shouldn't
 hesitate to enable it in your project. See the [full documentation](./snyk.md). For a summary of all Snyk vulnerabilities
-at The Guardian in one place you can head to the [Snyk dashboard on Security HQ](https://security-hq.gutools.co.uk/snyk) 
+at The Guardian in one place you can head to the [Snyk dashboard on Security HQ](https://public.security-hq.gutools.co.uk/snyk) 
 (VPN required).
 
 #### Dependabot


### PR DESCRIPTION
## What does this change?


Updated security report links

## What is the value of this?

The links are no longer broken (point to public resources)

## Will this require CloudFormation and/or updates to the AWS StackSet?

no

## Will this require changes to config?
no

## Any additional notes?

no