### PR TITLE
Bump janus-config-tools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ lazy val hq = (project in file("hq"))
       // exclude transitive dependency to avoid a runtime exception:
       // `com.fasterxml.jackson.databind.JsonMappingException: Scala module 2.10.2 requires Jackson Databind version >= 2.10.0 and < 2.11.0`
       "net.logstash.logback" % "logstash-logback-encoder" % "8.0" exclude("com.fasterxml.jackson.core", "jackson-databind"),
-      "com.gu" %% "janus-config-tools" % "3.0.0"
+      "com.gu" %% "janus-config-tools" % "4.0.0"
     ),
 
 


### PR DESCRIPTION


## What does this change?

This version bump adds a new feature to the config tools library, which means we need to update the library to support new config files. Otherwise, this doesn't affect how Security HQ is consuming the parsed file.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

We'll continue to be able to parse the Janus config file.


<!-- Why are these changes being made? -->

## Any additional notes?

See the following related PRs:

- https://github.com/guardian/janus-app/pull/539
- https://github.com/guardian/janus/pull/4697
- https://github.com/guardian/janus/pull/4698


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
