### PR TITLE
Create SSM parameter with ALB arn (for WAF configuration)

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -103,6 +103,25 @@ exports[`HQ stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
+    "AlbSsmParam485C1D52": {
+      "Properties": {
+        "DataType": "text",
+        "Description": "The arn of the ALB for security-hq-PROD. N.B. this parameter is created via cdk",
+        "Name": "/infosec/waf/services/PROD/security-hq-alb-arn",
+        "Tags": {
+          "Stack": "security",
+          "Stage": "PROD",
+          "gu:cdk:version": "TEST",
+          "gu:repo": "guardian/security-hq",
+        },
+        "Tier": "Standard",
+        "Type": "String",
+        "Value": {
+          "Ref": "LoadBalancerSecurityhqF59D9B82",
+        },
+      },
+      "Type": "AWS::SSM::Parameter",
+    },
     "AssumeRole3910C09D": {
       "Properties": {
         "PolicyDocument": {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -35,6 +35,7 @@ import {
 import { ListenerAction, UnauthenticatedAction } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import { EmailSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+import { ParameterDataType, ParameterTier, StringParameter } from "aws-cdk-lib/aws-ssm";
 
 export class SecurityHQ extends GuStack {
   private static app: AppIdentity = {
@@ -145,6 +146,16 @@ dpkg -i /tmp/installer.deb`,
     });
 
     ec2App.loadBalancer.addSecurityGroup(outboundHttpsSecurityGroup);
+
+    // This parameter is used by https://github.com/guardian/waf
+    new StringParameter(this, "AlbSsmParam", {
+      parameterName: `/infosec/waf/services/${this.stage}/security-hq-alb-arn`,
+      description: `The arn of the ALB for security-hq-${this.stage}. N.B. this parameter is created via cdk`,
+      simpleName: false,
+      stringValue: ec2App.loadBalancer.loadBalancerArn,
+      tier: ParameterTier.STANDARD,
+      dataType: ParameterDataType.TEXT,
+    });
 
     const clientId = new GuStringParameter(this, "ClientId", {
       description: "Google OAuth client ID",


### PR DESCRIPTION
## What does this change?

This PR adds the ALB's ARN to parameter store so that it can be used/looked up by `cdk` stacks in https://github.com/guardian/waf. 

See https://trello.com/c/Gf4wbq5Y/1716-configure-wafs-for-all-services-in-their-own-repository

## How to test

[Deploy to `PROD`](https://public.riffraff.gutools.co.uk/deployment/view/2a24091f-5c76-4350-bb08-27d38b691575) to confirm that the parameter is created as expected.

## How can we measure success?

This allows us to move forwards with the work to define a separate WAF for AMIgo via a different repository.