### PR TITLE
Change Lambda handler to ignore event

### DIFF
--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentialsLambda.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentialsLambda.scala
@@ -1,27 +1,24 @@
 package logic
 
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import settings.Settings
 
+import java.io.{InputStream, OutputStream}
 import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext}
 
-class IamOutdatedCredentialsLambda extends RequestHandler[Map[String, String], String] {
+class IamOutdatedCredentialsLambda extends RequestStreamHandler {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
 
-  override def handleRequest(
-      event: Map[String, String],
-      context: Context
-  ): String = {
+  override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
 
     val settings = Settings.fromEnvironment()
 
     val result = IamOutdatedCredentials.disableOutdatedCredentials(settings)
 
     Await.result(result.underlying, 10.minutes) match {
-      case Right(_) =>
-        "Success"
+      case Right(_) => ()
 
       case Left(failedAttempt) =>
         throw new RuntimeException(
@@ -30,4 +27,5 @@ class IamOutdatedCredentialsLambda extends RequestHandler[Map[String, String], S
         )
     }
   }
+
 }


### PR DESCRIPTION
## What does this change?

The previous implementation assumed a useful event.  We do not, in fact use the event, and worse, we don't have anything in scope that can parse it.  So: don't.


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
