### PR TITLE
Remove unused code that depends on the v1 AWS SDK

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val hq = (project in file("hq"))
       // exclude transitive dependency to avoid a runtime exception:
       // `com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0`
       "net.logstash.logback" % "logstash-logback-encoder" % "8.0" exclude("com.fasterxml.jackson.core", "jackson-databind"),
-      "com.gu" %% "janus-config-tools" % "1.0.0"
+      "com.gu" %% "janus-config-tools" % "2.0.0"
     ),
 
 

--- a/hq/app/aws/AwsAsyncHandler.scala
+++ b/hq/app/aws/AwsAsyncHandler.scala
@@ -1,25 +1,9 @@
 package aws
 
-import com.amazonaws.AmazonWebServiceRequest
-import com.amazonaws.handlers.AsyncHandler
-import play.api.Logging
 import utils.attempt.{Attempt, Failure}
 
 import java.util.concurrent.CompletableFuture
-
 import scala.concurrent.{ExecutionContext, Future, Promise}
-
-
-class AwsAsyncPromiseHandler[R <: AmazonWebServiceRequest, T](promise: Promise[T], clientContext: AwsClient[_]) extends AsyncHandler[R, T] with Logging {
-  def onError(e: Exception): Unit = {
-    val context = Failure.contextString(clientContext)
-    logger.warn(s"Failed to execute AWS SDK operation (${clientContext.client.getClass.getSimpleName}), $context", e)
-    promise failure e
-  }
-  def onSuccess(r: R, t: T): Unit = {
-    promise success t
-  }
-}
 
 object AwsAsyncHandler {
   private val ServiceName = ".*Service: ([^;]+);.*".r


### PR DESCRIPTION

## What does this change?

Remove unused code that depends on the v1 AWS SDK

This dead code was previously still compiling because the v1 AWS Java SDK was being brought in as a transitive dependency via the janus-config-tools library.

With the bump to v2 of janus-config-tools this is no longer the case, which highlighted this problem. Removing the unused code fixes the issue.

## What is the value of this?

This lets us update to the latest version of the janus-config-tools library, removes unused code, and eliminates an implicit dependency on the end-of-life v1 AWS Java SDK.

Closes https://github.com/guardian/security-hq/pull/1212
