### PR TITLE
chore(deps): Bump `anghammarad-client` from 1.2.0 to 1.7.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,7 @@ lazy val hq = (project in file("hq"))
       "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test,
       "org.scalacheck" %% "scalacheck" % "1.17.0" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0" % Test,
-      "com.gu" %% "anghammarad-client" % "1.2.0",
+      "com.gu" %% "anghammarad-client" % "1.7.5",
 
       // logstash-logback-encoder brings in version 2.11.0
       // exclude transitive dependency to avoid a runtime exception:
@@ -151,7 +151,7 @@ lazy val lambdaSecurityGroups = (project in file("lambda/security-groups")).
     name := """securitygroups-lambda""",
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",
     libraryDependencies ++= Seq(
-      "com.gu" %% "anghammarad-client" % "1.2.0"
+      "com.gu" %% "anghammarad-client" % "1.7.5"
     )
 )
 


### PR DESCRIPTION
## What does this change?
Updates the version of [anghammarad](https://github.com/guardian/anghammarad) being used.

## What is the value of this?
This helps address a vulnerability in a transitive dependency, and is an alternative to #1002.