### PR TITLE
chore: upgrade to Play v3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,11 +10,6 @@ ThisBuild / version := "0.5.0"
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 
-// We need to avoid a binary-incompatible version conflict - because janus-config-tools v.0.0.5 requires com.typesafe.play:twirl-api_2.13:1.4.2
-ThisBuild / libraryDependencySchemes ++= Seq(
-  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-)
-
 resolvers += DefaultMavenRepository
 
 val awsSdkVersion = "1.12.635"
@@ -70,7 +65,7 @@ lazy val hq = (project in file("hq"))
       // exclude transitive dependency to avoid a runtime exception:
       // `com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0`
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3" exclude("com.fasterxml.jackson.core", "jackson-databind"),
-      "com.gu" %% "janus-config-tools" % "0.0.5"
+      "com.gu" %% "janus-config-tools" % "0.0.6"
     ),
 
     

--- a/build.sbt
+++ b/build.sbt
@@ -6,19 +6,20 @@ import scala.concurrent.duration.DurationInt
 
 // common settings (apply to all projects)
 ThisBuild / organization := "com.gu"
-ThisBuild / version := "0.4.2"
+ThisBuild / version := "0.5.0"
 ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
+
+// We need to avoid a binary-incompatible version conflict - because janus-config-tools v.0.0.5 requires com.typesafe.play:twirl-api_2.13:1.4.2
+ThisBuild / libraryDependencySchemes ++= Seq(
+  "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
+)
 
 resolvers += DefaultMavenRepository
 
 val awsSdkVersion = "1.12.635"
-val playJsonVersion = "2.9.3"
+val playJsonVersion = "3.0.1"
 val jacksonVersion = "2.15.1"
-
-// Until all dependencies are on scala-java8-compat v1.x, this avoids unnecessary fatal eviction errors
-// See https://github.com/akka/akka/pull/30375
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-java8-compat" % VersionScheme.Always
 
 val mergeStrategySettings= assemblyMergeStrategy := {
   case PathList(ps@_*) if ps.last == "module-info.class" => MergeStrategy.discard
@@ -35,9 +36,9 @@ lazy val hq = (project in file("hq"))
     libraryDependencies ++= Seq(
       ws,
       filters,
-      "com.gu.play-googleauth" %% "play-v28" % "2.2.6",
-      "com.gu.play-secret-rotation" %% "play-v28" % "0.36",
-      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "0.36",
+      "com.gu.play-googleauth" %%  "play-v30" % "3.0.6",
+      "com.gu.play-secret-rotation" %% "play-v30" % "6.0.8",
+      "com.gu.play-secret-rotation" %% "aws-parameterstore-sdk-v1" % "6.0.8",
       "joda-time" % "joda-time" % "2.11.2",
       "org.typelevel" %% "cats-core" % "2.8.0",
       "com.github.tototoshi" %% "scala-csv" % "1.3.10",
@@ -71,6 +72,8 @@ lazy val hq = (project in file("hq"))
       "net.logstash.logback" % "logstash-logback-encoder" % "7.3" exclude("com.fasterxml.jackson.core", "jackson-databind"),
       "com.gu" %% "janus-config-tools" % "0.0.5"
     ),
+
+    
     Assets / pipelineStages := Seq(digest),
     // exclude docs
     Compile / doc / sources := Seq.empty,
@@ -138,7 +141,7 @@ lazy val lambdaCommon = (project in file("lambda/common")).
       "com.amazonaws" % "aws-java-sdk-sts" % awsSdkVersion,
       "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
       "org.scalatest" %% "scalatest" % "3.2.15" % Test,
-      "com.typesafe.play" %% "play-json" % playJsonVersion,
+      "org.playframework" %% "play-json" % playJsonVersion,
       "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
       "ch.qos.logback" % "logback-classic" % "1.4.14",
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -5,7 +5,7 @@ import com.amazonaws.regions.{Region, Regions}
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
-import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker, GoogleServiceAccount}
+import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupChecker}
 import com.gu.play.secretrotation.aws.parameterstore.{AwsSdkV1, SecretSupplier}
 import com.gu.play.secretrotation.{RotatingSecretComponents, SnapshotProvider, TransitionTiming}
 import model._

--- a/hq/app/filters/HstsFilter.scala
+++ b/hq/app/filters/HstsFilter.scala
@@ -1,6 +1,6 @@
 package filters
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import play.api.mvc.{Filter, RequestHeader, Result}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 libraryDependencies += "org.vafer" % "jdeb" % "1.10" artifacts Artifact("jdeb", "jar", "jar")
 
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.16")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.1")
 
 // web plugins
 

--- a/script/ci
+++ b/script/ci
@@ -7,7 +7,7 @@ set -e
     ./script/ci
 )
 
-./sbt --no-conf '; project hq; clean; compile; Debian / packageBin'
+./sbt --no-conf '; project hq; clean; compile; test; Debian / packageBin'
 
 # `sbt Debian / packageBin` produces `hq/target/security-hq_x.x.x_all.deb`. Rename it to something easier.
 # TODO Work out how to do this within build.sbt


### PR DESCRIPTION
## What does this change?

- Upgrades Play to v3.0.1.

- Upgrades various other dependencies to enable this to work. 

- Bumps the version of Security HQ to 0.5.0. 

- One change to Scala config has been made to remove an import for `GoogleServiceAccount` that doesn't exist in the later version of Google Auth.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

This has been done to  remove our dependence on Akka. Play v3 uses Pekko instead.

## Will this require CloudFormation and/or updates to the AWS StackSet?

I don't think so.

## Will this require changes to config?

I have updated the local DEV config in S3 with a longer application secret, as required by Play v3. I don't  think PROD will be affected.

<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->
