### PR TITLE
Improve error logging on IAM credentials report

### DIFF
--- a/hq/app/aws/AwsAsyncHandler.scala
+++ b/hq/app/aws/AwsAsyncHandler.scala
@@ -48,7 +48,7 @@ object AwsAsyncHandler {
       } else if (e.getMessage.contains("Rate exceeded")) {
         Failure.rateLimitExceeded(serviceNameOpt, awsClient).attempt
       } else {
-        Failure.awsError(serviceNameOpt, awsClient).attempt
+        Failure.awsError(serviceNameOpt, awsClient, e).attempt
       }
     }
   }

--- a/hq/app/logic/IamUnrecognisedUsers.scala
+++ b/hq/app/logic/IamUnrecognisedUsers.scala
@@ -33,7 +33,12 @@ object IamUnrecognisedUsers extends Logging {
   def getCredsReportDisplayForAccount[A, B](allCreds: Map[A, Either[FailedAttempt, B]]): List[(A, B)] = {
     allCreds.toList.foldLeft[List[(A, B)]](Nil) {
       case (acc, (_, Left(failure))) =>
-        logger.error(s"unable to generate credential report display: ${failure.logMessage}")
+        failure.firstException match {
+          case Some(cause) =>
+            logger.error(s"unable to generate credential report display: ${failure.logMessage}", cause)
+          case None =>
+            logger.error(s"unable to generate credential report display: ${failure.logMessage}")
+        }
         acc
       case (acc, (account, Right(credReportDisplay))) =>
         (account, credReportDisplay) :: acc

--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -38,7 +38,7 @@ case class Failure(
 object Failure {
   // Pre-defined "common" failures
 
-  def awsError(serviceNameOpt: Option[String], clientContext: AwsClient[_]): Failure = {
+  def awsError(serviceNameOpt: Option[String], clientContext: AwsClient[_], err: Throwable): Failure = {
     val context = contextString(clientContext)
     val details = serviceNameOpt.fold(s"AWS unknown error, unknown service (check logs for stacktrace), $context") { serviceName =>
       s"AWS unknown error, service: $serviceName (check logs for stacktrace), $context"
@@ -46,7 +46,7 @@ object Failure {
     val friendlyMessage = serviceNameOpt.fold("Unknown error while making API calls to AWS.") { serviceName =>
       s"Unknown error while making an API call to AWS' $serviceName service"
     }
-    Failure(details, friendlyMessage, 500)
+    Failure(details, friendlyMessage, 500, throwable = Some(err))
   }
 
   def notYetLoaded(accountId: String, cacheContent: String): Failure = {


### PR DESCRIPTION
We add a cause to unexpected AWS SDK client errors, and use this newly-populated field (if present) from the IAM credentials report refresh code.

This should give us insights into the current failures.

