### PR TITLE
Make open security group notification more readable

### DIFF
--- a/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
+++ b/lambda/security-groups/src/main/scala/com/gu/hq/Notifier.scala
@@ -40,7 +40,7 @@ object Notifier extends StrictLogging {
          |Warning: Security group **$groupId** in account **$accountName** is open to the world.
          |
          |The security group has ${targetTags.length} tags.
-         |${targetTags.map(t => s"**${t.key}**: ${t.value}").mkString(", ")}
+         |${targetTags.map(t => s"**${t.key}**: ${t.value}").mkString("\n")}
          |
          |""".stripMargin
     val targets = getTargetsFromTags(targetTags, accountId)

--- a/lambda/security-groups/src/test/scala/com/gu/hq/NotifierTest.scala
+++ b/lambda/security-groups/src/test/scala/com/gu/hq/NotifierTest.scala
@@ -83,5 +83,14 @@ class NotifierTest extends AnyFreeSpec with Matchers with OptionValues {
       val notification = createNotification(groupId, targetTags, accountId, accountName, regionName)
       notification.target.toSet should contain allOf (Stack("stack"), App("app"))
     }
+
+    "puts each tag on a new line" in {
+      val notification = createNotification(groupId, targetTags, accountId, accountName, regionName)
+      notification.message should contain
+        """**Stack**: stack
+           |**App**: app
+           |**Stage**: PROD
+           |**Irrelevant**: foo""".stripMargin
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

Target tags are presented as one key value pair per line.

## What is the value of this?

Easier reading

## Will this require CloudFormation and/or updates to the AWS StackSet?

Requires stackset update, but not urgently, it can wait until next week.

## Will this require changes to config?

No

## Any additional notes?

No
