### PR TITLE
feat: Enable backup of DynamoDb table

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -8,4 +8,5 @@ new SecurityHQ(app, "security-hq", {
   stage: "PROD",
   cloudFormationStackName: "security-hq-PROD",
   env: { region: "eu-west-1" },
+  withBackup: true,
 });

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1132,6 +1132,10 @@ exports[`HQ stack matches the snapshot 1`] = `
         "TableName": "security-hq-iam",
         "Tags": [
           {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
+          {
             "Key": "gu:cdk:version",
             "Value": "TEST",
           },

--- a/cdk/lib/security-hq.test.ts
+++ b/cdk/lib/security-hq.test.ts
@@ -8,6 +8,7 @@ describe("HQ stack", () => {
     const stack = new SecurityHQ(app, "security-hq", {
       stack: "security",
       stage: "PROD",
+      withBackup: true,
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,7 +11,7 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@guardian/cdk": "52.1.0",
+        "@guardian/cdk": "52.2.0",
         "@guardian/eslint-config-typescript": "^7.0.0",
         "@types/jest": "^29.5.7",
         "@types/node": "20.8.10",
@@ -1427,15 +1427,15 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "52.1.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.1.0.tgz",
-      "integrity": "sha512-2Lzd+13n7F4/jmtGmklEeDVcl2A/UcdRvcIZ/OtopqJcBI6+igHOrn2OTBIGo72kSRFZSqhbJ1RomW1ZQzP1Sw==",
+      "version": "52.2.0",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-52.2.0.tgz",
+      "integrity": "sha512-KsvryvrKmt4lqfTJZNbI8HTrllN7BQpUzZJZbAsL1SJEpxOVJ2wwG/N3ELi/ZRrb0fY0v1fcb62dQ/eCmjqhOQ==",
       "dev": true,
       "dependencies": {
         "@changesets/cli": "^2.26.2",
         "@oclif/core": "2.15.0",
         "aws-cdk-lib": "2.100.0",
-        "aws-sdk": "^2.1485.0",
+        "aws-sdk": "^2.1490.0",
         "chalk": "^4.1.2",
         "codemaker": "^1.91.0",
         "constructs": "10.3.0",
@@ -3267,9 +3267,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1489.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1489.0.tgz",
-      "integrity": "sha512-DXps/qhDxnVMoQmMu+HIEd92IlCR5HLGGEMmivBaRkga1uyMBrI1D5glNYjyZMfZS1n7ECpiU6xXa/jyBKZ8Qg==",
+      "version": "2.1492.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1492.0.tgz",
+      "integrity": "sha512-3q17ruBkwb3pL87CHSbRlYiwx1LCq7D7hIjHgZ/5SPeKknkXgkHnD20SD2lC8Nj3xGbpIUhoKXcpDAGgIM5DBA==",
       "dev": true,
       "dependencies": {
         "buffer": "4.9.2",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,7 +15,7 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "52.1.0",
+    "@guardian/cdk": "52.2.0",
     "@guardian/eslint-config-typescript": "^7.0.0",
     "@types/jest": "^29.5.7",
     "@types/node": "20.8.10",


### PR DESCRIPTION
## What does this change?
Uses a [recent change to GuCDK](https://github.com/guardian/cdk/releases/tag/v52.2.0) to enable backup of the DynamoDb table.