### PR TITLE
Explicitly install sbt in dependency submission workflow

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - ts/fix-dependency-submission-workflow
   workflow_dispatch:
 jobs:
   dependency-graph:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,14 +1,25 @@
-name: Update Dependency Graph
+name: Update Dependency Graph for SBT
 on:
   push:
     branches:
-      - main # default branch of the project
+      - main
+      - ts/fix-dependency-submission-workflow
+  workflow_dispatch:
 jobs:
   dependency-graph:
-    name: Update Dependency Graph
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      - uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+      - name: Checkout branch
+        id: checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Install SBT
+        id: install
+        uses: sbt/setup-sbt@8a071aa780c993c7a204c785d04d3e8eb64ef272 # v1.1.0
+      - name: Submit dependencies
+        id: submit
+        uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0
+      - name: Log snapshot for user validation
+        id: validate
+        run: cat ${{ steps.submit.outputs.snapshot-json-path }} | jq
     permissions:
-        contents: write # this permission is needed to submit the dependency graph
+      contents: write


### PR DESCRIPTION
## What does this change?

- Installs sbt in the dependency submission workflow.

## What is the value of this?

The workflow is currently broken because the latest Ubuntu doesn't come with sbt bundled.

## How to test

This is the workflow run [before](https://github.com/guardian/security-hq/actions/runs/11209895261) and [after ](https://github.com/guardian/security-hq/actions/runs/11347765650)this change.

- [x] TODO: remove this branch from the workflow
