### PR TITLE
chore: Add sbt ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       prefix: "chore(deps): "
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
     groups:
       all:
         patterns: ["*"]
@@ -26,6 +28,22 @@ updates:
       - dependency-name: "constructs"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
     groups:
       all:
         patterns: ["*"]
+
+  - package-ecosystem: "sbt"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(deps): "
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 7
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,9 @@ updates:
       prefix: "chore(deps): "
     labels:
       - "dependencies"
-    cooldown:
-      default-days: 7
+    # Possibly not yet supported for sbt
+    # cooldown:
+    #   default-days: 7
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]


### PR DESCRIPTION
Now that Dependabot [supports sbt](https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/), we can compare what PRs it generates compared to [Scala Steward](https://github.com/guardian/scala-steward-public-repos/blob/3d2fd4555f0d39408c97e4c42f9d20f783cbb6fa/scala-steward.conf).
This repo is using both.

Although cooldown option is [supposed to be supported](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown), it [isn't](https://github.com/guardian/security-hq/pull/1373/checks?check_run_id=78032947334):
<img width="719" height="281" alt="image" src="https://github.com/user-attachments/assets/13b90f51-2381-41d2-92be-79d8c83222c2" />
