### PR TITLE
Fix instant conversion

### DIFF
--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -159,7 +159,7 @@ object IAMClient extends LazyLogging {
                 )
               }
           }
-        } yield CredentialMetadata(akm.userName, akm.accessKeyId, new DateTime(akm.createDate), credentialStatus)
+        } yield CredentialMetadata(akm.userName, akm.accessKeyId, new DateTime(akm.createDate.toEpochMilli), credentialStatus)
       }
     } yield credentialMetadatas
   }


### PR DESCRIPTION
## What does this change?

We have an error in the existing app, during the outdated credentials job, at this line:

```
	at aws.iam.IAMClient$.listUserAccessKeys$$anonfun$1$$anonfun$2$$anonfun$1$$anonfun$1(IAMClient.scala:162)
```

Extraordinarily, it isn't failing during the lambda execution of the outdated credentials job.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
