### PR TITLE
chore(deps): Remove unused dependency `@guardian/private-infrastructure-config`

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -45,11 +45,6 @@ jobs:
           cache: 'yarn'
           cache-dependency-path: 'cdk/yarn.lock'
 
-      - name: Add SSH key for accessing @guardian/private-infrastructure-config
-        uses: guardian/actions-read-private-repos@v0.1.0
-        with:
-          private-ssh-keys: ${{ secrets.PRIVATE_INFRASTRUCTURE_CONFIG_DEPLOY_KEY }}
-
       # 1. Seed the build number with last number from TeamCity.
       #    Update `LAST_TEAMCITY_BUILD` as needed or remove entirely if changing Riff-Raff project name.
       # 2. Execute `script/ci`, a script that will compile, run tests etc.

--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,2 +1,1 @@
-jest.mock('@guardian/cdk/lib/constants/tracking-tag');
-jest.mock('@guardian/private-infrastructure-config');
+jest.mock("@guardian/cdk/lib/constants/tracking-tag");

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@guardian/cdk": "49.0.1",
     "@guardian/eslint-config-typescript": "^2.0.0",
-    "@guardian/private-infrastructure-config": "git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.1",
     "@types/jest": "^29.2.5",
     "@types/node": "18.11.18",
     "aws-cdk": "2.59.0",

--- a/cdk/yarn.lock
+++ b/cdk/yarn.lock
@@ -379,10 +379,6 @@
     eslint-plugin-eslint-comments "3.2.0"
     eslint-plugin-import "2.26.0"
 
-"@guardian/private-infrastructure-config@git+ssh://git@github.com:guardian/private-infrastructure-config.git#1.2.1":
-  version "1.2.0"
-  resolved "git+ssh://git@github.com:guardian/private-infrastructure-config.git#c4cb5466ab2918448128c8d87b3029e1e77f821c"
-
 "@humanwhocodes/config-array@^0.11.8":
   version "0.11.8"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.8.tgz#03595ac2075a4dc0f191cc2131de14fbd7d410b9"


### PR DESCRIPTION
## What does this change?
Since #775 `@guardian/private-infrastructure-config` is no longer used, so can be removed.

## What is the value of this?
- Fewer dependencies
- A simpler build
