### PR TITLE
fix: Increase resource signal timeout for ASG

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -9,5 +9,5 @@ new SecurityHQ(app, "security-hq", {
   stage: "PROD",
   cloudFormationStackName: "security-hq-PROD",
   env: { region: "eu-west-1" },
-  buildIdentifier: process.env.BUILD_NUMBER ?? "DEV"
+  buildIdentifier: process.env.BUILD_NUMBER ?? "DEV",
 });

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HQ stack matches the snapshot 1`] = `
 {
@@ -178,7 +178,7 @@ exports[`HQ stack matches the snapshot 1`] = `
         },
         "ResourceSignal": {
           "Count": 1,
-          "Timeout": "PT3M",
+          "Timeout": "PT5M",
         },
       },
       "DependsOn": [

--- a/cdk/lib/security-hq.test.ts
+++ b/cdk/lib/security-hq.test.ts
@@ -8,7 +8,7 @@ describe("HQ stack", () => {
     const stack = new SecurityHQ(app, "security-hq", {
       stack: "security",
       stage: "PROD",
-      buildIdentifier: "TEST"
+      buildIdentifier: "TEST",
     });
     expect(Template.fromStack(stack).toJSON()).toMatchSnapshot();
   });


### PR DESCRIPTION
## What does this change?
This change does a small thing.
Specifically, it increases the timeout for the addition of the single instance to the stack's ASG from 3 minutes to 5 minutes.

## What is the value of this?
We're seeing Cloudformation deployments failing occasionally because the instance is timing out before it's fully healthy.     
But repeating the deploy always works, which makes us think we aren't giving the instance long enough to sort itself out.
For example, in this [failed deploy](https://riffraff.gutools.co.uk/deployment/view/973e39e3-34b0-411a-af02-c520f6f1223a):
> [11:45:39] New instance(s) added to autoscaling group - Waiting on 1 resource signal(s) with a timeout of PT3M.
> [11:48:36] AutoScalingGroupSecurityhqASG8DD277A5 (AWS::AutoScaling::AutoScalingGroup): UPDATE_IN_PROGRESS
> [11:48:36] Failed to receive 1 resource signal(s) for the current batch. Each resource signal timeout is counted as a FAILURE.
> [11:48:41] AutoScalingGroupSecurityhqASG8DD277A5 (AWS::AutoScaling::AutoScalingGroup): UPDATE_FAILED
> [11:48:41] Received 0 SUCCESS signal(s) out of 1. Unable to satisfy 100% MinSuccessfulInstancesPercent requirement
> [11:48:41] security-hq-PROD (AWS::CloudFormation::Stack): UPDATE_ROLLBACK_IN_PROGRESS

## Any additional notes?
Perhaps this is a naive change but we've decided it isn't worth spending a lot of time on it as this stack will soon be redundant.

`npm run format` has been run over the files so there are some formatting changes.
The only substantive change is 
```
cfnAsg.addOverride(
      "CreationPolicy.ResourceSignal.Timeout",
      Duration.minutes(5).toIsoString(),
    );
```
