### PR TITLE
Bump jackson explicitly to resolve incompatible version issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += DefaultMavenRepository
 
 val awsSdkVersion = "1.12.768"
 val playJsonVersion = "3.0.1"
-val jacksonVersion = "2.15.1"
+val jacksonVersion = "2.17.2"
 
 val mergeStrategySettings= assemblyMergeStrategy := {
   case PathList(ps@_*) if ps.last == "module-info.class" => MergeStrategy.discard


### PR DESCRIPTION
## What does this change?

We depend on both jackson-databind and jackson-module-scala, and explicitly ask for version 2.15.x to avoid vulnerabiltiies in 2.14.x (play's preferred version). The AWS SDK depends on jackson at version 2.17.x, which evicts our version (2.15.x) for jackson-databind, but not for the jackson-module-scala (which it doesn't know about). These incompatible versions throw an exception at start time, so the Play server does not start.

Bumping our override to 2.17.x resolves the incompatibility.

## What is the value of this?

The server will start :-)

## Any additional notes?

The risk with this change is that play does not work with jackson at v2.17.x. This was already an issue, because we were forcing 2.15.x. We'll keep an eye out.
