### PR TITLE
Put template in the location expected by generated riff raff yaml

### DIFF
--- a/.github/workflows/ci-sbt.yml
+++ b/.github/workflows/ci-sbt.yml
@@ -57,7 +57,7 @@ jobs:
           configPath: cdk/cdk.out/riff-raff.yaml
 
           contentDirectories: |
-            security-hq-cfn:
+            cdk.out:
               - cdk/cdk.out/security-hq.template.json
             security-hq:
               - dist


### PR DESCRIPTION
## What does this change?

The cdk generated riff raff yaml is expected to be in its default location (cdk.out).  Our existing deploy moved it to a different location.  This PR puts it back in the default location.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?



<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
