### PR TITLE
add database backup tag to security-hq-iam table

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1151,6 +1151,10 @@ exports[`HQ stack matches the snapshot 1`] = `
             "Key": "Stage",
             "Value": "PROD",
           },
+          Object {
+            "Key": "devx-backup-enabled",
+            "Value": "true",
+          },
         ],
       },
       "Type": "AWS::DynamoDB::Table",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -19,7 +19,7 @@ import {
   GuPutCloudwatchMetricsPolicy,
 } from "@guardian/cdk/lib/constructs/iam";
 import { GuAnghammaradSenderPolicy } from "@guardian/cdk/lib/constructs/iam/policies/anghammarad";
-import { Duration, RemovalPolicy, SecretValue } from "aws-cdk-lib";
+import { Duration, RemovalPolicy, SecretValue, Tags } from "aws-cdk-lib";
 import type { App } from "aws-cdk-lib";
 import {
   ComparisonOperator,
@@ -62,6 +62,9 @@ export class SecurityHQ extends GuStack {
         type: AttributeType.NUMBER,
       },
     });
+
+    // Enable automated backups for the ownership table via https://github.com/guardian/aws-backup
+    Tags.of(table).add("devx-backup-enabled", "true");
 
     this.overrideLogicalId(table, {
       logicalId: "SecurityHqIamDynamoTable",


### PR DESCRIPTION
## What does this change?


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
