### PR TITLE
fix: bump awssdk version to latest to remediate netty-codec vuln

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ ThisBuild / scalacOptions ++= Seq(
 
 resolvers += DefaultMavenRepository
 
-val awsSdkVersion = "2.42.41"
+val awsSdkVersion = "2.46.0"
 val playJsonVersion = "3.0.4"
 
 /*


### PR DESCRIPTION
## What does this change?

Upgrades the version of aws sdk to latest (v2.46.0) which brings in the patched version of io.netty:netty-codec (v4.1.133).

## What is the value of this?

Remediates the vulnerability in [this security alert](https://github.com/guardian/security-hq/security/dependabot/165).

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->

- [x] Tested locally