### PR TITLE
Add dryrun settings for remediation within app

### DIFF
--- a/core/src/main/scala/logic/IamUnrecognisedUsers.scala
+++ b/core/src/main/scala/logic/IamUnrecognisedUsers.scala
@@ -102,7 +102,7 @@ object IamUnrecognisedUsers extends LazyLogging {
   def disableAccountAccessKeys(
       accountUnrecognisedKeys: AccountUnrecognisedAccessKeys,
       iamClients: AwsClients[IamAsyncClient],
-      dryRun: Boolean = false
+      dryRun: Boolean
   )(implicit ec: ExecutionContext): Attempt[List[UpdateAccessKeyResponse]] = {
     if (!dryRun) {
       val AccountUnrecognisedAccessKeys(account, accessKeys) = accountUnrecognisedKeys
@@ -140,7 +140,7 @@ object IamUnrecognisedUsers extends LazyLogging {
   def removeAccountPasswords(
       accountUnrecognisedUsers: AccountUnrecognisedUsers,
       iamClients: AwsClients[IamAsyncClient],
-      dryRun: Boolean = false
+      dryRun: Boolean
   )(implicit ec: ExecutionContext): Attempt[List[Option[DeleteLoginProfileResponse]]] = {
     if (!dryRun) {
       val results = Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
@@ -169,7 +169,7 @@ object IamUnrecognisedUsers extends LazyLogging {
 
   def unrecognisedUserNotifications(
       accountUsers: List[AccountUnrecognisedUsers],
-      dryRun: Boolean = false
+      dryRun: Boolean
   ): List[Notification] = {
     if (!dryRun) {
       accountUsers.flatMap { case AccountUnrecognisedUsers(account, users) =>

--- a/core/src/main/scala/model/iamremediation.scala
+++ b/core/src/main/scala/model/iamremediation.scala
@@ -81,5 +81,6 @@ case class UnrecognisedJobConfigProperties(
     janusDataFileKey: String,
     janusUserBucket: String,
     securityAccount: AwsAccount,
-    anghammaradSnsTopicArn: String
+    anghammaradSnsTopicArn: String,
+    dryRun: Boolean
 )

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -5,7 +5,7 @@ import com.gu.googleauth.{AntiForgeryChecker, GoogleAuthConfig, GoogleGroupCheck
 import com.gu.play.secretrotation.aws.parameterstore.{AwsSdkV2, SecretSupplier}
 import com.gu.play.secretrotation.{SnapshotProvider, TransitionTiming}
 import model.*
-import play.api.Configuration
+import play.api.{Configuration, Logging}
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssm.SsmClient
 import utils.attempt.{Attempt, FailedAttempt, Failure}
@@ -16,7 +16,7 @@ import scala.concurrent.ExecutionContext
 import scala.jdk.CollectionConverters.*
 import scala.util.Try
 
-object Config {
+object Config extends Logging {
   val app = "security-hq"
 
   val documentationLinks: List[Documentation] = List(
@@ -135,19 +135,23 @@ object Config {
     )
   }
 
-  def getUnrecognisedUserDryRun(config: Configuration): Attempt[Boolean] = {
+  def getUnrecognisedUserDryRun(config: Configuration)(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
     Attempt.Right(
       // Default to true; only an explicit "false" disables dry-run.
       // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
       !config.getOptional[String]("unrecognisedUser.dryRun").getOrElse("true").equalsIgnoreCase("false")
+    ).tap(b =>
+      logger.info(s"unrecognisedUser.dryRun is set to ${b}")
     )
   }
 
-  def getOutdatedCredentialsDryRun(config: Configuration): Attempt[Boolean] = {
+  def getOutdatedCredentialsDryRun(config: Configuration)(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
     Attempt.Right(
       // Default to true; only an explicit "false" disables dry-run.
       // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
       !config.getOptional[String]("outdatedCredentials.dryRun").getOrElse("true").equalsIgnoreCase("false")
+    ).tap(b =>
+      logger.info(s"outdatedCredentials.dryRun is set to ${b}")
     )
   }
 

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -121,7 +121,7 @@ object Config extends Logging {
       bucket <- getIamUnrecognisedUserBucket(config)
       securityAccount <- getSecurityAccount(config)
       anghammaradSnsTopicArn <- getAnghammaradSNSTopicArn(config)
-      dryRun <- getUnrecognisedUserDryRun(config)
+      dryRun = getUnrecognisedUserDryRun(config)
     } yield UnrecognisedJobConfigProperties(accounts, key, bucket, securityAccount, anghammaradSnsTopicArn, dryRun)
   }
 
@@ -137,22 +137,18 @@ object Config extends Logging {
   // Default to true; only an explicit "false" disables dry-run.
   // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
   private[config] def getDryRun(config: Configuration, key: String) =
-    !config.getOptional[String](key).exists(_.equalsIgnoreCase("false"))
+    !config.getOptional[String](s"$key.dryRun").exists(_.equalsIgnoreCase("false"))
 
-  def getUnrecognisedUserDryRun(
-      config: Configuration
-  )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt
-      .Right(getDryRun(config, "unrecognisedUser.dryRun"))
-      .tap(b => logger.info(s"unrecognisedUser.dryRun is set to $b"))
+  def getUnrecognisedUserDryRun(config: Configuration): Boolean = {
+    val b = getDryRun(config, "unrecognisedUser")
+    logger.info(s"unrecognisedUser dry run is set to $b")
+    b
   }
 
-  def getOutdatedCredentialsDryRun(
-      config: Configuration
-  )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt
-      .Right(getDryRun(config, "outdatedCredentials.dryRun"))
-      .tap(b => logger.info(s"outdatedCredentials.dryRun is set to $b"))
+  def getOutdatedCredentialsDryRun(config: Configuration): Boolean = {
+    val b = getDryRun(config, "outdatedCredentials")
+    logger.info(s"outdatedCredentials dry run is set to $b")
+    b
   }
 
   def getAccountsForIamRemediationService(config: Configuration): Attempt[List[String]] = {

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -134,28 +134,22 @@ object Config extends Logging {
     )
   }
 
+  // Default to true; only an explicit "false" disables dry-run.
+  // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
+  private[config] def getDryRun(config: Configuration, key: String) = !config.getOptional[String](key).exists(_.equalsIgnoreCase("false"))
+
   def getUnrecognisedUserDryRun(
       config: Configuration
   )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt
-      .Right(
-        // Default to true; only an explicit "false" disables dry-run.
-        // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
-        config.getOptional[String]("unrecognisedUser.dryRun").exists(_.equalsIgnoreCase("false"))
-      )
-      .tap(b => logger.info(s"unrecognisedUser.dryRun is set to ${b}"))
+    Attempt.Right(getDryRun(config, "unrecognisedUser.dryRun"))
+      .tap(b => logger.info(s"unrecognisedUser.dryRun is set to $b"))
   }
 
   def getOutdatedCredentialsDryRun(
       config: Configuration
   )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt
-      .Right(
-        // Default to true; only an explicit "false" disables dry-run.
-        // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
-        config.getOptional[String]("outdatedCredentials.dryRun").exists(_.equalsIgnoreCase("false"))
-      )
-      .tap(b => logger.info(s"outdatedCredentials.dryRun is set to ${b}"))
+    Attempt.Right(getDryRun(config, "outdatedCredentials.dryRun"))
+      .tap(b => logger.info(s"outdatedCredentials.dryRun is set to $b"))
   }
 
   def getAccountsForIamRemediationService(config: Configuration): Attempt[List[String]] = {

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -136,19 +136,22 @@ object Config extends Logging {
 
   // Default to true; only an explicit "false" disables dry-run.
   // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
-  private[config] def getDryRun(config: Configuration, key: String) = !config.getOptional[String](key).exists(_.equalsIgnoreCase("false"))
+  private[config] def getDryRun(config: Configuration, key: String) =
+    !config.getOptional[String](key).exists(_.equalsIgnoreCase("false"))
 
   def getUnrecognisedUserDryRun(
       config: Configuration
   )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt.Right(getDryRun(config, "unrecognisedUser.dryRun"))
+    Attempt
+      .Right(getDryRun(config, "unrecognisedUser.dryRun"))
       .tap(b => logger.info(s"unrecognisedUser.dryRun is set to $b"))
   }
 
   def getOutdatedCredentialsDryRun(
       config: Configuration
   )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt.Right(getDryRun(config, "outdatedCredentials.dryRun"))
+    Attempt
+      .Right(getDryRun(config, "outdatedCredentials.dryRun"))
       .tap(b => logger.info(s"outdatedCredentials.dryRun is set to $b"))
   }
 

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -122,7 +122,8 @@ object Config {
       bucket <- getIamUnrecognisedUserBucket(config)
       securityAccount <- getSecurityAccount(config)
       anghammaradSnsTopicArn <- getAnghammaradSNSTopicArn(config)
-    } yield UnrecognisedJobConfigProperties(accounts, key, bucket, securityAccount, anghammaradSnsTopicArn)
+      dryRun <- getUnrecognisedUserDryRun(config)
+    } yield UnrecognisedJobConfigProperties(accounts, key, bucket, securityAccount, anghammaradSnsTopicArn, dryRun)
   }
 
   def getAnghammaradSNSTopicArn(config: Configuration): Attempt[String] = {
@@ -131,6 +132,22 @@ object Config {
       FailedAttempt(
         Failure("unable to get Anghammarad topic ARN", "unable to get Anghammarad topic ARN for IAM jobs", 500)
       )
+    )
+  }
+
+  def getUnrecognisedUserDryRun(config: Configuration): Attempt[Boolean] = {
+    Attempt.Right(
+      // Default to true; only an explicit "false" disables dry-run.
+      // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
+      !config.getOptional[String]("unrecognisedUser.dryRun").getOrElse("true").equalsIgnoreCase("false")
+    )
+  }
+
+  def getOutdatedCredentialsDryRun(config: Configuration): Attempt[Boolean] = {
+    Attempt.Right(
+      // Default to true; only an explicit "false" disables dry-run.
+      // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
+      !config.getOptional[String]("outdatedCredentials.dryRun").getOrElse("true").equalsIgnoreCase("false")
     )
   }
 

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -139,7 +139,7 @@ object Config extends Logging {
     Attempt.Right(
       // Default to true; only an explicit "false" disables dry-run.
       // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
-      !config.getOptional[String]("unrecognisedUser.dryRun").getOrElse("true").equalsIgnoreCase("false")
+      config.getOptional[String]("unrecognisedUser.dryRun").exists(_.equalsIgnoreCase("false"))
     ).tap(b =>
       logger.info(s"unrecognisedUser.dryRun is set to ${b}")
     )

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -149,7 +149,7 @@ object Config extends Logging {
     Attempt.Right(
       // Default to true; only an explicit "false" disables dry-run.
       // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
-      !config.getOptional[String]("outdatedCredentials.dryRun").getOrElse("true").equalsIgnoreCase("false")
+      config.getOptional[String]("outdatedCredentials.dryRun").exists(_.equalsIgnoreCase("false"))
     ).tap(b =>
       logger.info(s"outdatedCredentials.dryRun is set to ${b}")
     )

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -6,7 +6,6 @@ import com.gu.play.secretrotation.aws.parameterstore.{AwsSdkV2, SecretSupplier}
 import com.gu.play.secretrotation.{SnapshotProvider, TransitionTiming}
 import model.*
 import play.api.{Configuration, Logging}
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssm.SsmClient
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
@@ -135,24 +134,28 @@ object Config extends Logging {
     )
   }
 
-  def getUnrecognisedUserDryRun(config: Configuration)(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt.Right(
-      // Default to true; only an explicit "false" disables dry-run.
-      // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
-      config.getOptional[String]("unrecognisedUser.dryRun").exists(_.equalsIgnoreCase("false"))
-    ).tap(b =>
-      logger.info(s"unrecognisedUser.dryRun is set to ${b}")
-    )
+  def getUnrecognisedUserDryRun(
+      config: Configuration
+  )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
+    Attempt
+      .Right(
+        // Default to true; only an explicit "false" disables dry-run.
+        // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
+        config.getOptional[String]("unrecognisedUser.dryRun").exists(_.equalsIgnoreCase("false"))
+      )
+      .tap(b => logger.info(s"unrecognisedUser.dryRun is set to ${b}"))
   }
 
-  def getOutdatedCredentialsDryRun(config: Configuration)(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
-    Attempt.Right(
-      // Default to true; only an explicit "false" disables dry-run.
-      // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
-      config.getOptional[String]("outdatedCredentials.dryRun").exists(_.equalsIgnoreCase("false"))
-    ).tap(b =>
-      logger.info(s"outdatedCredentials.dryRun is set to ${b}")
-    )
+  def getOutdatedCredentialsDryRun(
+      config: Configuration
+  )(implicit executionContext: ExecutionContext): Attempt[Boolean] = {
+    Attempt
+      .Right(
+        // Default to true; only an explicit "false" disables dry-run.
+        // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid
+        config.getOptional[String]("outdatedCredentials.dryRun").exists(_.equalsIgnoreCase("false"))
+      )
+      .tap(b => logger.info(s"outdatedCredentials.dryRun is set to ${b}"))
   }
 
   def getAccountsForIamRemediationService(config: Configuration): Attempt[List[String]] = {

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -55,7 +55,11 @@ class IamRemediationService(
     val result = for {
       unrecognisedUsersConfig <- getIamUnrecognisedUserConfig(config)
       // fetch and parse our stored Janus config to use the canonical source of "recognised" usernames
-      s3Object <- getS3Object(securityS3Client, unrecognisedUsersConfig.janusUserBucket, unrecognisedUsersConfig.janusDataFileKey)
+      s3Object <- getS3Object(
+        securityS3Client,
+        unrecognisedUsersConfig.janusUserBucket,
+        unrecognisedUsersConfig.janusDataFileKey
+      )
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
       // look up the credentials report from the cache service as our source of current IAM users
@@ -71,9 +75,13 @@ class IamRemediationService(
         listAccountAccessKeys(_, iamClients)
       )
       // disable each access key for unrecognised users
-      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun))
+      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(
+        disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun)
+      )
       // remove passwords (i.e. login profiles) for each unrecognised user
-      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun))
+      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
+        removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun)
+      )
       // construct and send a notification for each unrecognised user
       notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
       notificationIds <- Attempt.traverse(notifications)(

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -118,11 +118,11 @@ class IamRemediationService(
   }
 
   private def disableOutdatedCredentials(): Attempt[Unit] = for {
-    dryRun <- Config.getOutdatedCredentialsDryRun(config)
     notificationTopicArn <- getAnghammaradSNSTopicArn(config)
     tableName <- getIamDynamoTableName(config)
     serviceAccountIds <- Config.getAccountsForIamRemediationService(config)
     rawCredsReports = cacheService.getAllCredentials
+    dryRun = Config.getOutdatedCredentialsDryRun(config)
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
     result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -71,11 +71,11 @@ class IamRemediationService(
         listAccountAccessKeys(_, iamClients)
       )
       // disable each access key for unrecognised users
-      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(disableAccountAccessKeys(_, iamClients))
+      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(disableAccountAccessKeys(_, iamClients, config.dryRun))
       // remove passwords (i.e. login profiles) for each unrecognised user
-      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(removeAccountPasswords(_, iamClients))
+      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(removeAccountPasswords(_, iamClients, config.dryRun))
       // construct and send a notification for each unrecognised user
-      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers)
+      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, config.dryRun)
       notificationIds <- Attempt.traverse(notifications)(
         AnghammaradNotifications.send(_, config.anghammaradSnsTopicArn, snsClient)
       )
@@ -101,9 +101,8 @@ class IamRemediationService(
           (now.getHourOfDay == 14 && now.getMinuteOfHour == 0)
 
         if (isWeekday && isTimeToRun) {
-//          disableOutdatedCredentials()
-//          disableUnrecognisedUsers()
-          logger.warn("NOT running IamRemediationService jobs to disable outdated credentials and unrecognised users.")
+          disableOutdatedCredentials()
+          disableUnrecognisedUsers()
         }
       }
 
@@ -111,13 +110,14 @@ class IamRemediationService(
   }
 
   private def disableOutdatedCredentials(): Attempt[Unit] = for {
+    dryRun <- Config.getOutdatedCredentialsDryRun(config)
     notificationTopicArn <- getAnghammaradSNSTopicArn(config)
     tableName <- getIamDynamoTableName(config)
     serviceAccountIds <- Config.getAccountsForIamRemediationService(config)
     rawCredsReports = cacheService.getAllCredentials
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun = false).disableOutdatedCredentials(
+    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
       notificationTopicArn,
       tableName,
       serviceAccountIds,

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -6,9 +6,8 @@ import com.gu.janus.JanusConfig
 import config.Config
 import config.Config.{getAnghammaradSNSTopicArn, getIamDynamoTableName, getIamUnrecognisedUserConfig}
 import db.IamRemediationDb
+import logic.IamUnrecognisedUsers
 import logic.IamUnrecognisedUsers.*
-import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
-import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
 import play.api.{Configuration, Environment, Mode}
@@ -74,20 +73,23 @@ class IamRemediationService(
       unrecognisedUserAccessKeys <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
         listAccountAccessKeys(_, iamClients)
       )
-      // disable each access key for unrecognised users
-      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(
-        disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun)
+      _ = logger.warn(
+        s"NOT running IamRemediationService jobs to disable unrecognised users.  Dry run flag is ${unrecognisedUsersConfig.dryRun}"
       )
-      // remove passwords (i.e. login profiles) for each unrecognised user
-      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
-        removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun)
-      )
-      // construct and send a notification for each unrecognised user
-      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
-      notificationIds <- Attempt.traverse(notifications)(
-        AnghammaradNotifications.send(_, unrecognisedUsersConfig.anghammaradSnsTopicArn, snsClient)
-      )
-    } yield notificationIds
+//      // disable each access key for unrecognised users
+//      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(
+//        disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun)
+//      )
+//      // remove passwords (i.e. login profiles) for each unrecognised user
+//      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
+//        removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun)
+//      )
+//      // construct and send a notification for each unrecognised user
+//      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
+//      notificationIds <- Attempt.traverse(notifications)(
+//        AnghammaradNotifications.send(_, unrecognisedUsersConfig.anghammaradSnsTopicArn, snsClient)
+//      )
+    } yield Nil // notificationIds
     result.tap {
       case Left(failedAttempt)    => logger.error(s"Failed to run unrecognised user job: ${failedAttempt.logMessage}")
       case Right(notificationIds) =>
@@ -125,12 +127,13 @@ class IamRemediationService(
     dryRun = Config.getOutdatedCredentialsDryRun(config)
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
-      notificationTopicArn,
-      tableName,
-      serviceAccountIds,
-      rawCredsReports,
-      allowedAwsAccountIds
-    )
-  } yield result
+    _ = logger.warn(s"NOT running IamRemediationService jobs to disable outdated credentials.  Dry run flag is $dryRun")
+//    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
+//      notificationTopicArn,
+//      tableName,
+//      serviceAccountIds,
+//      rawCredsReports,
+//      allowedAwsAccountIds
+//    )
+  } yield () // result
 }

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -53,9 +53,9 @@ class IamRemediationService(
     */
   private def disableUnrecognisedUsers()(implicit ec: ExecutionContext): Attempt[Unit] = {
     val result = for {
-      config <- getIamUnrecognisedUserConfig(config)
+      unrecognisedUsersConfig <- getIamUnrecognisedUserConfig(config)
       // fetch and parse our stored Janus config to use the canonical source of "recognised" usernames
-      s3Object <- getS3Object(securityS3Client, config.janusUserBucket, config.janusDataFileKey)
+      s3Object <- getS3Object(securityS3Client, unrecognisedUsersConfig.janusUserBucket, unrecognisedUsersConfig.janusDataFileKey)
       janusData = JanusConfig.load(makeFile(s3Object.mkString))
       janusUsernames = getJanusUsernames(janusData)
       // look up the credentials report from the cache service as our source of current IAM users
@@ -64,20 +64,20 @@ class IamRemediationService(
       allowedAccountsUnrecognisedUsers = unrecognisedUsersForAllowedAccounts(
         accountCredsReports,
         janusUsernames,
-        config.allowedAccounts
+        unrecognisedUsersConfig.allowedAccounts
       )
       // list the access keys associated to each user (this is required because the credentials report does not include access key ID)
       unrecognisedUserAccessKeys <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
         listAccountAccessKeys(_, iamClients)
       )
       // disable each access key for unrecognised users
-      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(disableAccountAccessKeys(_, iamClients, config.dryRun))
+      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun))
       // remove passwords (i.e. login profiles) for each unrecognised user
-      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(removeAccountPasswords(_, iamClients, config.dryRun))
+      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun))
       // construct and send a notification for each unrecognised user
-      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, config.dryRun)
+      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
       notificationIds <- Attempt.traverse(notifications)(
-        AnghammaradNotifications.send(_, config.anghammaradSnsTopicArn, snsClient)
+        AnghammaradNotifications.send(_, unrecognisedUsersConfig.anghammaradSnsTopicArn, snsClient)
       )
     } yield notificationIds
     result.tap {

--- a/hq/test/config/ConfigTest.scala
+++ b/hq/test/config/ConfigTest.scala
@@ -1,9 +1,6 @@
 package config
 
 import org.scalatest.EitherValues
-
-import scala.concurrent.Await
-import scala.concurrent.duration.*
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import play.api.Configuration
@@ -19,7 +16,6 @@ class ConfigTest extends AnyFreeSpec with Matchers with EitherValues {
       "rubbishValue" -> "rubbish"
     )
   )
-
 
   "Check we read the dryRun flag correctly from the config" - {
 

--- a/hq/test/config/ConfigTest.scala
+++ b/hq/test/config/ConfigTest.scala
@@ -1,0 +1,54 @@
+package config
+
+import org.scalatest.EitherValues
+
+import scala.concurrent.Await
+import scala.concurrent.duration.*
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.Configuration
+
+class ConfigTest extends AnyFreeSpec with Matchers with EitherValues {
+
+  val configuration: Configuration = Configuration.from(
+    Map(
+      "trueValue" -> "true",
+      "falseValue" -> "false",
+      "TRUEValue" -> "TRUE",
+      "FALSEValue" -> "FALSE",
+      "rubbishValue" -> "rubbish"
+    )
+  )
+
+
+  "Check we read the dryRun flag correctly from the config" - {
+
+    "only exactly 'false' (ignoring case) is treated as false" - {
+      "dryRun flag is 'false'" in {
+        Config.getDryRun(configuration, "falseValue") shouldBe false
+      }
+
+      "dryRun flag is 'FALSE'" in {
+        Config.getDryRun(configuration, "FALSEValue") shouldBe false
+      }
+    }
+
+    "anything that isn't exactly 'false' is treated as true" - {
+      "dryRun flag is 'true'" in {
+        Config.getDryRun(configuration, "trueValue") shouldBe true
+      }
+
+      "dryRun flag is 'TRUE'" in {
+        Config.getDryRun(configuration, "TRUEValue") shouldBe true
+      }
+
+      "dryRun flag is 'rubbish'" in {
+        Config.getDryRun(configuration, "rubbishValue") shouldBe true
+      }
+
+      "dryRun flag is not present" in {
+        Config.getDryRun(configuration, "missing") shouldBe true
+      }
+    }
+  }
+}

--- a/hq/test/config/ConfigTest.scala
+++ b/hq/test/config/ConfigTest.scala
@@ -9,11 +9,11 @@ class ConfigTest extends AnyFreeSpec with Matchers with EitherValues {
 
   val configuration: Configuration = Configuration.from(
     Map(
-      "trueValue" -> "true",
-      "falseValue" -> "false",
-      "TRUEValue" -> "TRUE",
-      "FALSEValue" -> "FALSE",
-      "rubbishValue" -> "rubbish"
+      "trueValue.dryRun" -> "true",
+      "falseValue.dryRun" -> "false",
+      "TRUEValue.dryRun" -> "TRUE",
+      "FALSEValue.dryRun" -> "FALSE",
+      "rubbishValue.dryRun" -> "rubbish"
     )
   )
 


### PR DESCRIPTION
## What does this change?

We found on Friday (17/7/2026) that the remediation job was broken, and fixed it.  This resulted in the immediate deactivation of 38 keys, without prior warning.

Before turning this job back on _either in the app or the lambda_, we need to ensure that this will not be repeated.

We want to be able to run both the jobs in dry run mode (in either implementation) to output the plan without actually actioning it.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
