### PR TITLE
fix: Display all tags on a security group 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import scala.concurrent.duration.DurationInt
 
 // common settings (apply to all projects)
 ThisBuild / organization := "com.gu"
-ThisBuild / version := "0.4.0"
+ThisBuild / version := "0.4.1"
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 

--- a/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
+++ b/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
@@ -35,7 +35,14 @@ object Notifier extends StrictLogging {
     val actions = List(
       Action("View in AWS Console", s"https://$regionName.console.aws.amazon.com/ec2/v2/home?region=$regionName#SecurityGroups:search=$groupId")
     )
-    val message = s"Warning: Security group **$groupId** in account **$accountName** is open to the world"
+    val message =
+      s"""
+         |Warning: Security group **$groupId** in account **$accountName** is open to the world.
+         |
+         |The security group has ${targetTags.length} tags.
+         |${targetTags.map(t => s"*${t.key}*: ${t.value}").mkString(", ")}
+         |
+         |""".stripMargin
     val targets = getTargetsFromTags(targetTags, accountId)
 
     Notification(subject, message, actions, targets, channel, sourceSystem)

--- a/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
+++ b/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
@@ -31,29 +31,11 @@ object Notifier extends StrictLogging {
     }
   }
 
-  private def getTag(targetTags: List[Tag], key: String): Option[String] = {
-    targetTags.find(t => t.key.equals(key)).map(t => t.value)
-  }
-
   def createNotification(groupId: String, targetTags: List[Tag], accountId: String, accountName:String, regionName: String): Notification = {
     val actions = List(
       Action("View in AWS Console", s"https://$regionName.console.aws.amazon.com/ec2/v2/home?region=$regionName#SecurityGroups:search=$groupId")
     )
-
-    val stack = getTag(targetTags, "Stack").getOrElse("unknown")
-    val stage = getTag(targetTags, "Stage").getOrElse("unknown")
-    val app = getTag(targetTags, "App").getOrElse("unknown")
-    val repo = getTag(targetTags, "gu:repo").getOrElse("unknown")
-
-    val message =
-      s"""
-         |Warning: Security group **$groupId** in account **$accountName** is open to the world.
-         |
-         |Stack: $stack, Stage: $stage, App: $app
-         |
-         |Repository: $repo
-         |
-         |""".stripMargin
+    val message = s"Warning: Security group **$groupId** in account **$accountName** is open to the world"
     val targets = getTargetsFromTags(targetTags, accountId)
 
     Notification(subject, message, actions, targets, channel, sourceSystem)
@@ -76,8 +58,8 @@ object Notifier extends StrictLogging {
   }
 
   private def getTargetsFromTags(tags: List[Tag], account: String):List[Target] = {
-    val stack = getTag(tags, "Stack").map(t => Stack(t))
-    val app = getTag(tags, "App").map(t => App(t))
+    val stack = tags.find(t => t.key.equals("Stack")).map(t => Stack(t.value))
+    val app = tags.find(t => t.key.equals("App")).map(t => App(t.value))
     List(stack, app, Some(AwsAccount(account))).flatten
   }
 }


### PR DESCRIPTION
## What does this change?
Improves on https://github.com/guardian/security-hq/pull/1006, to better handle those cases where the `Stack`, `Stage`, `App`, or `gu:repo` tags are not present.

Printing all the tags offers better UX, as when the specific tags are all `unknown`, the message isn't very helpful:

<img width="515" alt="image" src="https://github.com/guardian/security-hq/assets/836140/d892deec-93ac-4c8d-b145-b5d87c7e972c">
