### PR TITLE
Remove `public.security-hq.gutools.co.uk` CNAME

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -34,7 +34,6 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
       "GuCname",
-      "GuCname",
       "GuHttpsEgressSecurityGroup",
       "GuStringParameter",
       "GuParameter",
@@ -278,10 +277,7 @@ dpkg -i /tmp/installer.deb",
     "CertificateSecurityhqD266EC9D": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "public.security-hq.gutools.co.uk",
-        "SubjectAlternativeNames": [
-          "security-hq.gutools.co.uk",
-        ],
+        "DomainName": "security-hq.gutools.co.uk",
         "Tags": [
           {
             "Key": "App",
@@ -1349,23 +1345,6 @@ dpkg -i /tmp/installer.deb",
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "securityhqgutoolscouk": {
-      "Properties": {
-        "Name": "public.security-hq.gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": [
-          {
-            "Fn::GetAtt": [
-              "LoadBalancerSecurityhqF59D9B82",
-              "DNSName",
-            ],
-          },
-        ],
-        "Stage": "PROD",
-        "TTL": 3600,
-      },
-      "Type": "Guardian::DNS::RecordSet",
     },
   },
 }

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -21,7 +21,6 @@ import {
 import { GuAnghammaradSenderPolicy } from '@guardian/cdk/lib/constructs/iam/policies/anghammarad';
 import { Duration, RemovalPolicy, SecretValue } from 'aws-cdk-lib';
 import type { App } from 'aws-cdk-lib';
-import { CfnCertificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
   ComparisonOperator,
   Metric,
@@ -84,7 +83,7 @@ export class SecurityHQ extends GuStack {
     );
     const auditDataS3BucketPath = `${this.stack}/${this.stage}/*`;
 
-    const domainName = 'public.security-hq.gutools.co.uk';
+    const domainName = 'security-hq.gutools.co.uk';
 
     const ec2App = new GuEc2App(this, {
       access: {
@@ -137,26 +136,9 @@ dpkg -i /tmp/installer.deb`,
       },
     });
 
-    // Despite what the ID value is, this CNAME is for public.security-hq.gutools.co.uk
-    new GuCname(this, 'security-hq.gutools.co.uk', {
-      app: SecurityHQ.app.app,
-      domainName,
-      ttl: Duration.hours(1),
-      resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
-    });
-
-    const certificate = this.node
-      .findAll()
-      .find((_) => _ instanceof CfnCertificate) as CfnCertificate;
-
-    certificate.subjectAlternativeNames = [
-      ...(certificate.subjectAlternativeNames ?? []),
-      'security-hq.gutools.co.uk',
-    ];
-
     new GuCname(this, 'DnsRecord', {
       app: SecurityHQ.app.app,
-      domainName: 'security-hq.gutools.co.uk',
+      domainName,
       ttl: Duration.hours(1),
       resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
     });


### PR DESCRIPTION
> **Note**
> Only to be merged once comms have been sent.

## What does this change?
Removes access to SHQ on the domain `public.security-hq.gutools.co.uk` as we've reverted back to `security-hq.gutools.co.uk`.

The removed resources include:
  - The 301 redirect from `public.security-hq.gutools.co.uk` to `security-hq.gutools.co.uk`
  - The TLS certificate for `public.security-hq.gutools.co.uk`
  - The CNAME for `public.security-hq.gutools.co.uk`