### PR TITLE
fix: high severity vulnerability in netty-handler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-Xf
 
 resolvers += DefaultMavenRepository
 
-val awsSdkVersion = "2.30.16"
+val awsSdkVersion = "2.30.37"
 val playJsonVersion = "3.0.4"
 val jacksonVersion = "2.18.2"
 


### PR DESCRIPTION
## What does this change?

Bumps `awssdk` to latest to remediate a High severity vulnerability in `netty-handler`: https://github.com/advisories/GHSA-4g8c-wm8x-jfhw

