### PR TITLE
Single threadpool for AWS clients

### DIFF
--- a/core/src/main/scala/aws/AWS.scala
+++ b/core/src/main/scala/aws/AWS.scala
@@ -61,10 +61,12 @@ object AWS {
     } yield AwsClient(client, account, region)
   }
 
+  private lazy val sharedThreadPool = newCachedThreadPool()
+
   private def withCustomThreadPool[A, B <: AwsAsyncClientBuilder[B, A]] =
     (asyncClientBuilder: AwsAsyncClientBuilder[B, A]) =>
       asyncClientBuilder.asyncConfiguration(c =>
-        c.advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, newCachedThreadPool())
+        c.advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, sharedThreadPool)
       )
 
   def cfnClients(accounts: List[AwsAccount], regions: List[Region]): AwsClients[CloudFormationAsyncClient] =


### PR DESCRIPTION
## What does this change?

Updates the custom threadpool that the async SDK clients are configured to use from a unique threadpool per client, to a single threadpool shared by all async clients. We hope this should encourage the clients to reuse threads as needed and decrease the total amount of threads active on an instance.

An alternate idea was to convert to using the synchronous clients, and instead managing the concurrency with Scala futures running on a similar single thread pool. However upon further reflection I was worried that this would instead cause higher thread usage, as the SDK calls started blocking on the async threads. This appears to be avoided by using the async SDK clients natively (the SDK docs say "The configured Executor will be invoked by the async HTTP client's I/O threads (e.g., EventLoops), which must be reserved for non-blocking behavior. Blocking an I/O thread can cause severe performance degradation, including across multiple clients, as clients are configured, by default, to share a single I/O thread pool (e.g., EventLoopGroup)"), so I went back to using them, but with the single threadpool.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

We should be more comfortable with extending scanning to more regions, without worrying that thread usage will start to cause problems.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
