### PR TITLE
chore: add dependency tree plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,3 +18,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-rjs" % "1.0.10")
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.1.2")
+
+addDependencyTreePlugin


### PR DESCRIPTION
## What does this change?

Adds the SBT dependency tree plugin.

## What is the value of this?

This will allow us to generate the dependency tree locally, including using the useful `dependencyBrowseTree` command to display a searchable tree in the browser.