### PR TITLE
Add config read permissions for outdated-credentials lambda

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -9,6 +9,7 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuPutCloudwatchMetricsPolicy",
       "GuGetS3ObjectsPolicy",
+      "GuGetS3ObjectsPolicy",
       "GuDynamoDBReadPolicy",
       "GuDynamoDBWritePolicy",
       "GuAllowPolicy",
@@ -1332,6 +1333,38 @@ exports[`HQ stack matches the snapshot 1`] = `
           },
           {
             "Ref": "iamunrecognisedusersServiceRole58E0D3DD",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "S3ConfigRead61D038C2": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:s3:::",
+                    {
+                      "Ref": "DistributionBucketName",
+                    },
+                    "/security/PROD/undefined/security-hq.conf",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "S3ConfigRead61D038C2",
+        "Roles": [
+          {
+            "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
         ],
       },

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -9,7 +9,7 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuStringParameter",
       "GuPutCloudwatchMetricsPolicy",
       "GuGetS3ObjectsPolicy",
-      "GuGetS3ObjectsPolicy",
+      "GuPolicy",
       "GuDynamoDBReadPolicy",
       "GuDynamoDBWritePolicy",
       "GuAllowPolicy",
@@ -1274,18 +1274,7 @@ exports[`HQ stack matches the snapshot 1`] = `
             {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {
-                      "Ref": "DistributionBucketName",
-                    },
-                    "/security/PROD/security-hq/security-hq.conf",
-                  ],
-                ],
-              },
+              "Resource": "security/PROD/security-hq/security-hq.conf",
               "Sid": "LoadAccountConfig",
             },
             {
@@ -1345,18 +1334,8 @@ exports[`HQ stack matches the snapshot 1`] = `
             {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {
-                      "Ref": "DistributionBucketName",
-                    },
-                    "/security/PROD/undefined/security-hq.conf",
-                  ],
-                ],
-              },
+              "Resource": "security/PROD/security-hq/security-hq.conf",
+              "Sid": "LoadAccountConfig",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -119,9 +119,14 @@ export class SecurityHQ extends GuStack {
     dpkg -i /tmp/installer.deb`);
 
     const guPutCloudwatchMetricsPolicy = new GuPutCloudwatchMetricsPolicy(this);
