### PR TITLE
Redirect `public.security-hq.gutools.co.uk` to `security-hq.gutools.co.uk`

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -797,6 +797,34 @@ dpkg -i /tmp/installer.deb",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
+    "ListenerSecurityhqredirectRule34167D17": {
+      "Properties": {
+        "Actions": [
+          {
+            "RedirectConfig": {
+              "Host": "security-hq.gutools.co.uk",
+              "StatusCode": "HTTP_301",
+            },
+            "Type": "redirect",
+          },
+        ],
+        "Conditions": [
+          {
+            "Field": "host-header",
+            "HostHeaderConfig": {
+              "Values": [
+                "public.security-hq.gutools.co.uk",
+              ],
+            },
+          },
+        ],
+        "ListenerArn": {
+          "Ref": "ListenerSecurityhq0F356342",
+        },
+        "Priority": 1,
+      },
+      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    },
     "LoadBalancerSecurityhqF59D9B82": {
       "Properties": {
         "LoadBalancerAttributes": [

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -31,6 +31,7 @@ import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import {
   ListenerAction,
+  ListenerCondition,
   UnauthenticatedAction,
 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Topic } from 'aws-cdk-lib/aws-sns';
@@ -201,6 +202,17 @@ dpkg -i /tmp/installer.deb`,
         ),
         next: ListenerAction.forward([ec2App.targetGroup]),
       }),
+    });
+
+    ec2App.listener.addAction('redirect', {
+      action: ListenerAction.redirect({
+        permanent: true,
+        host: 'security-hq.gutools.co.uk',
+      }),
+      conditions: [
+        ListenerCondition.hostHeaders(['public.security-hq.gutools.co.uk']),
+      ],
+      priority: 1,
     });
 
     const notificationTopic = new Topic(this, 'NotificationTopic', {


### PR DESCRIPTION
## What does this change?
In #811 we made Security accessible on security-hq.gutools.co.uk again.

In this change we configure a 301 redirect from `public.security-hq.gutools.co.uk` to `security-hq.gutools.co.uk`, so that requests always land on `security-hq.gutools.co.uk`. This is important because the auth config only supports one domain name; if you go to `security-hq.gutools.co.uk` now, you get a token validation error as configuration uses `public.security-hq.gutools.co.uk`.

> **Note**
> We'd need to change the config in S3 to use `janus.gutools.co.uk` before shipping this change.

This is part of the work to revert back to pre-incident domains. We will eventually drop the `public.` domain entirely (#813), this is an intermediate step to improve DX.