### PR TITLE
fix: Add config read permissions for unrecognised-users lambda

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1367,6 +1367,9 @@ exports[`HQ stack matches the snapshot 1`] = `
           {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
+          {
+            "Ref": "iamunrecognisedusersServiceRole58E0D3DD",
+          },
         ],
       },
       "Type": "AWS::IAM::Policy",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -390,6 +390,7 @@ export class SecurityHQ extends GuStack {
       GuAnghammaradSenderPolicy.getInstance(this),
       guPutCloudwatchMetricsPolicy,
       guGetS3AuditObjectsPolicy,
+      guGetS3ConfigObjectsPolicy,
       guAssumeRolePolicy,
       guDescribeRegionsPolicy,
     ];


### PR DESCRIPTION
## What does this change?

Adds explicit permission for the unrecognised users lambda to read the config. This was implicit in the app, but not for the lambda. See #1425 and #1426.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Allows the lambda to run as it doesn't currently.

## Will this require CloudFormation and/or updates to the AWS StackSet?

Yes. Updated snapshot.

## Will this require changes to config?

No.