-    const guGetS3ObjectsPolicy = new GuGetS3ObjectsPolicy(this, "S3AuditRead", {
+    const guGetS3AuditObjectsPolicy = new GuGetS3ObjectsPolicy(this, "S3AuditRead", {
       bucketName: auditDataS3BucketName.valueAsString,
       paths: [auditDataS3BucketPath],
+    });
+    const configS3BucketPath = `${this.stack}/${this.stage}/${this.app}/security-hq.conf`;
+    const guGetS3ConfigObjectsPolicy = new GuGetS3ObjectsPolicy(this, "S3ConfigRead", {
+      bucketName: distBucket.valueAsString,
+      paths: [configS3BucketPath],
     });
     const guDynamoDBReadPolicy = new GuDynamoDBReadPolicy(this, "DynamoRead", {
       tableName: table.tableName,
@@ -146,7 +151,7 @@ export class SecurityHQ extends GuStack {
     const appAdditionalPolicies = [
       GuAnghammaradSenderPolicy.getInstance(this),
       guPutCloudwatchMetricsPolicy,
-      guGetS3ObjectsPolicy,
+      guGetS3AuditObjectsPolicy,
       guDynamoDBReadPolicy,
       guDynamoDBWritePolicy,
       guAssumeRolePolicy,
@@ -322,7 +327,8 @@ export class SecurityHQ extends GuStack {
     const iamOutdatedCredentialsLambdaAdditionalPolicies = [
       GuAnghammaradSenderPolicy.getInstance(this),
       guPutCloudwatchMetricsPolicy,
-      guGetS3ObjectsPolicy,
+      guGetS3AuditObjectsPolicy,
+      guGetS3ConfigObjectsPolicy,
       guDynamoDBReadPolicy,
       guDynamoDBWritePolicy,
       guAssumeRolePolicy,
@@ -371,7 +377,7 @@ export class SecurityHQ extends GuStack {
     const iamUnrecognisedUsersLambdaAdditionalPolicies = [
       GuAnghammaradSenderPolicy.getInstance(this),
       guPutCloudwatchMetricsPolicy,
-      guGetS3ObjectsPolicy,
+      guGetS3AuditObjectsPolicy,
       guAssumeRolePolicy,
       guDescribeRegionsPolicy,
     ];

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -119,15 +119,23 @@ export class SecurityHQ extends GuStack {
     dpkg -i /tmp/installer.deb`);
 
     const guPutCloudwatchMetricsPolicy = new GuPutCloudwatchMetricsPolicy(this);
-    const guGetS3AuditObjectsPolicy = new GuGetS3ObjectsPolicy(this, "S3AuditRead", {
-      bucketName: auditDataS3BucketName.valueAsString,
-      paths: [auditDataS3BucketPath],
-    });
+    const guGetS3AuditObjectsPolicy = new GuGetS3ObjectsPolicy(
+      this,
+      "S3AuditRead",
+      {
+        bucketName: auditDataS3BucketName.valueAsString,
+        paths: [auditDataS3BucketPath],
+      },
+    );
     const configS3BucketPath = `${this.stack}/${this.stage}/${this.app}/security-hq.conf`;
-    const guGetS3ConfigObjectsPolicy = new GuGetS3ObjectsPolicy(this, "S3ConfigRead", {
-      bucketName: distBucket.valueAsString,
-      paths: [configS3BucketPath],
-    });
+    const guGetS3ConfigObjectsPolicy = new GuGetS3ObjectsPolicy(
+      this,
+      "S3ConfigRead",
+      {
+        bucketName: distBucket.valueAsString,
+        paths: [configS3BucketPath],
+      },
+    );
     const guDynamoDBReadPolicy = new GuDynamoDBReadPolicy(this, "DynamoRead", {
       tableName: table.tableName,
     });

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -2,8 +2,8 @@ import { GuScheduledLambda } from "@guardian/cdk";
 import { AccessScope } from "@guardian/cdk/lib/constants";
 import { GuAlarm } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
-import { GuAnghammaradTopicParameter } from "@guardian/cdk/lib/constructs/core";
 import {
+  GuAnghammaradTopicParameter,
   GuDistributionBucketParameter,
   GuParameter,
   GuStack,
@@ -18,6 +18,7 @@ import {
   GuDynamoDBReadPolicy,
   GuDynamoDBWritePolicy,
   GuGetS3ObjectsPolicy,
+  GuPolicy,
   GuPutCloudwatchMetricsPolicy,
 } from "@guardian/cdk/lib/constructs/iam";
 import { GuAnghammaradSenderPolicy } from "@guardian/cdk/lib/constructs/iam/policies/anghammarad";
@@ -127,15 +128,15 @@ export class SecurityHQ extends GuStack {
         paths: [auditDataS3BucketPath],
       },
     );
-    const configS3BucketPath = `${this.stack}/${this.stage}/${this.app}/security-hq.conf`;
-    const guGetS3ConfigObjectsPolicy = new GuGetS3ObjectsPolicy(
-      this,
-      "S3ConfigRead",
-      {
-        bucketName: distBucket.valueAsString,
-        paths: [configS3BucketPath],
-      },
-    );
+    const configS3BucketPath = `${this.stack}/${this.stage}/${SecurityHQ.app.app}/security-hq.conf`;
+    const guGetS3ConfigObjectsPolicy = new GuPolicy(this, "S3ConfigRead", {
+      statements: [
+        this.loadAccountConfigPolicy(
+          distBucket.valueAsString,
+          configS3BucketPath,
+        ),
+      ],
+    });
     const guDynamoDBReadPolicy = new GuDynamoDBReadPolicy(this, "DynamoRead", {
       tableName: table.tableName,
     });
@@ -327,7 +328,10 @@ export class SecurityHQ extends GuStack {
         this.getCallerIdentityPolicy(),
         this.getArtifactBucketParameterPolicy(),
         this.getLocalDevConfigS3Policy(distBucket.valueAsString),
-        this.loadAccountConfigPolicy(distBucket.valueAsString),
+        this.loadAccountConfigPolicy(
+          distBucket.valueAsString,
+          configS3BucketPath,
+        ),
         this.discoverRegionsPolicy(),
       ],
     });
@@ -493,15 +497,13 @@ export class SecurityHQ extends GuStack {
     });
   }
 
-  private loadAccountConfigPolicy(bucketName: string) {
+  private loadAccountConfigPolicy(bucketName: string, path: string) {
     // Used by lambdas to load the security-hq.conf file
     return new PolicyStatement({
       sid: "LoadAccountConfig",
       effect: Effect.ALLOW,
       actions: ["s3:GetObject"],
-      resources: [
-        `arn:aws:s3:::${bucketName}/security/${this.stage}/security-hq/security-hq.conf`,
-      ],
+      resources: [path],
     });
   }
 


### PR DESCRIPTION
## What does this change?

This permission appears to be implicit for the app, but needs to be explicit for a lambda. 

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
