### PR TITLE
chore(deps): Bump anghammarad-client from 1.7.5 to 1.8.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,7 @@ lazy val lambdaSecurityGroups = (project in file("lambda/security-groups")).
     name := """securitygroups-lambda""",
     assembly / assemblyJarName := s"${name.value}-${version.value}.jar",
     libraryDependencies ++= Seq(
-      "com.gu" %% "anghammarad-client" % "1.7.5"
+      "com.gu" %% "anghammarad-client" % "1.8.1"
     )
 )
 


### PR DESCRIPTION
## What does this change?
Bump the version of [Anghammarad](https://github.com/guardian/anghammarad) used to resolve a high vulnerability reported by Snyk.
