### PR TITLE
Add `security-hq.gutools.co.uk` CNAME

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -34,6 +34,7 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuCname",
+      "GuCname",
       "GuHttpsEgressSecurityGroup",
       "GuStringParameter",
       "GuParameter",
@@ -278,6 +279,9 @@ dpkg -i /tmp/installer.deb",
       "DeletionPolicy": "Retain",
       "Properties": {
         "DomainName": "public.security-hq.gutools.co.uk",
+        "SubjectAlternativeNames": [
+          "security-hq.gutools.co.uk",
+        ],
         "Tags": [
           {
             "Key": "App",
@@ -401,6 +405,23 @@ dpkg -i /tmp/installer.deb",
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DnsRecord": {
+      "Properties": {
+        "Name": "security-hq.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerSecurityhqF59D9B82",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "DynamoReadF4CBA3FD": {
       "Properties": {


### PR DESCRIPTION
## What does this change?
In this change we create the CNAME of `security-hq.gutools.co.uk` pointing to the same ALB as `public.security-hq.gutools.co.uk`.

This is part of an effort to restore pre-incident URLs[^1], whilst also maintaining any changes implemented during the incident (i.e. WAF).

This change also sets the subject alternative name of the TLS certificate that is served by the ALB.

Once this is merged, SHQ will be accessible via both `public.security-hq.gutools.co.uk` and `security-hq.gutools.co.uk`.

## Will this require CloudFormation and/or updates to the AWS StackSet?
Yes. See CDK snapshot update for exact changes.

## Will this require changes to config?
N/A.

## Any additional notes?
None.

[^1]: We've spotted a number of cross linking between apps break because they reference the pre-incident URL. Rather than update them, we think restoring these URLs offer a better DX.