### PR TITLE
chore(deps-dev): Update GuCDK from 59.5.0 to 59.5.1

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -179,7 +179,7 @@ exports[`HQ stack matches the snapshot 1`] = `
         },
         "ResourceSignal": {
           "Count": 1,
-          "Timeout": "PT2M",
+          "Timeout": "PT3M",
         },
       },
       "Properties": {
@@ -258,7 +258,7 @@ exports[`HQ stack matches the snapshot 1`] = `
           "MaxBatchSize": 2,
           "MinInstancesInService": 1,
           "MinSuccessfulInstancesPercent": 100,
-          "PauseTime": "PT2M",
+          "PauseTime": "PT3M",
           "SuspendProcesses": [
             "AlarmNotification",
           ],

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,7 +11,7 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@guardian/cdk": "59.5.0",
+        "@guardian/cdk": "59.5.1",
         "@guardian/eslint-config-typescript": "^12.0.0",
         "@types/jest": "^29.5.12",
         "@types/node": "22.5.1",
@@ -796,9 +796,9 @@
       }
     },
     "node_modules/@guardian/cdk": {
-      "version": "59.5.0",
-      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.5.0.tgz",
-      "integrity": "sha512-cmdh/V0+SxhPC4qsqIiQ1Axdh+133s7oJv63SxCu/OGAp49XclLVOL2TA00bsVJC0ozI8pUMU1h+di0yTaDgyA==",
+      "version": "59.5.1",
+      "resolved": "https://registry.npmjs.org/@guardian/cdk/-/cdk-59.5.1.tgz",
+      "integrity": "sha512-BqLRnRGICL4O2NPUTT7yvReDIMNC4rGBxAwImSE5j6eu9OkwbpqzdrrvdB7USATyhq5VDc4sEO3QqpGcnRprUw==",
       "dev": true,
       "dependencies": {
         "@oclif/core": "3.26.6",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,7 +15,7 @@
     "synth": "cdk synth --path-metadata false --version-reporting false"
   },
   "devDependencies": {
-    "@guardian/cdk": "59.5.0",
+    "@guardian/cdk": "59.5.1",
     "@guardian/eslint-config-typescript": "^12.0.0",
     "@types/jest": "^29.5.12",
     "@types/node": "22.5.1",


### PR DESCRIPTION
## What does this change?
Updates the version of GuCDK, with an aim to improve deployment stability.

See also https://github.com/guardian/cdk/releases/tag/v59.5.1.