### PR TITLE
Ignore some typescript and eslint bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,12 +18,21 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "chore(deps): "
-    # The version of AWS CDK libraries must match those from @guardian/cdk.
-    # We'd never be able to update them here independently, so just ignore them.
     ignore:
+      # The version of AWS CDK libraries must match those from @guardian/cdk.
+      # We'd never be able to update them here independently, so just ignore them.
       - dependency-name: "aws-cdk"
       - dependency-name: "aws-cdk-lib"
       - dependency-name: "constructs"
+      # The version of typescript must match the versions required by @guardian/eslint-config-typescript which
+      # currently only allows patch updates, so ignore the minor and major version bumps.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # The version of eslint must match the versions required by @guardian/eslint-config-typescript which
+      # currently only allows patch and minor updates, so ignore the major version bumps.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+
     labels:
       - "dependencies"
     groups:


### PR DESCRIPTION
## What does this change?

Tells Dependabot to ignore version bumps for certain versions of `typescript` and `eslint`, so they don't get bumped and break the peer dep requirements of `@guardian/eslint-config-typescript`.

`version = '10.0.1'
peerDependencies = { eslint: '^8.56.0', tslib: '^2.6.2', typescript: '~5.3.3' }`

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Fewer Dependabot PRs that we have to fix manually, hopefully.