### PR TITLE
chore: Add dev policy for running Security HQ lambdas

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,5 +1,5 @@
 import "source-map-support/register";
-import { GuRoot } from '@guardian/cdk/lib/constructs/root';
+import { GuRoot } from "@guardian/cdk/lib/constructs/root";
 import { SecurityHQ } from "../lib/security-hq";
 
 const app = new GuRoot();

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -42,6 +42,7 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuDeveloperPolicyExperimental",
+      "GuDeveloperPolicyExperimental",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
     ],
@@ -1211,6 +1212,78 @@ exports[`HQ stack matches the snapshot 1`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RunSecurityHqLocallyPolicyF7855C97": {
+      "Properties": {
+        "Description": "Run Security HQ lambdas locally",
+        "Path": "/developer-policy/guardian/security-hq/security/PROD/security-hq-dev/",
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:GetCallerIdentity",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": "ssm:GetParameter",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/account/services/artifact.bucket",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/security/DEV/security-hq/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/security/PROD/security-hq/security-hq.conf",
+                  ],
+                ],
+              },
+              "Sid": "LoadAccountConfig",
+            },
+            {
+              "Action": "ec2:DescribeRegions",
+              "Effect": "Allow",
+              "Resource": "*",
+              "Sid": "DiscoverRegions",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::IAM::ManagedPolicy",
     },
     "S3AuditRead9DF4AE59": {
       "Properties": {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -126,9 +126,13 @@ export class SecurityHQ extends GuStack {
     const guDynamoDBReadPolicy = new GuDynamoDBReadPolicy(this, "DynamoRead", {
       tableName: table.tableName,
     });
-    const guDynamoDBWritePolicy = new GuDynamoDBWritePolicy(this, "DynamoWrite", {
-      tableName: table.tableName,
-    });
+    const guDynamoDBWritePolicy = new GuDynamoDBWritePolicy(
+      this,
+      "DynamoWrite",
+      {
+        tableName: table.tableName,
+      },
+    );
     // Allow security HQ to assume roles in watched accounts.
     const guAssumeRolePolicy = new GuAllowPolicy(this, "AssumeRole", {
       resources: ["*"],
@@ -159,7 +163,7 @@ export class SecurityHQ extends GuStack {
       },
       app: "security-hq",
       applicationPort: 9000,
-      imageRecipe: 'arm64-jammy-java21-security',
+      imageRecipe: "arm64-jammy-java21-security",
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.LARGE),
       certificateProps: {
         domainName,
@@ -302,6 +306,19 @@ export class SecurityHQ extends GuStack {
       ],
     });
 
+    new GuDeveloperPolicyExperimental(this, "RunSecurityHqLocallyPolicy", {
+      grantId: "security-hq-dev",
+      friendlyName: "Run Security HQ lambdas locally",
+      withoutPolicyChecks: true,
+      statements: [
+        this.getCallerIdentityPolicy(),
+        this.getArtifactBucketParameterPolicy(),
+        this.getLocalDevConfigS3Policy(distBucket.valueAsString),
+        this.loadAccountConfigPolicy(distBucket.valueAsString),
+        this.discoverRegionsPolicy(),
+      ],
+    });
+
     const iamOutdatedCredentialsLambdaAdditionalPolicies = [
       GuAnghammaradSenderPolicy.getInstance(this),
       guPutCloudwatchMetricsPolicy,
@@ -312,37 +329,41 @@ export class SecurityHQ extends GuStack {
       guDescribeRegionsPolicy,
     ];
 
-
-    const iamOutdatedCredentialsLambda = new GuScheduledLambda(this, "iam-outdated-credentials", {
-      monitoringConfiguration: {
-        // Tolerates 0 failures (triggers an alarm if any execution fails)
-        toleratedErrorPercentage: 0,
-        snsTopicName: GuAnghammaradTopicParameter.getInstance(this).valueAsString,
-      },
-      rules: [
-        {
-          schedule: Schedule.cron({
-            minute: '0',
-            hour: '9,14',
-            weekDay: 'MON-FRI'
-          }),
-          description: "Run iam-outdated-credentials lambda, Monday-Friday at 9AM and 2PM",
+    const iamOutdatedCredentialsLambda = new GuScheduledLambda(
+      this,
+      "iam-outdated-credentials",
+      {
+        monitoringConfiguration: {
+          // Tolerates 0 failures (triggers an alarm if any execution fails)
+          toleratedErrorPercentage: 0,
+          snsTopicName:
+            GuAnghammaradTopicParameter.getInstance(this).valueAsString,
         },
-      ],
-      app: "iam-outdated-credentials",
-      runtime: Runtime.JAVA_21,
-      handler: 'logic.IamOutdatedCredentialsLambda::handleRequest',
-      timeout: Duration.minutes(10),
-      environment: {
-        "STACK": this.stack,
-        "STAGE": this.stage,
-        "DRY_RUN": "true",
-        "CONFIG_BUCKET": "security-dist",
-        "CONFIG_KEY": `security/${this.stage}/security-hq/security-hq.conf`
+        rules: [
+          {
+            schedule: Schedule.cron({
+              minute: "0",
+              hour: "9,14",
+              weekDay: "MON-FRI",
+            }),
+            description:
+              "Run iam-outdated-credentials lambda, Monday-Friday at 9AM and 2PM",
+          },
+        ],
+        app: "iam-outdated-credentials",
+        runtime: Runtime.JAVA_21,
+        handler: "logic.IamOutdatedCredentialsLambda::handleRequest",
+        timeout: Duration.minutes(10),
+        environment: {
+          STACK: this.stack,
+          STAGE: this.stage,
+          DRY_RUN: "true",
+          CONFIG_BUCKET: "security-dist",
+          CONFIG_KEY: `security/${this.stage}/security-hq/security-hq.conf`,
+        },
+        fileName: `iam-outdated-credentials-${buildIdentifier}.jar`,
       },
-      fileName: `iam-outdated-credentials-${buildIdentifier}.jar`
-
-    })
+    );
     iamOutdatedCredentialsLambdaAdditionalPolicies.forEach((policy) => {
       iamOutdatedCredentialsLambda.role!.attachInlinePolicy(policy);
     });
@@ -377,6 +398,57 @@ export class SecurityHQ extends GuStack {
           "ssm:resourceTag/aws:autoscaling:groupName": [`${asgArn}`],
         },
       },
+    });
+  }
+
+  private getCallerIdentityPolicy() {
+    // Used by setup to check that valid, non-expired credentials are configured
+    return new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["sts:GetCallerIdentity"],
+      resources: ["*"],
+    });
+  }
+
+  private getArtifactBucketParameterPolicy() {
+    // Used by setup to look up distribution bucket name
+    return new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["ssm:GetParameter"],
+      resources: [
+        `arn:aws:ssm:${this.region}:${this.account}:parameter/account/services/artifact.bucket`,
+      ],
+    });
+  }
+
+  private getLocalDevConfigS3Policy(bucketName: string) {
+    // Used by setup to download local dev configuration and service account cert
+    return new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["s3:GetObject"],
+      resources: [`arn:aws:s3:::${bucketName}/security/DEV/security-hq/*`],
+    });
+  }
+
+  private loadAccountConfigPolicy(bucketName: string) {
+    // Used by lambdas to load the security-hq.conf file
+    return new PolicyStatement({
+      sid: "LoadAccountConfig",
+      effect: Effect.ALLOW,
+      actions: ["s3:GetObject"],
+      resources: [
+        `arn:aws:s3:::${bucketName}/security/${this.stage}/security-hq/security-hq.conf`,
+      ],
+    });
+  }
+
+  private discoverRegionsPolicy() {
+    // Used by lambdas to get a list of regions
+    return new PolicyStatement({
+      sid: "DiscoverRegions",
+      effect: Effect.ALLOW,
+      actions: ["ec2:DescribeRegions"],
+      resources: ["*"],
     });
   }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -9,6 +9,7 @@
     "tsc": "tsc",
     "test": "jest",
     "format": "prettier --write \"{lib,bin}/**/*.ts\"",
+    "format:check": "prettier --check \"{lib,bin}/**/*.ts\"",
     "cdk": "cdk",
     "lint": "eslint --no-error-on-unmatched-pattern",
     "diff": "cdk diff --path-metadata false --version-reporting false",

--- a/cdk/script/ci
+++ b/cdk/script/ci
@@ -4,5 +4,6 @@ set -e
 
 npm ci
 npm run lint
+npm run format:check
 npm test
 npm run synth


### PR DESCRIPTION
## What does this change?
Adds a dev policy, initially by guesswork, that should allow all the steps in the setup script and running the new lambda code locally.

Have also added a formatting check to CI as the pre-existing `format` npm task was breaking locally.
So there's a few formatting changes to existing code.

## What is the value of this?
We no longer need to use the dev permission to run SHQ.

## Will this require CloudFormation and/or updates to the AWS StackSet?
It should trigger an automatic update to cloudformation.

## Will this require changes to config?
No.

## Any additional notes?
This is part of the general migration of the SHQ play app services to standalone lambdas.
See:
* [overarching Asana ticket](https://app.asana.com/1/1210045093164357/project/1214110347938932/task/1214109339123725?focus=true)
* [Associated dev policy grant](https://github.com/guardian/janus/pull/5619)
