### PR TITLE
chore(deps): bump janus-config-tools to v3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val hq = (project in file("hq"))
       // exclude transitive dependency to avoid a runtime exception:
       // `com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0`
       "net.logstash.logback" % "logstash-logback-encoder" % "8.0" exclude("com.fasterxml.jackson.core", "jackson-databind"),
-      "com.gu" %% "janus-config-tools" % "2.0.0"
+      "com.gu" %% "janus-config-tools" % "3.0.0"
     ),
 
 

--- a/hq/test/schedule/unrecognised/IamUnrecognisedUsersTest.scala
+++ b/hq/test/schedule/unrecognised/IamUnrecognisedUsersTest.scala
@@ -2,15 +2,15 @@ package schedule.unrecognised
 
 import com.gu.janus
 import com.gu.janus.model.{ACL, JanusData, SupportACL}
-import model._
-import org.joda.time.{DateTime, Seconds}
 import logic.IamUnrecognisedUsers._
-import logic.IamUnrecognisedUsers.{USERNAME_TAG_KEY, getCredsReportDisplayForAccount, getJanusUsernames, isTaggedForUnrecognisedUser, unrecognisedUsersForAllowedAccounts}
-import utils.attempt.{FailedAttempt, Failure}
-
-import scala.io.Source
+import model._
+import org.joda.time.DateTime
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import utils.attempt.{FailedAttempt, Failure}
+
+import java.time.Duration
+import scala.io.Source
 
 class IamUnrecognisedUsersTest extends AnyFreeSpec with Matchers {
   val humanUser1 = HumanUser("ade.bimbola", true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, None, List(Tag(USERNAME_TAG_KEY, "ade.bimbola")))
@@ -28,7 +28,7 @@ class IamUnrecognisedUsersTest extends AnyFreeSpec with Matchers {
         Set(janus.model.AwsAccount("Deploy Tools", "deployTools")),
         ACL(Map("firstName.secondName" -> Set.empty)),
         ACL(Map.empty),
-        SupportACL(Map.empty, Set.empty, Seconds.ZERO),
+        SupportACL(Map.empty, Set.empty, Duration.ZERO),
         None
       )
 


### PR DESCRIPTION
## What does this change?
Upgrades janus-config-tools library from v2.0.0 to [v3.0.0](https://github.com/guardian/janus-app/releases/tag/v3.0.0).  
This migrates some case classes to use java.time types so there's a small change to a test.

## What is the value of this?
Keeps the dependencies up to date.

## Any additional notes?
There are still plenty of uses of Joda time in this repo but they will be addressed later on.
