### PR TITLE
Remove 301 redirect

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -793,34 +793,6 @@ dpkg -i /tmp/installer.deb",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
-    "ListenerSecurityhqredirectRule34167D17": {
-      "Properties": {
-        "Actions": [
-          {
-            "RedirectConfig": {
-              "Host": "security-hq.gutools.co.uk",
-              "StatusCode": "HTTP_301",
-            },
-            "Type": "redirect",
-          },
-        ],
-        "Conditions": [
-          {
-            "Field": "host-header",
-            "HostHeaderConfig": {
-              "Values": [
-                "public.security-hq.gutools.co.uk",
-              ],
-            },
-          },
-        ],
-        "ListenerArn": {
-          "Ref": "ListenerSecurityhq0F356342",
-        },
-        "Priority": 1,
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::ListenerRule",
-    },
     "LoadBalancerSecurityhqF59D9B82": {
       "Properties": {
         "LoadBalancerAttributes": [

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -30,7 +30,6 @@ import { AttributeType, Table } from 'aws-cdk-lib/aws-dynamodb';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import {
   ListenerAction,
-  ListenerCondition,
   UnauthenticatedAction,
 } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { Topic } from 'aws-cdk-lib/aws-sns';
@@ -184,17 +183,6 @@ dpkg -i /tmp/installer.deb`,
         ),
         next: ListenerAction.forward([ec2App.targetGroup]),
       }),
-    });
-
-    ec2App.listener.addAction('redirect', {
-      action: ListenerAction.redirect({
-        permanent: true,
-        host: 'security-hq.gutools.co.uk',
-      }),
-      conditions: [
-        ListenerCondition.hostHeaders(['public.security-hq.gutools.co.uk']),
-      ],
-      priority: 1,
     });
 
     const notificationTopic = new Topic(this, 'NotificationTopic', {


### PR DESCRIPTION
## What does this change?
Removes the redirect from `public.security-hq.gutools.co.uk` to `security-hq.gutools.co.uk`.

This was missed in #813.