### PR TITLE
Fixes detection of report generation after the v2 SDK update

### DIFF
--- a/hq/app/aws/iam/CredentialsReport.scala
+++ b/hq/app/aws/iam/CredentialsReport.scala
@@ -4,7 +4,6 @@ import java.io.StringReader
 import model.{AwsStack, CredentialReportDisplay, IAMCredential, IAMCredentialsReport}
 import com.github.tototoshi.csv._
 import org.joda.time.{DateTime, Hours, Seconds}
-
 import logic.DateUtils
 import net.logstash.logback.marker.Markers.appendEntries
 import play.api.{Logging, MarkerContext}
@@ -13,13 +12,13 @@ import utils.attempt.{Attempt, FailedAttempt}
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success, Try}
 import scala.jdk.CollectionConverters._
-
 import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.iam.model.{GenerateCredentialReportResponse, GetCredentialReportResponse}
+import software.amazon.awssdk.services.iam.model.{GenerateCredentialReportResponse, GetCredentialReportResponse, ReportStateType}
 
 object CredentialsReport extends Logging {
 
-  def isComplete(report: GenerateCredentialReportResponse): Boolean = report.state == "COMPLETE"
+  def isComplete(report: GenerateCredentialReportResponse): Boolean =
+    report.state == ReportStateType.COMPLETE
 
   def credentialsReportReadyForRefresh(currentReport: Either[FailedAttempt, CredentialReportDisplay], currentTime: DateTime): Boolean = {
     currentReport match {


### PR DESCRIPTION
Since the AWS v2 Java SDK update, the test of whether the report has finished being generated was broken. We correct this here so that we will detect a finished report.

This will stop us getting rate limit errors, and restore IAM remediation functionality.

## What does this change?

The v1 SDK used a String for the status field, but in v2 this is an enum called `ReportType`. We had a type error warning, but because this projefct does not have fatal warnings enabled it was easy to miss. This incorrect equality check means we will be constantly retrying the report generation check instead of proceeding to load the report.
