### PR TITLE
Fix: bump logback to fix high Snyk vulnerabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,8 @@ lazy val hq = (project in file("hq"))
       "org.scalacheck" %% "scalacheck" % "1.17.0" % Test,
       "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0" % Test,
       "com.gu" %% "anghammarad-client" % "1.8.1",
+      "ch.qos.logback" % "logback-classic" % "1.4.14",
+
 
       // logstash-logback-encoder brings in version 2.11.0
       // exclude transitive dependency to avoid a runtime exception:
@@ -138,7 +140,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "org.scalatest" %% "scalatest" % "3.2.15" % Test,
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-      "ch.qos.logback" % "logback-classic" % "1.2.11",
+      "ch.qos.logback" % "logback-classic" % "1.2.13",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -140,7 +140,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "org.scalatest" %% "scalatest" % "3.2.15" % Test,
       "com.typesafe.play" %% "play-json" % playJsonVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
-      "ch.qos.logback" % "logback-classic" % "1.2.13",
+      "ch.qos.logback" % "logback-classic" % "1.4.14",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     )
   )


### PR DESCRIPTION
## What does this change?

Bumps logback-classic (and core) to versions that don't have high vulnerabilities. Because Play ships with a vulnerable version of logback (even Play 2.9), I have added the dependency explicitly so that it overrides Play's version.

Note: I could have updated Play to v.2.9 and sbt to v1.9.7, but it wasn't necessary to fix the vulnerabilities. Please comment if you think this should be done as part of this change too.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?

I don't think so. 

## Will this require changes to config?

I don't think so.

I tested this by running `./script/ci` `sbt test` `sbt compile` and `snyk test` to ensure the high vulnerabilities had been removed. 