### PR TITLE
ci: Stop linking to a Code stage deployment

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -62,3 +62,6 @@ jobs:
               - cdk/cdk.out/security-hq.template.json
             security-hq:
               - dist
+          # No point in links to a Code stage, as there isn't one
+          commentingEnabled: false
+          


### PR DESCRIPTION
## What does this change?
This should stop comments appearing in PRs linking to a non-existent Code stage, according to the [documentation](https://github.com/guardian/actions-riff-raff?tab=readme-ov-file#commentingenabled).
See [this example](https://github.com/guardian/security-hq/pull/1261#issuecomment-3206908928).
