### PR TITLE
Use arm64-jammy-java11-security as the AMI

### DIFF
--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -18,6 +18,6 @@ deployments:
       amiParameter: AMISecurityhq
       amiEncrypted: true
       amiTags:
-        Recipe: security-java-11-arm64
+        Recipe: arm64-jammy-java11-security
         BuiltBy: amigo
         AmigoStage: PROD


### PR DESCRIPTION
## What does this change?

Move to use https://amigo.gutools.co.uk/recipes/arm64-jammy-java11-security.

This will allow us to:

- Move Security-HQ to 22.04 to avoid the 18.04 EOL

## How to test

Deploy this PR to the PROD environment and check the EC2 instances with the new AMI are successfully brought into service & that we can access the Security-HQ.

See: https://riffraff.gutools.co.uk/deployment/view/027c9159-462c-47c4-9767-fdfac66aa3a0?verbose=1

## How can we measure success?

Can we use the jammy AMI to successfully deploy Security-HQ?

## Have we considered potential risks?

Security-HQ is not deployable with Jammy base AMIs, we'll revert.
