### PR TITLE
Restrict last action to preceding two weeks

### DIFF
--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -6,8 +6,9 @@ import com.gu.janus.JanusConfig
 import config.Config
 import config.Config.{getAnghammaradSNSTopicArn, getIamDynamoTableName, getIamUnrecognisedUserConfig}
 import db.IamRemediationDb
-import logic.IamUnrecognisedUsers
 import logic.IamUnrecognisedUsers.*
+import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
+import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
 import play.api.{Configuration, Environment, Mode}
@@ -73,23 +74,20 @@ class IamRemediationService(
       unrecognisedUserAccessKeys <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
         listAccountAccessKeys(_, iamClients)
       )
-      _ = logger.warn(
-        s"NOT running IamRemediationService jobs to disable unrecognised users.  Dry run flag is ${unrecognisedUsersConfig.dryRun}"
+      // disable each access key for unrecognised users
+      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(
+        disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun)
       )
-//      // disable each access key for unrecognised users
-//      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(
-//        disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun)
-//      )
-//      // remove passwords (i.e. login profiles) for each unrecognised user
-//      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
-//        removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun)
-//      )
-//      // construct and send a notification for each unrecognised user
-//      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
-//      notificationIds <- Attempt.traverse(notifications)(
-//        AnghammaradNotifications.send(_, unrecognisedUsersConfig.anghammaradSnsTopicArn, snsClient)
-//      )
-    } yield Nil // notificationIds
+      // remove passwords (i.e. login profiles) for each unrecognised user
+      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
+        removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun)
+      )
+      // construct and send a notification for each unrecognised user
+      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
+      notificationIds <- Attempt.traverse(notifications)(
+        AnghammaradNotifications.send(_, unrecognisedUsersConfig.anghammaradSnsTopicArn, snsClient)
+      )
+    } yield notificationIds
     result.tap {
       case Left(failedAttempt)    => logger.error(s"Failed to run unrecognised user job: ${failedAttempt.logMessage}")
       case Right(notificationIds) =>
@@ -127,13 +125,12 @@ class IamRemediationService(
     dryRun = Config.getOutdatedCredentialsDryRun(config)
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-    _ = logger.warn(s"NOT running IamRemediationService jobs to disable outdated credentials.  Dry run flag is $dryRun")
-//    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
-//      notificationTopicArn,
-//      tableName,
-//      serviceAccountIds,
-//      rawCredsReports,
-//      allowedAwsAccountIds
-//    )
-  } yield () // result
+    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
+      notificationTopicArn,
+      tableName,
+      serviceAccountIds,
+      rawCredsReports,
+      allowedAwsAccountIds
+    )
+  } yield result
 }

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -323,8 +323,8 @@ object IamOutdatedCredentials extends LazyLogging {
         remediationHistory.activityHistory
           // ...matching db records for the given access key
           .filter(_.problemCreationDate.isEqual(lastRotatedDate))
-          // ...where the last action was in the last week and a day
-          .filter(_.dateNotificationSent.isAfter(now.minusDays(8)))
+          // ...where the last action was in the last two weeks
+          .filter(_.dateNotificationSent.isAfter(now.minusWeeks(2)))
           // ...returning the most recent one, if any.
           .maxByOption(_.dateNotificationSent.getMillis)
       case None =>

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -297,7 +297,7 @@ object IamOutdatedCredentials extends LazyLogging {
     for {
       userRemediationHistory <- remediationHistories
       vulnerableKey <- identifyVulnerableKeys(userRemediationHistory, now)
-      keyPreviousAlert = identifyMostRecentActivity(userRemediationHistory, vulnerableKey)
+      keyPreviousAlert = identifyMostRecentActivity(userRemediationHistory, vulnerableKey, now)
       keyNextActivity <- identifyRemediationOperation(keyPreviousAlert, now, userRemediationHistory, vulnerableKey)
     } yield keyNextActivity
   }
@@ -313,22 +313,20 @@ object IamOutdatedCredentials extends LazyLogging {
 
   private[logic] def identifyMostRecentActivity(
       remediationHistory: IamUserRemediationHistory,
-      vulnerableKey: AccessKey
+      vulnerableKey: AccessKey,
+      now: DateTime
   ): Option[IamRemediationActivity] = {
     // TODO lastRotatedDate should not be an Option, because every IAM access key has a last rotated date. Change SHQ's model.
     vulnerableKey.lastRotated match {
       case Some(lastRotatedDate) =>
-        // filter activity list to find matching db records for given access key
-        val keyPreviousActivities =
-          remediationHistory.activityHistory.filter(_.problemCreationDate.isEqual(lastRotatedDate))
-        keyPreviousActivities match {
-          case Nil =>
-            // there is no recent activity for the given access key, so return None.
-            None
-          case remediationActivities =>
-            // get the most recent remediation activity
-            Some(remediationActivities.maxBy(_.dateNotificationSent.getMillis))
-        }
+        // filter activity list to find...
+        remediationHistory.activityHistory
+          // ...matching db records for the given access key
+          .filter(_.problemCreationDate.isEqual(lastRotatedDate))
+          // ...where the last action was in the last week and a day
+          .filter(_.dateNotificationSent.isAfter(now.minusDays(8)))
+          // ...returning the most recent one, if any.
+          .maxByOption(_.dateNotificationSent.getMillis)
       case None =>
         val name = remediationHistory.iamUser.username
         val account = remediationHistory.awsAccount.name

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -403,7 +403,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           machineWithOneOldEnabledAccessKey.username
         )
         val history = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(activity))
-        identifyMostRecentActivity(history, key).map(_.iamRemediationActivityType) shouldEqual Some(Warning)
+        identifyMostRecentActivity(history, key, date).map(_.iamRemediationActivityType) shouldEqual Some(Warning)
       }
       "if the key's most recent activity is Final, return Final" in {
         val key = humanAccessKeyOldAndEnabled1
@@ -414,18 +414,18 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           humanWithOneOldEnabledAccessKey.username
         )
         val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(activity))
