### PR TITLE
feat: Add Stack, Stage, App to notification message

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import scala.concurrent.duration.DurationInt
 
 // common settings (apply to all projects)
 ThisBuild / organization := "com.gu"
-ThisBuild / version := "0.3.2"
+ThisBuild / version := "0.4.0"
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 

--- a/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
+++ b/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
@@ -31,11 +31,29 @@ object Notifier extends StrictLogging {
     }
   }
 
+  private def getTag(targetTags: List[Tag], key: String): Option[String] = {
+    targetTags.find(t => t.key.equals(key)).map(t => t.value)
+  }
+
   def createNotification(groupId: String, targetTags: List[Tag], accountId: String, accountName:String, regionName: String): Notification = {
     val actions = List(
       Action("View in AWS Console", s"https://$regionName.console.aws.amazon.com/ec2/v2/home?region=$regionName#SecurityGroups:search=$groupId")
     )
-    val message = s"Warning: Security group **$groupId** in account **$accountName** is open to the world"
+
+    val stack = getTag(targetTags, "Stack").getOrElse("unknown")
+    val stage = getTag(targetTags, "Stage").getOrElse("unknown")
+    val app = getTag(targetTags, "App").getOrElse("unknown")
+    val repo = getTag(targetTags, "gu:repo").getOrElse("unknown")
+
+    val message =
+      s"""
+         |Warning: Security group **$groupId** in account **$accountName** is open to the world.
+         |
+         |Stack: $stack, Stage: $stage, App: $app
+         |
+         |Repository: $repo
+         |
+         |""".stripMargin
     val targets = getTargetsFromTags(targetTags, accountId)
 
     Notification(subject, message, actions, targets, channel, sourceSystem)
@@ -58,8 +76,8 @@ object Notifier extends StrictLogging {
   }
 
   private def getTargetsFromTags(tags: List[Tag], account: String):List[Target] = {
-    val stack = tags.find(t => t.key.equals("Stack")).map(t => Stack(t.value))
-    val app = tags.find(t => t.key.equals("App")).map(t => App(t.value))
+    val stack = getTag(tags, "Stack").map(t => Stack(t))
+    val app = getTag(tags, "App").map(t => App(t))
     List(stack, app, Some(AwsAccount(account))).flatten
   }
 }


### PR DESCRIPTION
## What does this change, and what is the value?
The `Stack`, `Stage`, `App`, and `gu:repo` tags can be used to identify a service, and where it is defined.

Add these to the notification message to make it easier to triage at a glance.

Here's what the current chat notification looks like:

<img width="584" alt="image" src="https://github.com/guardian/security-hq/assets/836140/b95b5c25-bbb0-45e2-8a5d-3a48be7fa78e">
