### PR TITLE
Update vulnerability recommendations

### DIFF
--- a/hq/markdown/vulnerability-management.md
+++ b/hq/markdown/vulnerability-management.md
@@ -114,26 +114,28 @@ All GNM managed third party applications must be patched on a regular basis as p
 Technical owners are responsible to establish such a process.
 ```  
 ### 1. Find the vulnerabilities
-At The Guardian we recommend 2 vulnerability scanners: Snyk and Dependabot. All PROD applications should have a vulnerability
-scanner installed - this should be possible to do in a few clicks in the Snyk/Github UI (see below for details).
+At The Guardian we recommend 2 vulnerability scanners: Snyk and Dependabot. All PROD applications must have a vulnerability
+scanner enabled. DevX will attempt to do this automatically on your behalf, but if you are not sure if your application has it,
+or are using a language we don't recommend, you may have to organise this yourself. DevX security are happy to assist with this process.
 
 #### Snyk
-The Guardian has an enterprise account with Snyk, which will scan your repo for vulnerabilities and open PRs where possible
-to resolve them. This is the recommended tool for Scala projects. We have unlimited scans with Snyk so you shouldn't
-hesitate to enable it in your project. See the [full documentation](./snyk.md). For a summary of all Snyk vulnerabilities
-at The Guardian in one place you can head to the [Snyk dashboard on Security HQ](https://security-hq.gutools.co.uk/snyk) 
-(VPN required).
+The Guardian has an enterprise account with Snyk, which will scan your repo for vulnerabilities. This is the recommended
+tool for Scala projects. See the [full documentation](./snyk.md). For a summary of all Snyk vulnerabilities at The Guardian
+in one place you can head to the [Snyk dashboard on Security HQ](https://security-hq.gutools.co.uk/snyk).
 
 #### Dependabot
-Dependabot is a similar tool by Github. For TypeScript/Javascript projects you might choose to use this instead of Snyk
-as it integrates well with the Github UI. (It's not worth switching if you're already set up with Snyk though). It opens
+Dependabot is a similar tool, owned by GitHub. For TypeScript/JavaScript projects you might choose to use this instead of Snyk
+as it integrates well with the GitHub UI. (It's not worth switching if you're already set up with Snyk though). It can open
  automated PRs, but you can also see more detail, including any PRs that have been ignored/closed in the 'Security' tab
- of your repo. One downside of Dependabot is that there's no API or central dashboard, so the only way of checking dependency
- issues is by going to each repo one by one.
- 
-One thing to note is that dependabot will tell you when there's a new version of a library even if there isn't a security
-concern. If you're trying to save time you might opt to skip these - any security related fixes will say so in the PR
-description.  
+ of your repo. One downside of Dependabot is that there is no central dashboard available to developers, but you can check
+vulnerabilities repo by repo, via the CLI.
+
+There are two ways to configure dependabot updates:
+ - Raise PRs for all dependency updates
+ - Raise PRs for security updates only
+
+We recommend teams use the first option, as this makes it easier to keep on top of updates, but ultimately it's up to teams
+to decide which option is the most sustainable for them.
 
 #### Scala Steward
 Scala Steward works like Dependabot for Scala dependencies.
@@ -142,11 +144,15 @@ We
 [recommend that it is configured for all repos containing Scala code](https://github.com/guardian/recommendations/blob/main/scala.md#continuous-dependency-management).
  
 ### 2. Prioritise the vulnerabilities
-Soo, your team should have some kind of process for staying up to date with patching. Not every vulnerability highlighted by
+So, your team should have some kind of process for staying up to date with patching. Not every vulnerability highlighted by
 Snyk or Dependabot necessarily needs fixing - maybe the way your app works (e.g. in a private VPC) means that the vulnerability
 listed isn't of concern. However, in many cases it's easier to fix rather than to justify not fixing something though, and in general
 it's good to have 'defence in depth' - so to assume that any other security measures might get compromised and not to rely on
 e.g. network security. 
+
+Our departmental obligations are that we should actively manage all vulnerabilities with a severity of Critical or High.
+Critical vulnerabilities should be resolved within a day, and High vulnerabilities within two weeks. Prioritisation of
+all other vulnerabilities is at the development team's discretion.
 
 :exclamation: Updating dependencies can be expensive. Focus on 'high' severity vulnerabilities to begin with. It may be
 perfectly reasonable to not fix something if you have a justification.


### PR DESCRIPTION
## What does this change?

Small tweaks to update documentation about dependabot/snyk

Add a section talking about when we expect vulnerabilities to be resolved

## What is the value of this?

Increase departmental awareness of security obligations

## Will this require CloudFormation and/or updates to the AWS StackSet?

No

## Will this require changes to config?

No