-        identifyMostRecentActivity(history, key).map(_.iamRemediationActivityType) shouldEqual Some(FinalWarning)
+        identifyMostRecentActivity(history, key, date).map(_.iamRemediationActivityType) shouldEqual Some(FinalWarning)
       }
       "if the key's most recent activity is Remediation, return Remediation" in {
         val key = humanAccessKeyOldAndEnabled1
         val activity = remediationActivity(1, Remediation, key, humanWithOneOldEnabledAccessKey.username)
         val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(activity))
-        identifyMostRecentActivity(history, key).map(_.iamRemediationActivityType) shouldEqual Some(Remediation)
+        identifyMostRecentActivity(history, key, date).map(_.iamRemediationActivityType) shouldEqual Some(Remediation)
       }
       "given a key does not have any activity, return None" in {
         val activity = Nil
         val machineNoActivity = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey2, activity)
-        identifyMostRecentActivity(machineNoActivity, machineAccessKeyOldAndEnabledOnTimeThreshold) shouldBe empty
+        identifyMostRecentActivity(machineNoActivity, machineAccessKeyOldAndEnabledOnTimeThreshold, date) shouldBe empty
       }
       "if the key's most recent activity is Warning, return the correct output" in {
         val key = machineAccessKeyOldAndEnabled
@@ -436,7 +436,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           machineWithOneOldEnabledAccessKey.username
         )
         val history = IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, List(activity))
-        val result = identifyMostRecentActivity(history, key)
+        val result = identifyMostRecentActivity(history, key, date)
         inside(result.value) {
           case IamRemediationActivity(
                 awsAccountId,
@@ -461,9 +461,57 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           humanWithOneOldEnabledAccessKey.username
         )
         val history = IamUserRemediationHistory(account, humanWithOneOldEnabledAccessKey, List(activity))
-        identifyMostRecentActivity(history, key).map(_.dateNotificationSent) shouldEqual Some(
+        identifyMostRecentActivity(history, key, date).map(_.dateNotificationSent) shouldEqual Some(
           date.minusDays(daysBetweenFinalNotificationAndRemediation)
         )
+      }
+
+      "given a key that was marked as final warning months ago, but the task has not run since" in {
+        val username = "ancientMachine"
+        // Key was created two years ago.  It is ancient.
+        val twoYearsAgo = date.minusMonths(24)
+        // Key was issued a final warning a year ago.
+        val aYearAgo = date.minusMonths(12)
+        // Key was issued a warning a year ago.
+        val aYearAndABit = aYearAgo.minusDays(daysBetweenWarningAndFinalNotification)
+        val machineUser = MachineUser(
+          username,
+          AccessKey(AccessKeyEnabled, Some(twoYearsAgo)),
+          AccessKey(AccessKeyEnabled, Some(aYearAgo)),
+          Green,
+          None,
+          None,
+          Nil
+        )
+        val remediationOperation = calculateOutstandingAccessKeyOperations(
+          List(
+            IamUserRemediationHistory(
+              account,
+              machineUser,
+              List(
+                IamRemediationActivity(
+                  account.id,
+                  username,
+                  aYearAndABit,
+                  Warning,
+                  OutdatedCredential,
+                  twoYearsAgo
+                ),
+                IamRemediationActivity(
+                  account.id,
+                  username,
+                  aYearAgo,
+                  FinalWarning,
+                  OutdatedCredential,
+                  twoYearsAgo
+                )
+              )
+            )
+          ),
+          date
+        ).head
+        remediationOperation.iamProblem shouldBe OutdatedCredential
+        remediationOperation.iamRemediationActivityType shouldBe Warning
       }
     }
 

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -465,46 +465,99 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           date.minusDays(daysBetweenFinalNotificationAndRemediation)
         )
       }
