### PR TITLE
reduce frequency of dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps): "
     labels:
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/cdk"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore(deps): "
     # The version of AWS CDK libraries must match those from @guardian/cdk.


### PR DESCRIPTION
## What does this change?

Switch from weekly to monthly dependabot PRs

## What is the value of this?

Security HQ is in maintenance mode, and we have plans to deprecate it soon. Keeping it's dependencies up to date is not as important as other projects the team maintains. Less time reviewing these PRs means more time for other priorities.

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Will this require changes to config?

No

## Any additional notes?

No
