### PR TITLE
Improve error handling / logging

### DIFF
--- a/hq/app/utils/attempt/Failure.scala
+++ b/hq/app/utils/attempt/Failure.scala
@@ -7,7 +7,8 @@ case class FailedAttempt(failures: List[Failure]) {
 
   def logMessage: String = failures.map { failure =>
     val context = failure.context.fold("")(c => s" ($c)")
-    s"${failure.message}$context"
+    val causedBy = firstException.fold("")(err => s" caused by: ${err.getMessage}")
+    s"${failure.message}$context$causedBy"
   }.mkString(", ")
 
   def firstException: Option[Throwable] = {


### PR DESCRIPTION
Log messages on Failures now include a summary of the underlying cause, if present. This should improve error visibility across the board in Security HQ.

We also add additional error handling to the cache service. On every cache update we include a summary of which accounts have failures in their cache data.

This is motivated by the IAM remediation issues, and will give us more information for digging into the problem.