### PR TITLE
feat: Use `GuEc2AppExperimental` to deploy app updates via CFN

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -38,6 +38,10 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'cdk/package-lock.json'
 
+      - run: |
+          LAST_TEAMCITY_BUILD=1265
+          echo "BUILD_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD ))" >> $GITHUB_ENV
+
       - name: Run script/ci
         run: ./script/ci
 
@@ -45,12 +49,11 @@ jobs:
         with:
           projectName: security-hq
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          # Seed the build number with last number from TeamCity.
-          buildNumberOffset: 1265
+          buildNumber: ${{ env.BUILD_NUMBER }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           configPath: hq/conf/riff-raff.yaml
           contentDirectories: |
             security-hq-cfn:
               - cdk/cdk.out/security-hq.template.json
             security-hq:
-              - hq/target/security-hq.deb
+              - dist

--- a/cdk/jest.setup.js
+++ b/cdk/jest.setup.js
@@ -1,1 +1,3 @@
 jest.mock("@guardian/cdk/lib/constants/tracking-tag");
+
+process.env.BUILD_NUMBER = "TEST";

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -18,7 +18,7 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
-      "GuEc2App",
+      "GuEc2AppExperimental",
       "GuCertificate",
       "GuInstanceRole",
       "GuSsmSshPolicy",
@@ -123,6 +123,34 @@ exports[`HQ stack matches the snapshot 1`] = `
       },
       "Type": "AWS::SSM::Parameter",
     },
+    "AsgRollingUpdatePolicy2A1DDC6F": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudformation:SignalResource",
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "AWS::StackId",
+              },
+            },
+            {
+              "Action": "elasticloadbalancing:DescribeTargetHealth",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleSecurityhq7C08CA33",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "AssumeRole3910C09D": {
       "Properties": {
         "PolicyDocument": {
@@ -145,7 +173,17 @@ exports[`HQ stack matches the snapshot 1`] = `
       "Type": "AWS::IAM::Policy",
     },
     "AutoScalingGroupSecurityhqASG8DD277A5": {
+      "CreationPolicy": {
+        "AutoScalingCreationPolicy": {
+          "MinSuccessfulInstancesPercent": 100,
+        },
+        "ResourceSignal": {
+          "Count": 1,
+          "Timeout": "PT5M",
+        },
+      },
       "Properties": {
+        "DesiredCapacity": "1",
         "HealthCheckGracePeriod": 120,
         "HealthCheckType": "ELB",
         "LaunchTemplate": {
@@ -163,10 +201,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         "MetricsCollection": [
           {
             "Granularity": "1Minute",
-            "Metrics": [
-              "GroupTotalInstances",
-              "GroupInServiceInstances",
-            ],
           },
         ],
         "MinSize": "1",
@@ -219,6 +253,18 @@ exports[`HQ stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingRollingUpdate": {
+          "MaxBatchSize": 2,
+          "MinInstancesInService": 1,
+          "MinSuccessfulInstancesPercent": 100,
+          "PauseTime": "PT5M",
+          "SuspendProcesses": [
+            "AlarmNotification",
+          ],
+          "WaitOnResourceSignals": true,
+        },
+      },
     },
     "CertificateSecurityhqD266EC9D": {
       "DeletionPolicy": "Retain",
@@ -1553,6 +1599,21 @@ exports[`HQ stack matches the snapshot 1`] = `
                 "",
                 [
                   "#!/bin/bash
+function exitTrap(){
+exitCode=$?
+
+        cfn-signal --stack ",
+                  {
+                    "Ref": "AWS::StackId",
+                  },
+                  "           --resource AutoScalingGroupSecurityhqASG8DD277A5           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
+        
+}
+trap exitTrap EXIT
 # setup security-hq
     mkdir -p /etc/gu
 
@@ -1572,7 +1633,39 @@ exports[`HQ stack matches the snapshot 1`] = `
                   },
                   "/security/PROD/security-hq/security-hq.deb /tmp/installer.deb
 
-    dpkg -i /tmp/installer.deb",
+    dpkg -i /tmp/installer.deb
+# GuEc2AppExperimental UserData Start
+
+      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
+
+      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupSecurityhq530DEDAA",
+                  },
+                  "         --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
+
+      until [ "$STATE" == "\\"healthy\\"" ]; do
+        echo "Instance not yet healthy within target group. Current state $STATE. Sleeping..."
+        sleep 5
+        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
+                  {
+                    "Ref": "TargetGroupSecurityhq530DEDAA",
+                  },
+                  "           --region ",
+                  {
+                    "Ref": "AWS::Region",
+                  },
+                  "           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
+      done
+
+      echo "Instance is healthy in target group."
+      
+# GuEc2AppExperimental UserData End",
                 ],
               ],
             },

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1631,7 +1631,7 @@ trap exitTrap EXIT
                   {
                     "Ref": "DistributionBucketName",
                   },
-                  "/security/PROD/security-hq/security-hq.deb /tmp/installer.deb
+                  "/security/PROD/security-hq/security-hq-TEST.deb /tmp/installer.deb
 
     dpkg -i /tmp/installer.deb
 # GuEc2AppExperimental UserData Start

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -1,4 +1,3 @@
-import { GuEc2App } from "@guardian/cdk";
 import { AccessScope } from "@guardian/cdk/lib/constants";
 import { GuAlarm } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
@@ -20,6 +19,7 @@ import {
   GuPutCloudwatchMetricsPolicy,
 } from "@guardian/cdk/lib/constructs/iam";
 import { GuAnghammaradSenderPolicy } from "@guardian/cdk/lib/constructs/iam/policies/anghammarad";
+import { GuEc2AppExperimental } from "@guardian/cdk/lib/experimental/patterns/ec2-app";
 import { Duration, RemovalPolicy, SecretValue } from "aws-cdk-lib";
 import type { App } from "aws-cdk-lib";
 import {
@@ -96,7 +96,7 @@ export class SecurityHQ extends GuStack {
 
     dpkg -i /tmp/installer.deb`);
 
-    const ec2App = new GuEc2App(this, {
+    const ec2App = new GuEc2AppExperimental(this, {
       applicationLogging: {
         enabled: true
       },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -86,13 +86,15 @@ export class SecurityHQ extends GuStack {
 
     const domainName = "security-hq.gutools.co.uk";
 
+    const buildNumber = process.env.BUILD_NUMBER ?? "DEV";
+
     const userData = UserData.forLinux();
     userData.addCommands(`# setup security-hq
     mkdir -p /etc/gu
 
     aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.stage}/security-hq/security-hq.conf /etc/gu
     aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.stage}/security-hq/security-hq-service-account-cert.json /etc/gu
-    aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.stage}/security-hq/security-hq.deb /tmp/installer.deb
+    aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.stage}/security-hq/security-hq-${buildNumber}.deb /tmp/installer.deb
 
     dpkg -i /tmp/installer.deb`);
 

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,7 +11,7 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@guardian/cdk": "59.3.5",
+        "@guardian/cdk": "github:guardian/cdk#aa/ec2-AutoScalingReplacingUpdate",
         "@guardian/eslint-config-typescript": "^12.0.0",
         "@types/jest": "^29.5.12",
         "@types/node": "22.5.1",
@@ -797,8 +797,7 @@
     },
     "node_modules/@guardian/cdk": {
       "version": "59.3.5",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.3.5.tgz",
-      "integrity": "sha512-2RJyR+cLvsaBVfqOsPms65lGgxotz3JchX3gNwps1iBvr2sXTFBi8hWQJiTtgzsORpyuRettrS+m4v9R7VCiRA==",
+      "resolved": "git+ssh://git@github.com/guardian/cdk.git#b4801a052a6f662c20db124d097588a123333d40",
       "dev": true,
       "dependencies": {
         "@oclif/core": "3.26.6",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,13 +11,13 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@guardian/cdk": "59.3.1",
+        "@guardian/cdk": "59.3.5",
         "@guardian/eslint-config-typescript": "^12.0.0",
         "@types/jest": "^29.5.12",
         "@types/node": "22.5.1",
         "@typescript-eslint/eslint-plugin": "^8.3.0",
-        "aws-cdk": "2.155.0",
-        "aws-cdk-lib": "2.155.0",
+        "aws-cdk": "2.157.0",
+        "aws-cdk-lib": "2.157.0",
         "constructs": "10.3.0",
         "eslint": "^8.57.0",
         "eslint-import-resolver-typescript": "^3.6.1",
@@ -56,15 +56,15 @@
       "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.3.tgz",
-      "integrity": "sha512-twhuEG+JPOYCYPx/xy5uH2+VUsIEhPTzDY0F1KuB+ocjWWB/KEDiOVL19nHvbPCB6fhWnkykXEMJ4HHcKvjtvg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "dev": true
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "36.0.24",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-36.0.24.tgz",
-      "integrity": "sha512-dHyb4lvd6nbNHLVvdyxVPgwc0MyzN3VzIJnWwGJWKOIwVqL7hvU2NkQQrktY9T2MtdhzUdDFm9qluxuLRV5Cfw==",
+      "version": "36.0.25",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-36.0.25.tgz",
+      "integrity": "sha512-AK86v4IMV4zcWfp392e3wlaVJPT72/dk39Lo2SDDFxQR+sikMOyY2IGrULyhK1TwQmPiyxM7QB/0MkTbMDAPrw==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -796,16 +796,16 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "59.3.1",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.3.1.tgz",
-      "integrity": "sha512-Y6ZpDNuUpXGs2Rxaw8f4G3k507pqx42ZdVkRIRePIRIOPXNSZ03OEAfhMrc+n0M7kG3/JZYZsUNWCF5ihUy67w==",
+      "version": "59.3.5",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.3.5.tgz",
+      "integrity": "sha512-2RJyR+cLvsaBVfqOsPms65lGgxotz3JchX3gNwps1iBvr2sXTFBi8hWQJiTtgzsORpyuRettrS+m4v9R7VCiRA==",
       "dev": true,
       "dependencies": {
         "@oclif/core": "3.26.6",
-        "aws-sdk": "^2.1687.0",
+        "aws-sdk": "^2.1691.0",
         "chalk": "^4.1.2",
         "codemaker": "^1.103.1",
-        "git-url-parse": "^14.1.0",
+        "git-url-parse": "^15.0.0",
         "js-yaml": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.kebabcase": "^4.1.1",
@@ -817,8 +817,8 @@
         "gu-cdk": "bin/gu-cdk"
       },
       "peerDependencies": {
-        "aws-cdk": "2.155.0",
-        "aws-cdk-lib": "2.155.0",
+        "aws-cdk": "2.157.0",
+        "aws-cdk-lib": "2.157.0",
         "constructs": "10.3.0"
       }
     },
@@ -2625,9 +2625,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.155.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.155.0.tgz",
-      "integrity": "sha512-AV7Ym/o7/xyDh6sqcGatWD6Bqa7Swe0OWJq+1srVww0MdBiy5yM3zYAA1+ZeqZNjFQThJPA+pYZQFTgojuaVBA==",
+      "version": "2.157.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.157.0.tgz",
+      "integrity": "sha512-x/6ZUm/JuQoSdbDUiNdPvKcwh5tsJl+Mk07RKJLSKagN179VJLQk5BzT4P+bFVMzAeYRMpURjPCOwjKbU1V7OQ==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -2640,9 +2640,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.155.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.155.0.tgz",
-      "integrity": "sha512-QGzDhLldBXsyOUmhgtZ98PiOUS2g1Mb5MO08FiOvQn3+KSyJjQdq0GoyxtDpCNGLaWmIfcyrtB9aDhod38fl9g==",
+      "version": "2.157.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.157.0.tgz",
+      "integrity": "sha512-07uVY1MVool092wP+jb2XjPR9PFvF26VDDatY6BXR+AliW9sFZ4NKB7zzJrzZOyAbA3cTbedEca0EpRLZ7bjYw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -3018,9 +3018,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1687.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1687.0.tgz",
-      "integrity": "sha512-Pk7RbIxJ8yDmFJRKzaapiUsAvz5cTPKCz7soomU+lASx1jvO29Z9KAPB6KJR22m7rDDMO/HNNN9OJRzfdvh7xQ==",
+      "version": "2.1691.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1691.0.tgz",
+      "integrity": "sha512-/F2YC+DlsY3UBM2Bdnh5RLHOPNibS/+IcjUuhP8XuctyrN+MlL+fWDAiela32LTDk7hMy4rx8MTgvbJ+0blO5g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -4792,9 +4792,9 @@
       }
     },
     "node_modules/git-url-parse": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-14.1.0.tgz",
-      "integrity": "sha512-8xg65dTxGHST3+zGpycMMFZcoTzAdZ2dOtu4vmgIfkTFnVHBxHMzBC2L1k8To7EmrSiHesT8JgPLT91VKw1B5g==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-15.0.0.tgz",
+      "integrity": "sha512-5reeBufLi+i4QD3ZFftcJs9jC26aULFLBU23FeKM/b1rI0K6ofIeAblmDVO7Ht22zTDE9+CkJ3ZVb0CgJmz3UQ==",
       "dev": true,
       "dependencies": {
         "git-up": "^7.0.0"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,13 +15,13 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "59.3.1",
+    "@guardian/cdk": "59.3.5",
     "@guardian/eslint-config-typescript": "^12.0.0",
     "@types/jest": "^29.5.12",
     "@types/node": "22.5.1",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
-    "aws-cdk": "2.155.0",
-    "aws-cdk-lib": "2.155.0",
+    "aws-cdk": "2.157.0",
+    "aws-cdk-lib": "2.157.0",
     "constructs": "10.3.0",
     "eslint": "^8.57.0",
     "eslint-import-resolver-typescript": "^3.6.1",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,7 +15,7 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "59.3.5",
+    "@guardian/cdk": "github:guardian/cdk#aa/ec2-AutoScalingReplacingUpdate",
     "@guardian/eslint-config-typescript": "^12.0.0",
     "@types/jest": "^29.5.12",
     "@types/node": "22.5.1",

--- a/hq/conf/riff-raff.yaml
+++ b/hq/conf/riff-raff.yaml
@@ -5,11 +5,10 @@ stacks:
 regions:
 - eu-west-1
 deployments:
-
   security-hq:
     type: autoscaling
-    dependencies: [security-hq-cfn]
-
+    actions:
+      - uploadArtifacts
   security-hq-cfn:
     type: cloud-formation
     app: security-hq
@@ -23,3 +22,5 @@ deployments:
         Recipe: arm64-jammy-java11-security
         BuiltBy: amigo
         AmigoStage: PROD
+    dependencies:
+      - security-hq

--- a/script/ci
+++ b/script/ci
@@ -9,6 +9,5 @@ set -e
 
 ./sbt --no-conf '; project hq; clean; compile; test; Debian / packageBin'
 
-# `sbt Debian / packageBin` produces `hq/target/security-hq_x.x.x_all.deb`. Rename it to something easier.
-# TODO Work out how to do this within build.sbt
-mv hq/target/security-hq_*_all.deb hq/target/security-hq.deb
+mkdir -p dist
+mv hq/target/security-hq_*_all.deb "dist/security-hq-$BUILD_NUMBER.deb"


### PR DESCRIPTION
## What does this change?
Use `GuEc2AppExperimental` to deploy app updates via CFN.

[Successfully deployed to PROD](https://riffraff.gutools.co.uk/deployment/view/24d99e23-eee2-442d-add2-b8610446ee52)(this stack is a singleton, so no CODE).

## What is the value of this?
(this stack is a singleton, so no CODE)

## Will this require CloudFormation and/or updates to the AWS StackSet?
No.

## Will this require changes to config?
No.

## Any additional notes?
We should swap to an [auto-generated `riff-raff.yaml` file](https://github.com/guardian/cdk/blob/main/src/riff-raff-yaml-file/README.md).