### PR TITLE
Add workflow for sending dependency information to Github

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,14 @@
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main # default branch of the project
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: scalacenter/sbt-dependency-submission@v2
+    permissions:
+        contents: write # this permission is needed to submit the dependency graph


### PR DESCRIPTION
## What does this change?

We're continuing to investigate Github's dependency scanning.

## What is the value of this?

As well as using Snyk, we'll now have dependency information available in Github. Having a few repos integrated (janus-app is already done) helps us look at how we'll manage this across the org.

## Will this require CloudFormation and/or updates to the AWS StackSet?

N/A

## Will this require changes to config?

N/A

## Any additional notes?

N/A