### PR TITLE
Fix a date format runtime exception

### DIFF
--- a/hq/app/aws/iam/CredentialsReport.scala
+++ b/hq/app/aws/iam/CredentialsReport.scala
@@ -53,7 +53,7 @@ object CredentialsReport extends Logging {
 
   def extractReport(response: GetCredentialReportResponse)(implicit  ec: ExecutionContext): Attempt[IAMCredentialsReport] = {
     val report = response.content.asUtf8String()
-    tryParsingReport(report).map(IAMCredentialsReport(new DateTime(response.generatedTime), _))
+    tryParsingReport(report).map(IAMCredentialsReport(new DateTime(response.generatedTime.toEpochMilli), _))
   }
 
 


### PR DESCRIPTION
This should be the last step on fixing the credentials report logic, following the AWS v2 Java SDK update.

I've seen the report get cached locally following this change.

This PR follows https://github.com/guardian/security-hq/pull/1194 and https://github.com/guardian/security-hq/pull/1196, following the SDK update (https://github.com/guardian/security-hq/pull/1179) some time back.