### PR TITLE
Start separating out IAMOutdatedCredentials

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ lazy val core = (project in file("core"))
 lazy val hq = (project in file("hq"))
   .enablePlugins(PlayScala, SbtWeb, JDebPackaging, SystemdPlugin)
   .disablePlugins(sbtassembly.AssemblyPlugin)
-  .dependsOn(core)
+  .dependsOn(core, iamOutdatedCredentials)
   .settings(
     name := """security-hq""",
     playDefaultPort := 9090,
@@ -141,6 +141,77 @@ lazy val hq = (project in file("hq"))
     maintainer := "Security Team <devx.sec.ops@guardian.co.uk>",
     packageSummary := "Security HQ app.",
     packageDescription := """Deb for Security HQ - the Guardian's service to centralise security information for our AWS accounts.""",
+    Universal / javaOptions ++= Seq(
+      "-Dpidfile.path=/dev/null",
+      "-Dconfig.file=/etc/gu/security-hq.conf",
+      "-J-XX:+UseCompressedOops",
+      "-J-XX:NativeMemoryTracking=detail",
+      "-J-XX:MaxRAMPercentage=50",
+      "-J-XX:InitialRAMPercentage=50",
+      "-J-XX:MaxMetaspaceSize=300m",
+      "-J-Xlog:gc*",
+      s"-J-Xlog:gc:/var/log/${packageName.value}/gc.log"
+    ),
+    mergeStrategySettings
+  )
+
+lazy val iamOutdatedCredentials = (project in file("iam-outdated-credentials"))
+  .enablePlugins(JDebPackaging)
+  .disablePlugins(sbtassembly.AssemblyPlugin)
+  .dependsOn(core)
+  .settings(
+    name := """iam-outdated-credentials""",
+    fileDescriptorLimit := Some("16384"), // This increases the number of open files allowed when running in AWS
+    libraryDependencies ++= Seq(
+      ws,
+      filters,
+      "joda-time" % "joda-time" % "2.14.2",
+      "co.fs2" %% "fs2-core" % "3.13.0",
+      "com.github.tototoshi" %% "scala-csv" % "2.0.0",
+      "software.amazon.awssdk" % "iam" % awsSdkVersion,
+      "software.amazon.awssdk" % "cloudformation" % awsSdkVersion,
+      "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
+      "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
+      "software.amazon.awssdk" % "ec2" % awsSdkVersion,
+      "software.amazon.awssdk" % "efs" % awsSdkVersion,
+      "software.amazon.awssdk" % "s3" % awsSdkVersion,
+      "software.amazon.awssdk" % "sns" % awsSdkVersion,
+      "software.amazon.awssdk" % "ssm" % awsSdkVersion,
+      "software.amazon.awssdk" % "sts" % awsSdkVersion,
+      "software.amazon.awssdk" % "support" % awsSdkVersion,
+      "com.vladsch.flexmark" % "flexmark" % "0.64.8",
+      "org.scalatest" %% "scalatest" % "3.2.20" % Test,
+      "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
+      "org.scalacheck" %% "scalacheck" % "1.19.0" % Test,
+      "com.gu" %% "anghammarad-client" % "7.0.0",
+      "ch.qos.logback" % "logback-classic" % "1.5.34",
+      "net.logstash.logback" % "logstash-logback-encoder" % "9.0",
+      "com.gu" %% "janus-config-tools" % "10.0.0"
+    ) ++ safeTransitiveDependencies,
+    Assets / pipelineStages := Seq(digest),
+    // exclude docs
+    Compile / doc / sources := Seq.empty,
+    Universal / packageName := "iam-outdated-credentials",
+    // include beanstalk config files in the zip produced by `dist`
+    Universal / mappings ++=
+      (baseDirectory.value / "beanstalk" * "*" get)
+        .map(f => f -> s"beanstalk/${f.getName}"),
+    // include upstart config files in the zip produced by `dist`
+    Universal / mappings ++=
+      (baseDirectory.value / "upstart" * "*" get)
+        .map(f => f -> s"upstart/${f.getName}"),
+    // include systemd config files in the zip produced by `dist`
+    Universal / mappings ++=
+      (baseDirectory.value / "systemd" * "*" get)
+        .map(f => f -> s"systemd/${f.getName}"),
+    Compile / unmanagedResourceDirectories += baseDirectory.value / "markdown",
+    Test / unmanagedSourceDirectories += baseDirectory.value / "test" / "jars",
+    Test / parallelExecution := false,
+    Test / fork := false,
+
+    maintainer := "Security Team <devx.sec.ops@guardian.co.uk>",
+    packageSummary := "IAM Outdated Credentials lambda.",
+    packageDescription := """Deb for IAM Outdated Credentials lambda - the Guardian's service to check for outdated credentials in AWS accounts.""",
     Universal / javaOptions ++= Seq(
       "-Dpidfile.path=/dev/null",
       "-Dconfig.file=/etc/gu/security-hq.conf",

--- a/build.sbt
+++ b/build.sbt
@@ -162,48 +162,10 @@ lazy val iamOutdatedCredentials = (project in file("iam-outdated-credentials"))
   .settings(
     name := """iam-outdated-credentials""",
     fileDescriptorLimit := Some("16384"), // This increases the number of open files allowed when running in AWS
-    libraryDependencies ++= Seq(
-      ws,
-      filters,
-      "joda-time" % "joda-time" % "2.14.2",
-      "co.fs2" %% "fs2-core" % "3.13.0",
-      "com.github.tototoshi" %% "scala-csv" % "2.0.0",
-      "software.amazon.awssdk" % "iam" % awsSdkVersion,
-      "software.amazon.awssdk" % "cloudformation" % awsSdkVersion,
-      "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
-      "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
-      "software.amazon.awssdk" % "ec2" % awsSdkVersion,
-      "software.amazon.awssdk" % "efs" % awsSdkVersion,
-      "software.amazon.awssdk" % "s3" % awsSdkVersion,
-      "software.amazon.awssdk" % "sns" % awsSdkVersion,
-      "software.amazon.awssdk" % "ssm" % awsSdkVersion,
-      "software.amazon.awssdk" % "sts" % awsSdkVersion,
-      "software.amazon.awssdk" % "support" % awsSdkVersion,
-      "com.vladsch.flexmark" % "flexmark" % "0.64.8",
-      "org.scalatest" %% "scalatest" % "3.2.20" % Test,
-      "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test,
-      "org.scalacheck" %% "scalacheck" % "1.19.0" % Test,
-      "com.gu" %% "anghammarad-client" % "7.0.0",
-      "ch.qos.logback" % "logback-classic" % "1.5.34",
-      "net.logstash.logback" % "logstash-logback-encoder" % "9.0",
-      "com.gu" %% "janus-config-tools" % "10.0.0"
-    ) ++ safeTransitiveDependencies,
     Assets / pipelineStages := Seq(digest),
     // exclude docs
     Compile / doc / sources := Seq.empty,
     Universal / packageName := "iam-outdated-credentials",
-    // include beanstalk config files in the zip produced by `dist`
-    Universal / mappings ++=
-      (baseDirectory.value / "beanstalk" * "*" get)
-        .map(f => f -> s"beanstalk/${f.getName}"),
-    // include upstart config files in the zip produced by `dist`
-    Universal / mappings ++=
-      (baseDirectory.value / "upstart" * "*" get)
-        .map(f => f -> s"upstart/${f.getName}"),
-    // include systemd config files in the zip produced by `dist`
-    Universal / mappings ++=
-      (baseDirectory.value / "systemd" * "*" get)
-        .map(f => f -> s"systemd/${f.getName}"),
     Compile / unmanagedResourceDirectories += baseDirectory.value / "markdown",
     Test / unmanagedSourceDirectories += baseDirectory.value / "test" / "jars",
     Test / parallelExecution := false,
@@ -212,17 +174,6 @@ lazy val iamOutdatedCredentials = (project in file("iam-outdated-credentials"))
     maintainer := "Security Team <devx.sec.ops@guardian.co.uk>",
     packageSummary := "IAM Outdated Credentials lambda.",
     packageDescription := """Deb for IAM Outdated Credentials lambda - the Guardian's service to check for outdated credentials in AWS accounts.""",
-    Universal / javaOptions ++= Seq(
-      "-Dpidfile.path=/dev/null",
-      "-Dconfig.file=/etc/gu/security-hq.conf",
-      "-J-XX:+UseCompressedOops",
-      "-J-XX:NativeMemoryTracking=detail",
-      "-J-XX:MaxRAMPercentage=50",
-      "-J-XX:InitialRAMPercentage=50",
-      "-J-XX:MaxMetaspaceSize=300m",
-      "-J-Xlog:gc*",
-      s"-J-Xlog:gc:/var/log/${packageName.value}/gc.log"
-    ),
     mergeStrategySettings
   )
 

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -116,7 +116,7 @@ class IamRemediationService(
     rawCredsReports = cacheService.getAllCredentials
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-  } yield new IamOutdatedCredentials(snsClient, iamClients, dynamo).disableOutdatedCredentials(
+  } yield new IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun = false).disableOutdatedCredentials(
     notificationTopicArn,
     tableName,
     serviceAccountIds,

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -1,14 +1,13 @@
 package services
 
 import aws.AwsClients
-import aws.iam.IAMClient
 import aws.s3.S3.getS3Object
 import com.gu.janus.JanusConfig
-import config.Config.*
+import config.Config
+import config.Config.{getAnghammaradSNSTopicArn, getIamDynamoTableName, getIamUnrecognisedUserConfig}
 import db.IamRemediationDb
-import logic.IamOutdatedCredentials.*
 import logic.IamUnrecognisedUsers.*
-import model.*
+import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
 import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
@@ -42,61 +41,6 @@ class IamRemediationService(
 )(implicit ec: ExecutionContext)
     extends Scheduler {
 
-  /** If an AWS access key has not been rotated in a long time, then will automatically disable it.
-    *
-    * This job will first send a warning notification when it detects an outdated credential. If nothing changes it will
-    * send a final warning notification. After both these notifications have been ignored, the credential will be
-    * automatically disabled.
-    */
-  def disableOutdatedCredentials()(implicit ec: ExecutionContext): Attempt[Unit] = {
-    val now = new DateTime()
-    val result = for {
-      // lookup essential configuration
-      notificationTopicArn <- getAnghammaradSNSTopicArn(config)
-      tableName <- getIamDynamoTableName(config)
-      serviceAccountIds <- getAccountsForIamRemediationService(config)
-      allowedAwsAccountIds <- getAllowedAccountsForStage(
-        config
-      ) // this tells us which AWS accounts we are allowed to make changes to
-      // fetch IAM data from the application cache
-      rawCredsReports = cacheService.getAllCredentials
-      accountsCredReports = getCredsReportDisplayForAccount(rawCredsReports)
-      // identify users with outdated credentials for each account, from the credentials report
-      accountUsersWithOutdatedCredentials = identifyAllUsersWithOutdatedCredentials(accountsCredReports, now)
-      // DB lookup of previous SHQ activity for each user to produce a list of "candidate" vulnerabilities
-      vulnerabilitiesWithRemediationHistory <- lookupActivityHistory(
-        accountUsersWithOutdatedCredentials,
-        dynamo,
-        tableName
-      )
-      // based on activity history, decide which of these candidates have outstanding SHQ operations
-      outstandingOperations = calculateOutstandingAccessKeyOperations(vulnerabilitiesWithRemediationHistory, now)
-      // we'll only perform operations on accounts that have been configured as eligible
-      filteredOperations = partitionOperationsByAllowedAccounts(
-        outstandingOperations,
-        allowedAwsAccountIds,
-        serviceAccountIds
-      )
-      // we won't execute these operations, but can log them instead
-      _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(dummyOperation)
-      // now we know what operations need to be performed, so let's run each of those
-      results <- Attempt.traverse(filteredOperations.allowedOperations)(
-        performRemediationOperation(_, now, notificationTopicArn, tableName)
-      )
-    } yield results
-    result.tap {
-      case Left(failedAttempt) =>
-        logger.error(
-          s"Failure during 'disable outdated credentials' job: ${failedAttempt.logMessage}",
-          failedAttempt.firstException.orNull // make sure the exception goes into the log, if present
-        )
-      case Right(operationIds) =>
-        logger.info(
-          s"Successfully completed 'disable outdated credentials' job, with ${operationIds.length} operations"
-        )
-    }.unit
-  }
-
   /** Removes AWS access for colleagues that have departed.
     *
     * This feature is targeted at "recovery access", where teams keep one or two IAM users that can be used to gain
@@ -107,7 +51,7 @@ class IamRemediationService(
     * with google identity tags. If we find an IAM user tagged with an identity that is not in Janus, we can assume they
     * have left and disable the IAM user.
     */
-  def disableUnrecognisedUsers()(implicit ec: ExecutionContext): Attempt[Unit] = {
+  private def disableUnrecognisedUsers()(implicit ec: ExecutionContext): Attempt[Unit] = {
     val result = for {
       config <- getIamUnrecognisedUserConfig(config)
       // fetch and parse our stored Janus config to use the canonical source of "recognised" usernames
@@ -115,7 +59,7 @@ class IamRemediationService(
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
       // look up the credentials report from the cache service as our source of current IAM users
-      accountCredsReports = getCredsReportDisplayForAccount(cacheService.getAllCredentials)
+      accountCredsReports = IamUnrecognisedUsers.getCredsReportDisplayForAccount(cacheService.getAllCredentials)
       // determine the unrecognised users by comparing Janus usernames to the IAM users (and filter to allowed accounts)
       allowedAccountsUnrecognisedUsers = unrecognisedUsersForAllowedAccounts(
         accountCredsReports,
@@ -143,79 +87,6 @@ class IamRemediationService(
     }.unit
   }
 
-  /** Performs the specified operation, which will be one of:
-    *   - send a warning
-    *   - send a final warning
-    *   - disable an IAM credential and send a notification that this has been done
-    *   - remove an IAM password and send a notification that this has been done
-    */
-  def performRemediationOperation(
-      remediationOperation: RemediationOperation,
-      now: DateTime,
-      notificationTopicArn: String,
-      tableName: String
-  )(implicit ec: ExecutionContext): Attempt[String] = {
-    val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
-    val iamUser = remediationOperation.vulnerableCandidate.iamUser
-    val problemCreationDate = remediationOperation.problemCreationDate
-    // if successful, this record will be added to the database
-    val thisRemediationActivity = IamRemediationActivity(
-      awsAccount.id,
-      iamUser.username,
-      now,
-      remediationOperation.iamRemediationActivityType,
-      remediationOperation.iamProblem,
-      remediationOperation.problemCreationDate
-    )
-
-    (remediationOperation.iamRemediationActivityType, remediationOperation.iamProblem) match {
-      // Outdated credentials
-      case (Warning, OutdatedCredential) =>
-        val notification =
-          AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
-        for {
-          snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
-          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-        } yield snsId
-
-      case (FinalWarning, OutdatedCredential) =>
-        val notification =
-          AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
-        for {
-          snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
-          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-        } yield snsId
-
-      case (Remediation, OutdatedCredential) =>
-        val notification =
-          AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
-        for {
-          // disable the correct credential
-          userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
-          credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
-          _ <- IAMClient.disableAccessKey(
-            awsAccount,
-            credentialToDisable.username,
-            credentialToDisable.accessKeyId,
-            iamClients
-          )
-          // send a notification to say this is what we have done
-          notificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
-          // save a record of the change
-          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-        } yield notificationId
-    }
-  }
-
-  /** We only perform actions on accounts that are explicitly allowed, but it is helpful to log the operation that
-    * *would* have been performed, if allowed.
-    */
-  def dummyOperation(remediationOperation: RemediationOperation): Unit = {
-    val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
-    logger.warn(s"Remediation operation skipped because ${awsAccount.id} is not configured for remediation")
-    logger.warn(s"Skipping remediation action: ${formatRemediationOperation(remediationOperation)}")
-  }
-
   if (environment.mode != Mode.Test) {
     // Schedule the observable on weekdays only as we may make changes in accounts that affect live systems
     // if warnings are not heeded. Initial delay of 10 minutes, so that the cache service has time to populate
@@ -230,11 +101,26 @@ class IamRemediationService(
           (now.getHourOfDay == 14 && now.getMinuteOfHour == 0)
 
         if (isWeekday && isTimeToRun) {
-          disableOutdatedCredentials()
+          disableOutdatedCredentials
           disableUnrecognisedUsers()
         }
       }
 
     lifecycle.addStopHook(iamRemediationServiceSubscription)
   }
+
+  private def disableOutdatedCredentials = for {
+    notificationTopicArn <- getAnghammaradSNSTopicArn(config)
+    tableName <- getIamDynamoTableName(config)
+    serviceAccountIds <- Config.getAccountsForIamRemediationService(config)
+    rawCredsReports = cacheService.getAllCredentials
+    // this tells us which AWS accounts we are allowed to make changes to
+    allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
+  } yield new IamOutdatedCredentials(snsClient, iamClients, dynamo).disableOutdatedCredentials(
+    notificationTopicArn,
+    tableName,
+    serviceAccountIds,
+    rawCredsReports,
+    allowedAwsAccountIds
+  )
 }

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -20,7 +20,8 @@ import scala.concurrent.ExecutionContext
 class IamOutdatedCredentials(
     snsClient: SnsAsyncClient,
     iamClients: AwsClients[IamAsyncClient],
-    dynamo: IamRemediationDb
+    dynamo: IamRemediationDb,
+    dryRun: Boolean = true
 ) extends LazyLogging {
 
   /** Performs the specified operation, which will be one of:
@@ -33,7 +34,8 @@ class IamOutdatedCredentials(
       remediationOperation: RemediationOperation,
       now: DateTime,
       notificationTopicArn: String,
-      tableName: String
+      tableName: String,
+      dryRun: Boolean
   )(implicit ec: ExecutionContext): Attempt[String] = {
     val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
     val iamUser = remediationOperation.vulnerableCandidate.iamUser
@@ -50,7 +52,7 @@ class IamOutdatedCredentials(
 
     (remediationOperation.iamRemediationActivityType, remediationOperation.iamProblem) match {
       // Outdated credentials
-      case (Warning, OutdatedCredential) =>
+      case (Warning, OutdatedCredential) if !dryRun =>
         val notification =
           AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
         for {
@@ -58,7 +60,11 @@ class IamOutdatedCredentials(
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
         } yield snsId
 
-      case (FinalWarning, OutdatedCredential) =>
+      case (Warning, OutdatedCredential) =>
+        logger.info(s"Dry run: Would send warning for ${awsAccount}, ${iamUser}")
+        Attempt.Right("dummy-warning")
+
+      case (FinalWarning, OutdatedCredential) if !dryRun =>
         val notification =
           AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
         for {
@@ -66,7 +72,11 @@ class IamOutdatedCredentials(
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
         } yield snsId
 
-      case (Remediation, OutdatedCredential) =>
+      case (FinalWarning, OutdatedCredential) =>
+        logger.info(s"Dry run: Would send final warning for ${awsAccount}, ${iamUser}")
+        Attempt.Right("dummy-finalWarning")
+
+      case (Remediation, OutdatedCredential) if !dryRun =>
         val notification =
           AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
         for {
@@ -84,6 +94,11 @@ class IamOutdatedCredentials(
           // save a record of the change
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
         } yield notificationId
+
+      case (Remediation, OutdatedCredential)=>
+        logger.info(s"Dry run: Would execute remediation for ${awsAccount}, ${iamUser}")
+        Attempt.Right("dummy-remediation")
+
     }
   }
 
@@ -134,7 +149,7 @@ class IamOutdatedCredentials(
       _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(dummyOperation)
       // now we know what operations need to be performed, so let's run each of those
       results <- Attempt.traverse(filteredOperations.allowedOperations)(
-        performRemediationOperation(_, now, notificationTopicArn, tableName)
+        performRemediationOperation(_, now, notificationTopicArn, tableName, dryRun)
       )
     } yield results
     result.tap {

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -1,21 +1,162 @@
 package logic
 
+import aws.AwsClients
+import aws.iam.IAMClient
 import com.typesafe.scalalogging.LazyLogging
 import config.CoreConfig
 import config.CoreConfig.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
 import db.IamRemediationDb
+import logic.IamOutdatedCredentials.*
+import logic.IamUnrecognisedUsers.*
 import model.*
-import org.joda.time.{DateTime, Days}
+import notifications.AnghammaradNotifications
+import org.joda.time.DateTime
+import software.amazon.awssdk.services.iam.IamAsyncClient
+import software.amazon.awssdk.services.sns.SnsAsyncClient
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.ExecutionContext
 
+class IamOutdatedCredentials(
+    snsClient: SnsAsyncClient,
+    iamClients: AwsClients[IamAsyncClient],
+    dynamo: IamRemediationDb
+) extends LazyLogging {
+
+  /** Performs the specified operation, which will be one of:
+    *   - send a warning
+    *   - send a final warning
+    *   - disable an IAM credential and send a notification that this has been done
+    *   - remove an IAM password and send a notification that this has been done
+    */
+  private def performRemediationOperation(
+      remediationOperation: RemediationOperation,
+      now: DateTime,
+      notificationTopicArn: String,
+      tableName: String
+  )(implicit ec: ExecutionContext): Attempt[String] = {
+    val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
+    val iamUser = remediationOperation.vulnerableCandidate.iamUser
+    val problemCreationDate = remediationOperation.problemCreationDate
+    // if successful, this record will be added to the database
+    val thisRemediationActivity = IamRemediationActivity(
+      awsAccount.id,
+      iamUser.username,
+      now,
+      remediationOperation.iamRemediationActivityType,
+      remediationOperation.iamProblem,
+      remediationOperation.problemCreationDate
+    )
+
+    (remediationOperation.iamRemediationActivityType, remediationOperation.iamProblem) match {
+      // Outdated credentials
+      case (Warning, OutdatedCredential) =>
+        val notification =
+          AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
+        for {
+          snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+        } yield snsId
+
+      case (FinalWarning, OutdatedCredential) =>
+        val notification =
+          AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
+        for {
+          snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+        } yield snsId
+
+      case (Remediation, OutdatedCredential) =>
+        val notification =
+          AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
+        for {
+          // disable the correct credential
+          userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
+          credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
+          _ <- IAMClient.disableAccessKey(
+            awsAccount,
+            credentialToDisable.username,
+            credentialToDisable.accessKeyId,
+            iamClients
+          )
+          // send a notification to say this is what we have done
+          notificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+          // save a record of the change
+          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+        } yield notificationId
+    }
+  }
+
+  /** We only perform actions on accounts that are explicitly allowed, but it is helpful to log the operation that
+    * *would* have been performed, if allowed.
+    */
+  private def dummyOperation(remediationOperation: RemediationOperation): Unit = {
+    val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
+    logger.warn(s"Remediation operation skipped because ${awsAccount.id} is not configured for remediation")
+    logger.warn(s"Skipping remediation action: ${formatRemediationOperation(remediationOperation)}")
+  }
+
+  /** If an AWS access key has not been rotated in a long time, then will automatically disable it.
+    *
+    * This job will first send a warning notification when it detects an outdated credential. If nothing changes it will
+    * send a final warning notification. After both these notifications have been ignored, the credential will be
+    * automatically disabled.
+    */
+  def disableOutdatedCredentials(
+      notificationTopicArn: String,
+      tableName: String,
+      serviceAccountIds: List[String],
+      rawCredsReports: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]],
+      allowedAwsAccountIds: List[String]
+  )(implicit ec: ExecutionContext): Attempt[Unit] = {
+    val now = new DateTime()
+    val accountsCredReports = getCredsReportDisplayForAccount(rawCredsReports)
+    val accountUsersWithOutdatedCredentials = identifyAllUsersWithOutdatedCredentials(accountsCredReports, now)
+
+    val result = for {
+      // fetch IAM data from the application cache
+      // identify users with outdated credentials for each account, from the credentials report
+      // DB lookup of previous SHQ activity for each user to produce a list of "candidate" vulnerabilities
+      vulnerabilitiesWithRemediationHistory <- lookupActivityHistory(
+        accountUsersWithOutdatedCredentials,
+        dynamo,
+        tableName
+      )
+      // based on activity history, decide which of these candidates have outstanding SHQ operations
+      outstandingOperations = calculateOutstandingAccessKeyOperations(vulnerabilitiesWithRemediationHistory, now)
+      // we'll only perform operations on accounts that have been configured as eligible
+      filteredOperations = partitionOperationsByAllowedAccounts(
+        outstandingOperations,
+        allowedAwsAccountIds,
+        serviceAccountIds
+      )
+      // we won't execute these operations, but can log them instead
+      _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(dummyOperation)
+      // now we know what operations need to be performed, so let's run each of those
+      results <- Attempt.traverse(filteredOperations.allowedOperations)(
+        performRemediationOperation(_, now, notificationTopicArn, tableName)
+      )
+    } yield results
+    result.tap {
+      case Left(failedAttempt) =>
+        logger.error(
+          s"Failure during 'disable outdated credentials' job: ${failedAttempt.logMessage}",
+          failedAttempt.firstException.orNull // make sure the exception goes into the log, if present
+        )
+      case Right(operationIds) =>
+        logger.info(
+          s"Successfully completed 'disable outdated credentials' job, with ${operationIds.length} operations"
+        )
+    }.unit
+  }
+
+}
 object IamOutdatedCredentials extends LazyLogging {
 
   /** Look through all credentials reports to find users with expired credentials, see below for more detail
     * (`identifyUsersWithOutdatedCredentials`).
     */
-  def identifyAllUsersWithOutdatedCredentials(
+  private def identifyAllUsersWithOutdatedCredentials(
       accountCredentialReports: List[(AwsAccount, CredentialReportDisplay)],
       now: DateTime
   ): List[(AwsAccount, List[IAMUser])] = {
@@ -63,7 +204,7 @@ object IamOutdatedCredentials extends LazyLogging {
 
   /** Given an IAMUser (in an AWS account), look up that user's activity history form the Database.
     */
-  def lookupActivityHistory(
+  private def lookupActivityHistory(
       accountIdentifiedUsers: List[(AwsAccount, List[IAMUser])],
       dynamo: IamRemediationDb,
       tableName: String
@@ -87,7 +228,7 @@ object IamOutdatedCredentials extends LazyLogging {
     * the same user could appear in the output list twice, because both of their keys may require an operation. By
     * comparing the current date with the date of the most recent activity, we know which operation to perform next.
     */
-  def calculateOutstandingAccessKeyOperations(
+  private def calculateOutstandingAccessKeyOperations(
       remediationHistories: List[IamUserRemediationHistory],
       now: DateTime
   ): List[RemediationOperation] = {
@@ -204,7 +345,7 @@ object IamOutdatedCredentials extends LazyLogging {
     * AWS accounts to run the IamRemediationService on, because not all accounts are in a ready state for this service
     * yet.
     */
-  def partitionOperationsByAllowedAccounts(
+  private def partitionOperationsByAllowedAccounts(
       operations: List[RemediationOperation],
       allowedAwsAccountIds: List[String],
       serviceAccountIds: List[String]
@@ -222,7 +363,7 @@ object IamOutdatedCredentials extends LazyLogging {
     *
     * This might fail, because it may be that no matching key exists.
     */
-  def lookupCredentialId(
+  private def lookupCredentialId(
       badKeyCreationDate: DateTime,
       userCredentials: List[CredentialMetadata]
   ): Attempt[CredentialMetadata] = {
@@ -256,7 +397,7 @@ object IamOutdatedCredentials extends LazyLogging {
     }
   }
 
-  def formatRemediationOperation(remediationOperation: RemediationOperation): String = {
+  private def formatRemediationOperation(remediationOperation: RemediationOperation): String = {
     val problem = remediationOperation.iamProblem
     val activity = remediationOperation.iamRemediationActivityType
     val username = remediationOperation.vulnerableCandidate.iamUser.username

--- a/script/setup
+++ b/script/setup
@@ -44,7 +44,6 @@ downloadConfig() {
     # BSD sed (macOS)
     sed -i '' 's|"/Users/ADD_YOUR_NAME|${HOME}"|g' ~/.gu/security-hq/security-hq.local.conf
   fi
-}
 
 startDynamoDb() {
   docker-compose up -d


### PR DESCRIPTION
## What does this change?

This PR abstracts only only the IAMOutdatedCredentials class and object into a separate subproject as a precursor to creating a lambda to handle the function.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
