### PR TITLE
Remove Dependabot from `dependency-updates` process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,15 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    target-branch: "dependency-updates"
-  - package-ecosystem: "npm"
     directory: "/cdk"
     schedule:
-      interval: "weekly"
-    target-branch: "dependency-updates"
+      interval: "monthly"
     ignore:
       - dependency-name: "aws-cdk"
       - dependency-name: "aws-cdk-lib"

--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -19,15 +19,12 @@ jobs:
       # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
-    env:
-      UPLOAD_TO_RIFFRAFF: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
 
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
       - uses: aws-actions/configure-aws-credentials@v1
-        if: env.UPLOAD_TO_RIFFRAFF == 'true'
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
@@ -62,4 +59,4 @@ jobs:
         run: |
           LAST_TEAMCITY_BUILD=1265
           export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          ./script/ci $UPLOAD_TO_RIFFRAFF
+          ./script/ci

--- a/README.md
+++ b/README.md
@@ -78,21 +78,6 @@ If you have it installed, you can run:
 
 `cfn_nag_scan --input-path cloudformation/*`
 
-## Dependabot
-
-This repo has [dependabot security updates
-enabled])(https://github.com/guardian/security-hq/security/dependabot), which
-means dependabot will open PRs to fix security vulnerabilities in JS prod and dev
-dependencies. Note that this is different from the dependabot dependency updates
-feature, which auto-updates all dependencies to their latest versions, which
-this repo does not have enabled.
-
-The dependabot PRs are built as usual, except for the fact that the builds are not uploaded
-to riff raff. This is due to them not having access to the repo secrets. If you'd like to
-deploy a dependabot PR to test before merging, you'll need to manually trigger a
-build yourself. This will provide the build environment access to the necessary
-secrets.
-
 ## Introduction to Security HQ's features
 
 ### Credentials Reaper

--- a/script/ci
+++ b/script/ci
@@ -2,15 +2,9 @@
 
 set -e
 
-UPLOAD_TO_RIFFRAFF="$1"
-
 (
     cd cdk
     ./script/ci
 )
 
-if [ "$UPLOAD_TO_RIFFRAFF" = "true" ]; then
-    ./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'
-else
-    ./sbt --no-conf '; project hq; clean; compile'
-fi
+./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'


### PR DESCRIPTION
## What does this change?
In #445 and #552 we configured Dependabot to run weekly, and bundle changes into the `dependency-updates` branch, which gets PR'd against `main` once a month.

Whilst this process has been working, there are a couple of drawbacks:
  - The repository is set up differently from all other repositories
  - The revision history of the `dependency-updates` branch is [quite noisy](https://github.com/guardian/security-hq/pull/816), as Scala Steward is also adding commits
  - A single branch makes it difficult to isolate infrastructure changes from application changes

In this change, we configure Dependabot in the same way as other repositories:
  - Run once a month
  - Raise PRs against `main`, one PR per dependency bump

The downside of this is we loose the Riff-Raff upload protections that #445 added, but I'm not sure they are necessary as this behaviour hasn't been replicated elsewhere, even on more sensitive repositories (e.g. Janus, or Riff-Raff). It might be they were added here purely as a prototype?

## What is the value of this?
The shape of this repository matches others, making it more accessible.