### PR TITLE
ci: Switch to `guardian/actions-riff-raff`

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -45,13 +45,17 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'cdk/package-lock.json'
 
-      # 1. Seed the build number with last number from TeamCity.
-      #    Update `LAST_TEAMCITY_BUILD` as needed or remove entirely if changing Riff-Raff project name.
-      # 2. Execute `script/ci`, a script that will compile, run tests etc.
-      #    Ensure this file exists in your repository and has executable permissions (`chmod u+x script/ci`).
-      # See https://github.com/github/scripts-to-rule-them-all
       - name: Run script/ci
-        run: |
-          LAST_TEAMCITY_BUILD=1265
-          export GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))
-          ./script/ci
+        run: ./script/ci
+
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: security-hq
+          # Seed the build number with last number from TeamCity.
+          buildNumberOffset: 1265
+          configPath: hq/conf/riff-raff.yaml
+          contentDirectories: |
+            security-hq-cfn:
+              - cdk/cdk.out/security-hq.template.json
+            security-hq:
+              - hq/target/security-hq.deb

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import com.gu.riffraff.artifact.RiffRaffArtifact
-import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport._
 import com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader.Systemd
 import play.sbt.PlayImport.PlayKeys._
 import sbt.Keys.libraryDependencies
@@ -23,7 +21,7 @@ val jacksonVersion = "2.13.4"
 ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
 
 lazy val hq = (project in file("hq"))
-  .enablePlugins(PlayScala, RiffRaffArtifact, SbtWeb, JDebPackaging, SystemdPlugin)
+  .enablePlugins(PlayScala, SbtWeb, JDebPackaging, SystemdPlugin)
   .disablePlugins(sbtassembly.AssemblyPlugin)
   .settings(
     name := """security-hq""",
@@ -93,17 +91,6 @@ lazy val hq = (project in file("hq"))
     maintainer := "Security Team <devx.sec.ops@guardian.co.uk>",
     packageSummary := "Security HQ app.",
     packageDescription := """Deb for Security HQ - the Guardian's service to centralise security information for our AWS accounts.""",
-    riffRaffPackageType := (Debian / packageBin).value,
-    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
-    riffRaffUploadManifestBucket := Option("riffraff-builds"),
-
-    riffRaffAddManifestDir := Option("hq/public"),
-    riffRaffArtifactResources  := Seq(
-      riffRaffPackageType.value -> s"${name.value}/${name.value}.deb",
-      baseDirectory.value / "conf" / "riff-raff.yaml" -> "riff-raff.yaml",
-      file("cdk/cdk.out/security-hq.template.json") -> s"${name.value}-cfn/cfn.json"
-    ),
-
     Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null",
       "-Dconfig.file=/etc/gu/security-hq.conf",

--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
     parameters:
       prependStackToCloudFormationStackName: false
       cloudFormationStackName: security-hq
-      templatePath: cfn.json
+      templatePath: security-hq.template.json
       amiParameter: AMISecurityhq
       amiEncrypted: true
       amiTags:

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.18")
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts Artifact("jdeb", "jar", "jar")

--- a/script/ci
+++ b/script/ci
@@ -7,4 +7,8 @@ set -e
     ./script/ci
 )
 
-./sbt --no-conf '; project hq; clean; compile; riffRaffAddManifest; riffRaffUpload'
+./sbt --no-conf '; project hq; clean; compile; Debian / packageBin'
+
+# `sbt Debian / packageBin` produces `hq/target/security-hq_0.2.0_all.deb`. Rename it to something easier.
+# TODO Work out how to do this within build.sbt
+mv hq/target/security-hq_0.2.0_all.deb hq/target/security-hq.deb


### PR DESCRIPTION
## What does this change?
In this change we remove the [sbt-riffraff-artifact plugin](https://github.com/guardian/sbt-riffraff-artifact) in favour of [guardian/action-riff-raff](https://github.com/guardian/actions-riff-raff) making the application code ignorant of Riff-Raff (i.e. simpler).

## What is the value of this?
Fewer application dependencies to keep up to date.

## How to test
- Find the build in Riff-Raff
- Compare the files available between [this branch](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=security-hq&id=2290) and [main](https://riffraff.gutools.co.uk/deployment/request/deployFiles?projectName=security-hq&id=2287) (see comments for reasoning):
  - The `.deb` file should match
  - The CFN template should differ
- Deploy and Security-HQ should still work ([I've done this with success](https://riffraff.gutools.co.uk/deployment/view/0cdd0fc1-7eca-41ae-9209-90fcc5752863?verbose=1))