### PR TITLE
fix: Bold the tag name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import scala.concurrent.duration.DurationInt
 
 // common settings (apply to all projects)
 ThisBuild / organization := "com.gu"
-ThisBuild / version := "0.4.1"
+ThisBuild / version := "0.4.2"
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 

--- a/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
+++ b/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
@@ -40,7 +40,7 @@ object Notifier extends StrictLogging {
          |Warning: Security group **$groupId** in account **$accountName** is open to the world.
          |
          |The security group has ${targetTags.length} tags.
-         |${targetTags.map(t => s"*${t.key}*: ${t.value}").mkString(", ")}
+         |${targetTags.map(t => s"**${t.key}**: ${t.value}").mkString(", ")}
          |
          |""".stripMargin
     val targets = getTargetsFromTags(targetTags, accountId)


### PR DESCRIPTION
## What does this change?
A slight tweak to #1007, correcting the markdown(?) to bold the tag name, instead of italicise.

The current message italicises the tag name, which looks a bit odd!

<img width="523" alt="image" src="https://github.com/guardian/security-hq/assets/836140/fd074c0b-a286-41ce-8536-fe57ae2f3abb">