### PR TITLE
Switch to GuRoot to get generated riff-raff.yaml

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,8 +1,8 @@
 import "source-map-support/register";
-import { App } from "aws-cdk-lib";
+import { GuRoot } from '@guardian/cdk/lib/constructs/root';
 import { SecurityHQ } from "../lib/security-hq";
 
-const app = new App();
+const app = new GuRoot();
 
 new SecurityHQ(app, "security-hq", {
   stack: "security",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -124,6 +124,7 @@ export class SecurityHQ extends GuStack {
       },
       app: "security-hq",
       applicationPort: 9000,
+      imageRecipe: 'arm64-jammy-java21-security',
       instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.LARGE),
       certificateProps: {
         domainName,


### PR DESCRIPTION
## What does this change?

This PR uses GuRoot instead of App in the cdk definition, which triggers the creation of a riff-raff.yaml file.

A future PR will switch to use this new riff-raff.yaml file for deployment.

Tested by running `npm run synth`.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
