### PR TITLE
Reactivate app jobs

### DIFF
--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -6,8 +6,9 @@ import com.gu.janus.JanusConfig
 import config.Config
 import config.Config.{getAnghammaradSNSTopicArn, getIamDynamoTableName, getIamUnrecognisedUserConfig}
 import db.IamRemediationDb
-import logic.IamUnrecognisedUsers
 import logic.IamUnrecognisedUsers.*
+import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
+import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
 import play.api.{Configuration, Environment, Mode}
@@ -73,23 +74,20 @@ class IamRemediationService(
       unrecognisedUserAccessKeys <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
         listAccountAccessKeys(_, iamClients)
       )
-      _ = logger.warn(
-        s"NOT running IamRemediationService jobs to disable unrecognised users.  Dry run flag is ${unrecognisedUsersConfig.dryRun}"
+      // disable each access key for unrecognised users
+      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(
+        disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun)
       )
-//      // disable each access key for unrecognised users
-//      _ <- Attempt.traverse(unrecognisedUserAccessKeys)(
-//        disableAccountAccessKeys(_, iamClients, unrecognisedUsersConfig.dryRun)
-//      )
-//      // remove passwords (i.e. login profiles) for each unrecognised user
-//      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
-//        removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun)
-//      )
-//      // construct and send a notification for each unrecognised user
-//      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
-//      notificationIds <- Attempt.traverse(notifications)(
-//        AnghammaradNotifications.send(_, unrecognisedUsersConfig.anghammaradSnsTopicArn, snsClient)
-//      )
-    } yield Nil // notificationIds
+      // remove passwords (i.e. login profiles) for each unrecognised user
+      _ <- Attempt.traverse(allowedAccountsUnrecognisedUsers)(
+        removeAccountPasswords(_, iamClients, unrecognisedUsersConfig.dryRun)
+      )
+      // construct and send a notification for each unrecognised user
+      notifications = unrecognisedUserNotifications(allowedAccountsUnrecognisedUsers, unrecognisedUsersConfig.dryRun)
+      notificationIds <- Attempt.traverse(notifications)(
+        AnghammaradNotifications.send(_, unrecognisedUsersConfig.anghammaradSnsTopicArn, snsClient)
+      )
+    } yield notificationIds
     result.tap {
       case Left(failedAttempt)    => logger.error(s"Failed to run unrecognised user job: ${failedAttempt.logMessage}")
       case Right(notificationIds) =>
@@ -127,13 +125,12 @@ class IamRemediationService(
     dryRun = Config.getOutdatedCredentialsDryRun(config)
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-    _ = logger.warn(s"NOT running IamRemediationService jobs to disable outdated credentials.  Dry run flag is $dryRun")
-//    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
-//      notificationTopicArn,
-//      tableName,
-//      serviceAccountIds,
-//      rawCredsReports,
-//      allowedAwsAccountIds
-//    )
-  } yield () // result
+    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
+      notificationTopicArn,
+      tableName,
+      serviceAccountIds,
+      rawCredsReports,
+      allowedAwsAccountIds
+    )
+  } yield result
 }


### PR DESCRIPTION
## What does this change?

Now we have confirmed the dry run mode is true for both jobs, we can remove the comment markers and allow the jobs to run.


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