+    }
 
-      "given a key that was marked as final warning months ago, but the task has not run since" in {
-        val username = "ancientMachine"
-        // Key was created two years ago.  It is ancient.
-        val twoYearsAgo = date.minusMonths(24)
+    "identifyOutstandingAccessKeyOperations must handle gaps gracefully" - {
+      val username = "ancientMachine"
+      // Key was created two years ago.  It is ancient.
+      val twoYearsAgo = date.minusMonths(24)
+      val aYearAgo = date.minusMonths(12)
+      val machineUser = MachineUser(
+        username,
+        AccessKey(AccessKeyEnabled, Some(twoYearsAgo)),
+        AccessKey(AccessKeyEnabled, Some(aYearAgo)),
+        Green,
+        None,
+        None,
+        Nil
+      )
+      val aYearAndABit = aYearAgo.minusDays(daysBetweenWarningAndFinalNotification)
+      def warning(warningDate: DateTime) = IamRemediationActivity(
+        account.id,
+        username,
+        warningDate,
+        Warning,
+        OutdatedCredential,
+        twoYearsAgo
+      )
+      def finalWarning(finalWarningDate: DateTime) = IamRemediationActivity(
+        account.id,
+        username,
+        finalWarningDate,
+        FinalWarning,
+        OutdatedCredential,
+        twoYearsAgo
+      )
+
+      "given a key that was given a final warning months ago, but the task has not run since, go back to warning" in {
         // Key was issued a final warning a year ago.
-        val aYearAgo = date.minusMonths(12)
         // Key was issued a warning a year ago.
-        val aYearAndABit = aYearAgo.minusDays(daysBetweenWarningAndFinalNotification)
-        val machineUser = MachineUser(
-          username,
-          AccessKey(AccessKeyEnabled, Some(twoYearsAgo)),
-          AccessKey(AccessKeyEnabled, Some(aYearAgo)),
-          Green,
-          None,
-          None,
-          Nil
-        )
         val remediationOperation = calculateOutstandingAccessKeyOperations(
           List(
             IamUserRemediationHistory(
               account,
               machineUser,
               List(
-                IamRemediationActivity(
-                  account.id,
-                  username,
-                  aYearAndABit,
-                  Warning,
-                  OutdatedCredential,
-                  twoYearsAgo
-                ),
-                IamRemediationActivity(
-                  account.id,
-                  username,
-                  aYearAgo,
-                  FinalWarning,
-                  OutdatedCredential,
-                  twoYearsAgo
-                )
+                warning(aYearAndABit),
+                finalWarning(aYearAgo)
+              )
+            )
+          ),
+          date
+        ).head
+        remediationOperation.iamProblem shouldBe OutdatedCredential
+        remediationOperation.iamRemediationActivityType shouldBe Warning
+      }
+
+      "given a key that was given a final warning 13 days ago, but the task has not run since, carry on" in {
+        // Key was issued a final warning a year ago.
+        val aYearAgo = date.minusMonths(12)
+        // Key was issued a warning 14 days ago
+        val aYearAndFifteenDaysAgo = date.minusDays(15)
+        // Key was issued a final warning 13 days ago
+        val aYearAndThirteenDaysAgo = date.minusDays(13)
+        val remediationOperation = calculateOutstandingAccessKeyOperations(
+          List(
+            IamUserRemediationHistory(
+              account,
+              machineUser,
+              List(
+                warning(aYearAndFifteenDaysAgo),
+                finalWarning(aYearAndThirteenDaysAgo)
+              )
+            )
+          ),
+          date
+        ).head
+        remediationOperation.iamProblem shouldBe OutdatedCredential
+        remediationOperation.iamRemediationActivityType shouldBe Remediation
+      }
+
+      "given a key that was given a final warning 14 days ago, but the task has not run since, go back to warning" in {
+        // Key was issued a final warning a year ago.
+        val aYearAgo = date.minusMonths(12)
+        // Key was issued a warning 14 days ago
+        val aYearAndFifteenDaysAgo = date.minusDays(15)
+        // Key was issued a final warning 13 days ago
+        val aYearAndfourteenDaysAgo = date.minusDays(14)
+        val remediationOperation = calculateOutstandingAccessKeyOperations(
+          List(
+            IamUserRemediationHistory(
+              account,
+              machineUser,
+              List(
+                warning(aYearAndFifteenDaysAgo),
+                finalWarning(aYearAndfourteenDaysAgo)
               )
             )
           ),


### PR DESCRIPTION
## What does this change?

This change adds a test to cover the scenario where a key has had a final warning, but then for whatever reason the job has not run for a while.  This should not then result in an immediate de-activation of the key.  This test fails with the current code.

An additional filter has been added requiring that the last action was within fourteen days of the current action decision.  Following this addition, the new test passes.

This has required more changes to test code because all tests of this code must now pass in the nominal date (`date`) on which the action is being considered.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
