### PR TITLE
ci: Update build to fork and join method

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -22,6 +22,10 @@ jobs:
           cache-dependency-path: 'cdk/package-lock.json'
       - run: ./script/ci
         working-directory: cdk
+      - uses: actions/upload-artifact@v3
+        with:
+          name: cdk
+          path: cdk/cdk.out/security-hq.template.json
   SBT:
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +36,12 @@ jobs:
           distribution: 'corretto'
           cache: 'sbt'
       - run: ./script/ci
+      - uses: actions/upload-artifact@v3
+        with:
+          name: sbt
+          path: |
+            hq/conf/riff-raff.yaml
+            hq/target/security-hq.deb
   Riff-Raff:
     runs-on: ubuntu-latest
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
@@ -41,6 +51,12 @@ jobs:
       contents: read
     needs: [CDK, SBT]
     steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: cdk
+      - uses: actions/download-artifact@v3
+        with:
+          name: sbt
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
       - uses: aws-actions/configure-aws-credentials@v1
@@ -52,9 +68,9 @@ jobs:
           projectName: security-hq
           # Seed the build number with last number from TeamCity.
           buildNumberOffset: 1265
-          configPath: hq/conf/riff-raff.yaml
+          configPath: conf/riff-raff.yaml
           contentDirectories: |
             security-hq-cfn:
-              - cdk/cdk.out/security-hq.template.json
+              - security-hq.template.json
             security-hq:
-              - hq/target/security-hq.deb
+              - target/security-hq.deb

--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -14,7 +14,7 @@ jobs:
   CDK:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
@@ -25,7 +25,7 @@ jobs:
   SBT:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: '11'

--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -11,43 +11,42 @@ on:
     branches:
       - main
 jobs:
-  CI:
+  CDK:
     runs-on: ubuntu-latest
-
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          cache-dependency-path: 'cdk/package-lock.json'
+      - run: ./script/ci
+        working-directory: cdk
+  SBT:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'corretto'
+          cache: 'sbt'
+      - run: ./script/ci
+  Riff-Raff:
+    runs-on: ubuntu-latest
     # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
     permissions:
       # required by aws-actions/configure-aws-credentials
       id-token: write
       contents: read
+    needs: [CDK, SBT]
     steps:
-      - uses: actions/checkout@v2
-
       # Setup AWS credentials to enable uploading to S3 for Riff-Raff.
       # See https://github.com/aws-actions/configure-aws-credentials
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1
-
-      # Configuring caching is also recommended.
-      # See https://github.com/actions/setup-java
-      - name: Setup Java 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'corretto'
-          cache: 'sbt'
-
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          cache-dependency-path: 'cdk/package-lock.json'
-
-      - name: Run script/ci
-        run: ./script/ci
-
       - uses: guardian/actions-riff-raff@v2
         with:
           projectName: security-hq

--- a/script/ci
+++ b/script/ci
@@ -2,11 +2,6 @@
 
 set -e
 
-(
-    cd cdk
-    ./script/ci
-)
-
 ./sbt --no-conf '; project hq; clean; compile; Debian / packageBin'
 
 # `sbt Debian / packageBin` produces `hq/target/security-hq_0.2.0_all.deb`. Rename it to something easier.


### PR DESCRIPTION
## What does this change?
Changes the build to a fork and join method, performing the CDK (infrastructure) build in parallel to SBT (application). The theory being it reduces the build time.

### Before
```mermaid
graph TB
    A((Start))-->B((CDK build))
    B((CDK build))-->C((SBT build))
    C-->D((Riff-Raff upload))
```

### After
```mermaid
graph TB
    A((Start))-->B((CDK build))
    A-->C((SBT build))
    B-->D((Riff-Raff Upload))
    C-->D
```

By default, jobs in GitHub workflows do not share state. That is, the artifacts produced from the CDK and SBT steps aren't known to the Riff-Raff upload step. To enable this, we make use of [`actions/upload-artifact` and `actions/download-artifact`](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#passing-data-between-jobs-in-a-workflow).

The transfer of the SBT artifact is now the most expensive part of the build, as we're uploading/downloading and compressing/decompressing a ~140MB file.

## What is the value of this?
When comparing the build duration of this branch (2m 34s) against the last build on `main` (2m 48s), the build time has been reduced by 14 seconds 🏃🏽!

However, the screenshots below suggest build times are not predictable, as there are some build on `main` that took 2m 14s, and others 3m 35s. That is, the exact gains are difficult to predict.

<details>
<summary>Screenshot of historical builds on main</summary>

![image](https://user-images.githubusercontent.com/836140/220852245-2e38998b-b17a-4bd3-83bc-5df7e33742ad.png)

</details>

<details>
<summary>Screenshot of builds on this branch</summary>

![image](https://user-images.githubusercontent.com/836140/220852638-6f1368a8-edbf-4789-a9c1-dd1eaf0be79b.png)

</details>

## Any additional notes?
### Is it worth it?
The SBT artifact is ~140MB. When compared to the [amount of free storage available](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions), we'll very quickly enter the paid tier.

Additionally, the change in build duration isn't huge.

Is it worth it? For this project, I'd argue not.