### PR TITLE
Add notification to devx security on disable

### DIFF
--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -19,7 +19,7 @@ import scala.jdk.CollectionConverters.*
 
 object IAMClient extends LazyLogging {
 
-  val SOLE_REGION = Region.of("us-east-1")
+  private val SOLE_REGION = Region.of("us-east-1")
 
   private def generateCredentialsReport(
       client: AwsClient[IamAsyncClient]
@@ -74,7 +74,7 @@ object IAMClient extends LazyLogging {
     }
   }
 
-  def getCredentialReportDisplay(
+  private def getCredentialReportDisplay(
       account: AwsAccount,
       currentData: Either[FailedAttempt, CredentialReportDisplay],
       cfnClients: AwsClients[CloudFormationAsyncClient],
@@ -159,7 +159,12 @@ object IAMClient extends LazyLogging {
                 )
               }
           }
-        } yield CredentialMetadata(akm.userName, akm.accessKeyId, new DateTime(akm.createDate.toEpochMilli), credentialStatus)
+        } yield CredentialMetadata(
+          akm.userName,
+          akm.accessKeyId,
+          new DateTime(akm.createDate.toEpochMilli),
+          credentialStatus
+        )
       }
     } yield credentialMetadatas
   }

--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -19,7 +19,7 @@ import scala.jdk.CollectionConverters.*
 
 object IAMClient extends LazyLogging {
 
-  private val SOLE_REGION = Region.of("us-east-1")
+  val SOLE_REGION = Region.of("us-east-1")
 
   private def generateCredentialsReport(
       client: AwsClient[IamAsyncClient]
@@ -74,7 +74,7 @@ object IAMClient extends LazyLogging {
     }
   }
 
-  private def getCredentialReportDisplay(
+  def getCredentialReportDisplay(
       account: AwsAccount,
       currentData: Either[FailedAttempt, CredentialReportDisplay],
       cfnClients: AwsClients[CloudFormationAsyncClient],
@@ -159,12 +159,7 @@ object IAMClient extends LazyLogging {
                 )
               }
           }
-        } yield CredentialMetadata(
-          akm.userName,
-          akm.accessKeyId,
-          new DateTime(akm.createDate.toEpochMilli),
-          credentialStatus
-        )
+        } yield CredentialMetadata(akm.userName, akm.accessKeyId, new DateTime(akm.createDate.toEpochMilli), credentialStatus)
       }
     } yield credentialMetadatas
   }

--- a/core/src/main/scala/notifications/AnghammaradNotifications.scala
+++ b/core/src/main/scala/notifications/AnghammaradNotifications.scala
@@ -36,8 +36,8 @@ object AnghammaradNotifications extends LazyLogging {
       }
   }
 
-  val channel = Preferred(Email)
-  val sourceSystem = "Security HQ Credentials Notifier"
+  private val channel = Preferred(Email)
+  private val sourceSystem = "Security HQ Credentials Notifier"
 
   private def notificationTargets(awsAccount: AwsAccount, iamUser: IAMUser): List[Target] =
     Tag.tagsToAnghammaradTargets(iamUser.tags) :+ Account(awsAccount.accountNumber)
@@ -113,6 +113,37 @@ object AnghammaradNotifications extends LazyLogging {
       message + genericOutdatedCredentialText,
       Nil,
       notificationTargets(awsAccount, iamUser),
+      channel,
+      sourceSystem
+    )
+  }
+
+  def outdatedCredentialRemediationDevXSecurity(
+      awsAccount: AwsAccount,
+      iamUser: IAMUser,
+      problemCreationDate: DateTime,
+      devXSecurityAccount: AwsAccount
+  ): Notification = {
+    val endUserNotificationTargets = notificationTargets(awsAccount, iamUser)
+    val devxSecurityNotificationTargets = List(Account(devXSecurityAccount.accountNumber))
+    val endUserTargetsString = endUserNotificationTargets.map(_.toString).mkString(", ")
+    val message =
+      s"""
+         |The permanent credential, ${iamUser.username}, in ${awsAccount.name} was disabled today,
+         |because it was last rotated on ${printDay(problemCreationDate)}.
+         |
+         |Notification(s) have been sent to $endUserTargetsString, who are the owners of the disabled credential.
+         |
+         |THIS ACTION HAS HIGH POTENTIAL TO BREAK THINGS.
+         |
+         |BE PREPARED FOR USERS TO BE UPSET!
+         |""".stripMargin
+    val subject = s"DISABLED long-lived credential in ${awsAccount.name}"
+    Notification(
+      subject,
+      message + genericOutdatedCredentialText,
+      Nil,
+      devxSecurityNotificationTargets,
       channel,
       sourceSystem
     )

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -153,7 +153,8 @@ class AppComponents(context: Context)
     applicationLifecycle,
     environment,
     securityS3Client,
-    devXSecurityAccountMaybe
+    devXSecurityAccountMaybe,
+    dryRun = Config.getOutdatedCredentialsDryRun(configuration)
   )(executionContext)
 
   override def router: Router = new Routes(

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -5,6 +5,7 @@ import config.{Config, CoreConfig}
 import controllers.*
 import db.IamRemediationDb
 import filters.HstsFilter
+import logic.IamOutdatedCredentials
 import model.{AwsAccount, Stage}
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.WSClient
@@ -24,6 +25,7 @@ import software.amazon.awssdk.services.sns.SnsAsyncClient
 import software.amazon.awssdk.services.ssm.SsmClient
 import software.amazon.awssdk.utils.AttributeMap
 import utils.attempt.Attempt
+
 import scala.concurrent.duration.*
 import scala.concurrent.Await
 import scala.jdk.CollectionConverters.*
@@ -92,6 +94,7 @@ class AppComponents(context: Context)
   private val taClients = AWS.taClients(awsAccounts)
   private val s3Clients = AWS.s3Clients(awsAccounts, availableRegions)
   private val iamClients = AWS.iamClients(awsAccounts, availableRegions)
+  private val devXSecurityAccountMaybe = awsAccounts.find(_.id == IamOutdatedCredentials.SECURITY_ACCOUNT_ID)
 
   /*
       The casting from SdkHttpConfigurationOption[Integer] to AttributeMap.Key[Any] is required because Scala compiler comlains
@@ -149,7 +152,8 @@ class AppComponents(context: Context)
     iamClients,
     applicationLifecycle,
     environment,
-    securityS3Client
+    securityS3Client,
+    devXSecurityAccountMaybe
   )(executionContext)
 
   override def router: Router = new Routes(

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -144,17 +144,20 @@ class AppComponents(context: Context)
     cacheService
   )
 
+  private val dynamo = new IamRemediationDb(securityDynamoDbClient)
+  private val dryRun = Config.getOutdatedCredentialsDryRun(configuration)
+  private val iamOutdatedCredentials = IamOutdatedCredentials(securitySnsClient, iamClients, dynamo, devXSecurityAccountMaybe, dryRun)
+
   new IamRemediationService(
     cacheService,
     securitySnsClient,
-    new IamRemediationDb(securityDynamoDbClient),
+    dynamo,
     configuration,
     iamClients,
     applicationLifecycle,
     environment,
     securityS3Client,
-    devXSecurityAccountMaybe,
-    dryRun = Config.getOutdatedCredentialsDryRun(configuration)
+    iamOutdatedCredentials
   )(executionContext)
 
   override def router: Router = new Routes(

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -26,8 +26,8 @@ import software.amazon.awssdk.services.ssm.SsmClient
 import software.amazon.awssdk.utils.AttributeMap
 import utils.attempt.Attempt
 
-import scala.concurrent.duration.*
 import scala.concurrent.Await
+import scala.concurrent.duration.*
 import scala.jdk.CollectionConverters.*
 import scala.language.postfixOps
 
@@ -146,7 +146,8 @@ class AppComponents(context: Context)
 
   private val dynamo = new IamRemediationDb(securityDynamoDbClient)
   private val dryRun = Config.getOutdatedCredentialsDryRun(configuration)
-  private val iamOutdatedCredentials = IamOutdatedCredentials(securitySnsClient, iamClients, dynamo, devXSecurityAccountMaybe, dryRun)
+  private val iamOutdatedCredentials =
+    IamOutdatedCredentials(securitySnsClient, iamClients, dynamo, devXSecurityAccountMaybe, dryRun)
 
   new IamRemediationService(
     cacheService,

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -146,8 +146,18 @@ class AppComponents(context: Context)
 
   private val dynamo = new IamRemediationDb(securityDynamoDbClient)
   private val dryRun = Config.getOutdatedCredentialsDryRun(configuration)
+  private val notificationTopicArn = Config.getAnghammaradSNSTopicArn(configuration)
+  private val tableName = Config.getIamDynamoTableName(configuration)
   private val iamOutdatedCredentials =
-    IamOutdatedCredentials(securitySnsClient, iamClients, dynamo, devXSecurityAccountMaybe, dryRun)
+    IamOutdatedCredentials(
+      securitySnsClient,
+      iamClients,
+      dynamo,
+      devXSecurityAccountMaybe,
+      dryRun,
+      notificationTopicArn,
+      tableName
+    )
 
   new IamRemediationService(
     cacheService,

--- a/hq/app/config/Config.scala
+++ b/hq/app/config/Config.scala
@@ -105,12 +105,7 @@ object Config extends Logging {
     } yield AwsAccount(id, name, roleArn, number)
   }
 
-  def getIamDynamoTableName(config: Configuration): Attempt[String] = {
-    Attempt.fromOption(
-      config.getOptional[String]("alert.iamDynamoTableName"),
-      FailedAttempt(Failure("unable to get dynamo table name", "unable to get dynamo table name for IAM jobs", 500))
-    )
-  }
+  def getIamDynamoTableName(config: Configuration): String = requiredString(config, "alert.iamDynamoTableName")
 
   def getIamUnrecognisedUserConfig(
       config: Configuration
@@ -120,19 +115,12 @@ object Config extends Logging {
       key <- getJanusDataFileKey(config)
       bucket <- getIamUnrecognisedUserBucket(config)
       securityAccount <- getSecurityAccount(config)
-      anghammaradSnsTopicArn <- getAnghammaradSNSTopicArn(config)
+      anghammaradSnsTopicArn = getAnghammaradSNSTopicArn(config)
       dryRun = getUnrecognisedUserDryRun(config)
     } yield UnrecognisedJobConfigProperties(accounts, key, bucket, securityAccount, anghammaradSnsTopicArn, dryRun)
   }
 
-  def getAnghammaradSNSTopicArn(config: Configuration): Attempt[String] = {
-    Attempt.fromOption(
-      config.getOptional[String]("alert.anghammaradSnsArn"),
-      FailedAttempt(
-        Failure("unable to get Anghammarad topic ARN", "unable to get Anghammarad topic ARN for IAM jobs", 500)
-      )
-    )
-  }
+  def getAnghammaradSNSTopicArn(config: Configuration): String = requiredString(config, "alert.anghammaradSnsArn")
 
   // Default to true; only an explicit "false" disables dry-run.
   // Not using toBoolean because we want to default to true (do nothing) if the config is missing or invalid

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -39,9 +39,12 @@ class IamRemediationService(
     lifecycle: ApplicationLifecycle,
     environment: Environment,
     securityS3Client: S3Client,
-    devXSecurityAccountMaybe: Option[AwsAccount]
+    devXSecurityAccountMaybe: Option[AwsAccount],
+    dryRun: Boolean
 )(implicit ec: ExecutionContext)
     extends Scheduler {
+
+  private val iamOutdatedCredentials = IamOutdatedCredentials(snsClient, iamClients, dynamo, devXSecurityAccountMaybe, dryRun)
 
   /** Removes AWS access for colleagues that have departed.
     *
@@ -124,16 +127,14 @@ class IamRemediationService(
     tableName <- getIamDynamoTableName(config)
     serviceAccountIds <- Config.getAccountsForIamRemediationService(config)
     rawCredsReports = cacheService.getAllCredentials
-    dryRun = Config.getOutdatedCredentialsDryRun(config)
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-    result <- IamOutdatedCredentials(snsClient, iamClients, dynamo, dryRun).disableOutdatedCredentials(
+    result <- iamOutdatedCredentials.disableOutdatedCredentials(
       notificationTopicArn,
       tableName,
       serviceAccountIds,
       rawCredsReports,
-      allowedAwsAccountIds,
-      devXSecurityAccountMaybe
+      allowedAwsAccountIds
     )
   } yield result
 }

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -8,7 +8,6 @@ import config.Config.{getAnghammaradSNSTopicArn, getIamDynamoTableName, getIamUn
 import db.IamRemediationDb
 import logic.IamUnrecognisedUsers.*
 import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
-import model.AwsAccount
 import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
@@ -39,7 +38,7 @@ class IamRemediationService(
     lifecycle: ApplicationLifecycle,
     environment: Environment,
     securityS3Client: S3Client,
-    iamOutdatedCredentials: IamOutdatedCredentials,
+    iamOutdatedCredentials: IamOutdatedCredentials
 )(implicit ec: ExecutionContext)
     extends Scheduler {
 

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -39,12 +39,9 @@ class IamRemediationService(
     lifecycle: ApplicationLifecycle,
     environment: Environment,
     securityS3Client: S3Client,
-    devXSecurityAccountMaybe: Option[AwsAccount],
-    dryRun: Boolean
+    iamOutdatedCredentials: IamOutdatedCredentials,
 )(implicit ec: ExecutionContext)
     extends Scheduler {
-
-  private val iamOutdatedCredentials = IamOutdatedCredentials(snsClient, iamClients, dynamo, devXSecurityAccountMaybe, dryRun)
 
   /** Removes AWS access for colleagues that have departed.
     *

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -8,6 +8,7 @@ import config.Config.{getAnghammaradSNSTopicArn, getIamDynamoTableName, getIamUn
 import db.IamRemediationDb
 import logic.IamUnrecognisedUsers.*
 import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
+import model.AwsAccount
 import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
@@ -37,7 +38,8 @@ class IamRemediationService(
     iamClients: AwsClients[IamAsyncClient],
     lifecycle: ApplicationLifecycle,
     environment: Environment,
-    securityS3Client: S3Client
+    securityS3Client: S3Client,
+    devXSecurityAccountMaybe: Option[AwsAccount]
 )(implicit ec: ExecutionContext)
     extends Scheduler {
 
@@ -130,7 +132,8 @@ class IamRemediationService(
       tableName,
       serviceAccountIds,
       rawCredsReports,
-      allowedAwsAccountIds
+      allowedAwsAccountIds,
+      devXSecurityAccountMaybe
     )
   } yield result
 }

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -4,7 +4,7 @@ import aws.AwsClients
 import aws.s3.S3.getS3Object
 import com.gu.janus.JanusConfig
 import config.Config
-import config.Config.{getAnghammaradSNSTopicArn, getIamDynamoTableName, getIamUnrecognisedUserConfig}
+import config.Config.getIamUnrecognisedUserConfig
 import db.IamRemediationDb
 import logic.IamUnrecognisedUsers.*
 import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
@@ -119,15 +119,11 @@ class IamRemediationService(
   }
 
   private def disableOutdatedCredentials(): Attempt[Unit] = for {
-    notificationTopicArn <- getAnghammaradSNSTopicArn(config)
-    tableName <- getIamDynamoTableName(config)
     serviceAccountIds <- Config.getAccountsForIamRemediationService(config)
     rawCredsReports = cacheService.getAllCredentials
     // this tells us which AWS accounts we are allowed to make changes to
     allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
     result <- iamOutdatedCredentials.disableOutdatedCredentials(
-      notificationTopicArn,
-      tableName,
       serviceAccountIds,
       rawCredsReports,
       allowedAwsAccountIds

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -25,6 +25,7 @@ class IamOutdatedCredentials(
     snsClient: SnsAsyncClient,
     iamClients: AwsClients[IamAsyncClient],
     dynamo: IamRemediationDb,
+    devXSecurityAccountMaybe: Option[AwsAccount],
     dryRun: Boolean = true
 ) extends LazyLogging {
 
@@ -38,8 +39,7 @@ class IamOutdatedCredentials(
       remediationOperation: RemediationOperation,
       now: DateTime,
       notificationTopicArn: String,
-      tableName: String,
-      devXSecurityAccountMaybe: Option[AwsAccount]
+      tableName: String
   )(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
     val iamUser = remediationOperation.vulnerableCandidate.iamUser
@@ -149,8 +149,7 @@ class IamOutdatedCredentials(
       tableName: String,
       serviceAccountIds: List[String],
       rawCredsReports: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]],
-      allowedAwsAccountIds: List[String],
-      devXSecurityAccount: Option[AwsAccount]
+      allowedAwsAccountIds: List[String]
   )(implicit ec: ExecutionContext): Attempt[Unit] = {
     val now = new DateTime()
     val accountsCredReports = getCredsReportDisplayForAccount(rawCredsReports)
@@ -177,7 +176,7 @@ class IamOutdatedCredentials(
       _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(dummyOperation)
       // now we know what operations need to be performed, so let's run each of those
       results <- Attempt.traverse(filteredOperations.allowedOperations)(
-        performRemediationOperation(_, now, notificationTopicArn, tableName, devXSecurityAccount)
+        performRemediationOperation(_, now, notificationTopicArn, tableName)
       )
     } yield results.flatten
     result.tap {
@@ -231,14 +230,14 @@ object IamOutdatedCredentials extends LazyLogging {
         snsClient = snsClient,
         iamClients = iamClients,
         dynamo = dynamo,
+        devXSecurityAccountMaybe = devXSecurityAccount,
         dryRun = settings.dryRun
       ).disableOutdatedCredentials(
         notificationTopicArn = anghammaradSnsArn,
         tableName = iamDynamoTableName,
         serviceAccountIds = accountIdsForIamRemediationService,
         rawCredsReports = listOfCredentialReports,
-        allowedAwsAccountIds = allowedAccountIds,
-        devXSecurityAccount = devXSecurityAccount
+        allowedAwsAccountIds = allowedAccountIds
       )
     } yield disableResult
   }

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -2,6 +2,7 @@ package logic
 
 import aws.iam.IAMClient
 import aws.{AWS, AwsClients}
+import com.gu.anghammarad.models.Notification
 import com.typesafe.scalalogging.LazyLogging
 import config.CoreConfig
 import db.IamRemediationDb
@@ -33,14 +34,13 @@ class IamOutdatedCredentials(
     *   - disable an IAM credential and send a notification that this has been done
     *   - remove an IAM password and send a notification that this has been done
     */
-  private def performRemediationOperation(
+  private[logic] def performRemediationOperation(
       remediationOperation: RemediationOperation,
       now: DateTime,
       notificationTopicArn: String,
       tableName: String,
-      dryRun: Boolean,
       devXSecurityAccountMaybe: Option[AwsAccount]
-  )(implicit ec: ExecutionContext): Attempt[String] = {
+  )(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
     val iamUser = remediationOperation.vulnerableCandidate.iamUser
     val problemCreationDate = remediationOperation.problemCreationDate
@@ -62,11 +62,11 @@ class IamOutdatedCredentials(
         for {
           snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-        } yield snsId
+        } yield List(snsId)
 
       case (Warning, OutdatedCredential) =>
         logger.info(s"Dry run: Would send warning for $awsAccount, $iamUser")
-        Attempt.Right("dummy-warning")
+        Attempt.Right(Nil)
 
       case (FinalWarning, OutdatedCredential) if !dryRun =>
         val notification =
@@ -74,11 +74,11 @@ class IamOutdatedCredentials(
         for {
           snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-        } yield snsId
+        } yield List(snsId)
 
       case (FinalWarning, OutdatedCredential) =>
         logger.info(s"Dry run: Would send final warning for $awsAccount, $iamUser")
-        Attempt.Right("dummy-finalWarning")
+        Attempt.Right(Nil)
 
       case (Remediation, OutdatedCredential) if !dryRun =>
         val notification =
@@ -102,20 +102,30 @@ class IamOutdatedCredentials(
             iamClients
           )
           // send a notification to say this is what we have done
-          notificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+          userNotificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+          // Send a notification to devx too, if we've got an account for them.
+          securityNotificationIdMaybe <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe)
           // save a record of the change
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-          // Send a notification to devx too, if we've got an account for them.
-          _ <- notificationDevXSecurityMaybe
-            .map(notificationDevXSecurity =>
-              AnghammaradNotifications.send(notificationDevXSecurity, notificationTopicArn, snsClient)
-            )
-            .getOrElse(Attempt.Right(logger.warn("No devx security account configured")))
-        } yield notificationId
+        } yield List(userNotificationId) ++ securityNotificationIdMaybe
 
       case (Remediation, OutdatedCredential) =>
         logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
-        Attempt.Right("dummy-remediation")
+        Attempt.Right(Nil)
+    }
+  }
+
+  private def sendSecurityNotification(
+      notificationTopicArn: String,
+      notificationDevXSecurityMaybe: Option[Notification]
+  )(implicit executionContext: ExecutionContext): Attempt[Option[String]] = {
+    notificationDevXSecurityMaybe match {
+      case Some(notificationDevXSecurity) =>
+        logger.info("Sending notification to devx security account")
+        AnghammaradNotifications.send(notificationDevXSecurity, notificationTopicArn, snsClient).map(Some(_))
+      case None =>
+        logger.warn("No devx security account configured")
+        Attempt.Right(None)
     }
   }
 
@@ -167,9 +177,9 @@ class IamOutdatedCredentials(
       _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(dummyOperation)
       // now we know what operations need to be performed, so let's run each of those
       results <- Attempt.traverse(filteredOperations.allowedOperations)(
-        performRemediationOperation(_, now, notificationTopicArn, tableName, dryRun, devXSecurityAccount)
+        performRemediationOperation(_, now, notificationTopicArn, tableName, devXSecurityAccount)
       )
-    } yield results
+    } yield results.flatten
     result.tap {
       case Left(failedAttempt) =>
         logger.error(

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -178,7 +178,7 @@ class IamOutdatedCredentials(
       results <- Attempt.traverse(filteredOperations.allowedOperations)(
         performRemediationOperation(_, now, notificationTopicArn, tableName)
       )
-    } yield results.flatten
+    } yield results
     result.tap {
       case Left(failedAttempt) =>
         logger.error(

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -38,7 +38,8 @@ class IamOutdatedCredentials(
       now: DateTime,
       notificationTopicArn: String,
       tableName: String,
-      dryRun: Boolean
+      dryRun: Boolean,
+      devXSecurityAccountMaybe: Option[AwsAccount]
   )(implicit ec: ExecutionContext): Attempt[String] = {
     val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
     val iamUser = remediationOperation.vulnerableCandidate.iamUser
@@ -82,6 +83,14 @@ class IamOutdatedCredentials(
       case (Remediation, OutdatedCredential) if !dryRun =>
         val notification =
           AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
+        val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
+          AnghammaradNotifications.outdatedCredentialRemediationDevXSecurity(
+            awsAccount,
+            iamUser,
+            problemCreationDate,
+            devXSecurityAccount
+          )
+        )
         for {
           // disable the correct credential
           userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
@@ -96,6 +105,12 @@ class IamOutdatedCredentials(
           notificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
           // save a record of the change
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+          // Send a notification to devx too, if we've got an account for them.
+          _ <- notificationDevXSecurityMaybe
+            .map(notificationDevXSecurity =>
+              AnghammaradNotifications.send(notificationDevXSecurity, notificationTopicArn, snsClient)
+            )
+            .getOrElse(Attempt.Right(logger.warn("No devx security account configured")))
         } yield notificationId
 
       case (Remediation, OutdatedCredential) =>
@@ -124,7 +139,8 @@ class IamOutdatedCredentials(
       tableName: String,
       serviceAccountIds: List[String],
       rawCredsReports: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]],
-      allowedAwsAccountIds: List[String]
+      allowedAwsAccountIds: List[String],
+      devXSecurityAccount: Option[AwsAccount]
   )(implicit ec: ExecutionContext): Attempt[Unit] = {
     val now = new DateTime()
     val accountsCredReports = getCredsReportDisplayForAccount(rawCredsReports)
@@ -151,7 +167,7 @@ class IamOutdatedCredentials(
       _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(dummyOperation)
       // now we know what operations need to be performed, so let's run each of those
       results <- Attempt.traverse(filteredOperations.allowedOperations)(
-        performRemediationOperation(_, now, notificationTopicArn, tableName, dryRun)
+        performRemediationOperation(_, now, notificationTopicArn, tableName, dryRun, devXSecurityAccount)
       )
     } yield results
     result.tap {
@@ -182,6 +198,7 @@ object IamOutdatedCredentials extends LazyLogging {
 
     val awsAccountsConfig = CoreConfig.loadConfigFromS3(settings.configBucket, settings.configKey, s3Client)
     val awsAccounts = CoreConfig.parseAccounts(awsAccountsConfig)
+    val devXSecurityAccount = awsAccounts.find(_.id == SECURITY_ACCOUNT_ID)
     val anghammaradSnsArn = awsAccountsConfig.getString(ANGHAMMARAD_SNS_TOPIC_ARN_CONFIG_ITEM)
     val iamDynamoTableName = awsAccountsConfig.getString(IAM_DYNAMO_TABLE_NAME_CONFIG_ITEM)
     val allowedAccountIds: List[String] =
@@ -210,7 +227,8 @@ object IamOutdatedCredentials extends LazyLogging {
         tableName = iamDynamoTableName,
         serviceAccountIds = accountIdsForIamRemediationService,
         rawCredsReports = listOfCredentialReports,
-        allowedAwsAccountIds = allowedAccountIds
+        allowedAwsAccountIds = allowedAccountIds,
+        devXSecurityAccount = devXSecurityAccount
       )
     } yield disableResult
   }
@@ -469,5 +487,6 @@ object IamOutdatedCredentials extends LazyLogging {
   private val ALLOWED_ACCOUNT_IDS_CONFIG_ITEM = "ALLOWED_ACCOUNT_IDS"
   private val ANGHAMMARAD_SNS_TOPIC_ARN_CONFIG_ITEM = "ANGHAMMARAD_SNS_TOPIC_ARN"
   private val IAM_DYNAMO_TABLE_NAME_CONFIG_ITEM = "IAM_DYNAMO_TABLE_NAME"
+  val SECURITY_ACCOUNT_ID = "security"
 
 }

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -60,6 +60,8 @@ class IamOutdatedCredentials(
         val notification =
           AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
         for {
+          // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
+          // don't want to record we sent a warning if we didn't, so we do it in this order
           snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
         } yield List(snsId)
@@ -72,6 +74,8 @@ class IamOutdatedCredentials(
         val notification =
           AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
         for {
+          // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
+          // don't want to record we sent a final warning if we didn't, so we do it in this order
           snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
           _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
         } yield List(snsId)
@@ -92,21 +96,26 @@ class IamOutdatedCredentials(
           )
         )
         for {
-          // disable the correct credential
+          // plan the disable action for the correct credential
           userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
           credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
+
+          // record, then alert, then do.  Different order to the above.
+          // If we do the remediation, it's vitally important that the record happens, and the alert happens.
+          // So do them first.
+          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+          // send a notification to say this is what we have done
+          userNotificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+          // Send a notification to devx too, if we've got an account for them.
+          securityNotificationIdMaybe <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe)
+
+          // only now do we actually disable the credential
           _ <- IAMClient.disableAccessKey(
             awsAccount,
             credentialToDisable.username,
             credentialToDisable.accessKeyId,
             iamClients
           )
-          // send a notification to say this is what we have done
-          userNotificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
-          // Send a notification to devx too, if we've got an account for them.
-          securityNotificationIdMaybe <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe)
-          // save a record of the change
-          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
         } yield List(userNotificationId) ++ securityNotificationIdMaybe
 
       case (Remediation, OutdatedCredential) =>

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -26,7 +26,9 @@ class IamOutdatedCredentials(
     iamClients: AwsClients[IamAsyncClient],
     dynamo: IamRemediationDb,
     devXSecurityAccountMaybe: Option[AwsAccount],
-    dryRun: Boolean = true
+    dryRun: Boolean,
+    notificationTopicArn: String,
+    tableName: String
 ) extends LazyLogging {
 
   /** Performs the specified operation, which will be one of:
@@ -37,9 +39,7 @@ class IamOutdatedCredentials(
     */
   private[logic] def performRemediationOperation(
       remediationOperation: RemediationOperation,
-      now: DateTime,
-      notificationTopicArn: String,
-      tableName: String
+      now: DateTime
   )(implicit ec: ExecutionContext): Attempt[List[String]] = {
     val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
     val iamUser = remediationOperation.vulnerableCandidate.iamUser
@@ -56,71 +56,109 @@ class IamOutdatedCredentials(
 
     (remediationOperation.iamRemediationActivityType, remediationOperation.iamProblem) match {
       // Outdated credentials
-      case (Warning, OutdatedCredential) if !dryRun =>
-        val notification =
-          AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
-        for {
-          // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
-          // don't want to record we sent a warning if we didn't, so we do it in this order
-          snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
-          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-        } yield List(snsId)
-
       case (Warning, OutdatedCredential) =>
-        logger.info(s"Dry run: Would send warning for $awsAccount, $iamUser")
-        Attempt.Right(Nil)
-
-      case (FinalWarning, OutdatedCredential) if !dryRun =>
-        val notification =
-          AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
-        for {
-          // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
-          // don't want to record we sent a final warning if we didn't, so we do it in this order
-          snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
-          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-        } yield List(snsId)
-
+        warn(now, awsAccount, iamUser, problemCreationDate, thisRemediationActivity)
       case (FinalWarning, OutdatedCredential) =>
-        logger.info(s"Dry run: Would send final warning for $awsAccount, $iamUser")
-        Attempt.Right(Nil)
-
-      case (Remediation, OutdatedCredential) if !dryRun =>
-        val notification =
-          AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
-        val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
-          AnghammaradNotifications.outdatedCredentialRemediationDevXSecurity(
-            awsAccount,
-            iamUser,
-            problemCreationDate,
-            devXSecurityAccount
-          )
+        finalWarn(
+          now,
+          awsAccount,
+          iamUser,
+          problemCreationDate,
+          thisRemediationActivity
         )
-        for {
-          // plan the disable action for the correct credential
-          userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
-          credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
-
-          // record, then alert, then do.  Different order to the above.
-          // If we do the remediation, it's vitally important that the record happens, and the alert happens.
-          // So do them first.
-          _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
-          // send a notification to say this is what we have done
-          userNotificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
-          // Send a notification to devx too, if we've got an account for them.
-          securityNotificationIdMaybe <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe)
-
-          // only now do we actually disable the credential
-          _ <- IAMClient.disableAccessKey(
-            awsAccount,
-            credentialToDisable.username,
-            credentialToDisable.accessKeyId,
-            iamClients
-          )
-        } yield List(userNotificationId) ++ securityNotificationIdMaybe
 
       case (Remediation, OutdatedCredential) =>
-        logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
-        Attempt.Right(Nil)
+        remediation(awsAccount, iamUser, problemCreationDate, thisRemediationActivity)
+    }
+  }
+
+  private def remediation(
+      awsAccount: AwsAccount,
+      iamUser: IAMUser,
+      problemCreationDate: DateTime,
+      thisRemediationActivity: IamRemediationActivity
+  )(implicit ec: ExecutionContext) = {
+    if (!dryRun) {
+      val notification =
+        AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
+      val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
+        AnghammaradNotifications.outdatedCredentialRemediationDevXSecurity(
+          awsAccount,
+          iamUser,
+          problemCreationDate,
+          devXSecurityAccount
+        )
+      )
+      for {
+        // plan the disable action for the correct credential
+        userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
+        credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
+
+        // record, then alert, then do.  Different order to the above.
+        // If we do the remediation, it's vitally important that the record happens, and the alert happens.
+        // So do them first.
+        _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+        // send a notification to say this is what we have done
+        userNotificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+        // Send a notification to devx too, if we've got an account for them.
+        securityNotificationIdMaybe <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe)
+
+        // only now do we actually disable the credential
+        _ <- IAMClient.disableAccessKey(
+          awsAccount,
+          credentialToDisable.username,
+          credentialToDisable.accessKeyId,
+          iamClients
+        )
+      } yield List(userNotificationId) ++ securityNotificationIdMaybe
+    } else {
+      logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
+      Attempt.Right(Nil)
+    }
+  }
+
+  private def finalWarn(
+      now: DateTime,
+      awsAccount: AwsAccount,
+      iamUser: IAMUser,
+      problemCreationDate: DateTime,
+      thisRemediationActivity: IamRemediationActivity
+  )(implicit ec: ExecutionContext) = {
+    if (!dryRun) {
+
+      val notification =
+        AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
+      for {
+        // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
+        // don't want to record we sent a final warning if we didn't, so we do it in this order
+        snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+        _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+      } yield List(snsId)
+    } else {
+      logger.info(s"Dry run: Would send final warning for $awsAccount, $iamUser")
+      Attempt.Right(Nil)
+    }
+  }
+
+  private def warn(
+      now: DateTime,
+      awsAccount: AwsAccount,
+      iamUser: IAMUser,
+      problemCreationDate: DateTime,
+      thisRemediationActivity: IamRemediationActivity
+  )(implicit ec: ExecutionContext) = {
+    if (!dryRun) {
+      val notification =
+        AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
+      for {
+        // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
+        // don't want to record we sent a warning if we didn't, so we do it in this order
+        snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
+        _ <- dynamo.writeRemediationActivity(thisRemediationActivity, tableName)
+      } yield List(snsId)
+    } else {
+      logger.info(s"Dry run: Would send warning for $awsAccount, $iamUser")
+      Attempt.Right(Nil)
     }
   }
 
@@ -141,7 +179,7 @@ class IamOutdatedCredentials(
   /** We only perform actions on accounts that are explicitly allowed, but it is helpful to log the operation that
     * *would* have been performed, if allowed.
     */
-  private def dummyOperation(remediationOperation: RemediationOperation): Unit = {
+  private def logOperationOnly(remediationOperation: RemediationOperation): Unit = {
     val awsAccount = remediationOperation.vulnerableCandidate.awsAccount
     logger.warn(s"Remediation operation skipped because ${awsAccount.id} is not configured for remediation")
     logger.warn(s"Skipping remediation action: ${formatRemediationOperation(remediationOperation)}")
@@ -154,8 +192,6 @@ class IamOutdatedCredentials(
     * automatically disabled.
     */
   def disableOutdatedCredentials(
-      notificationTopicArn: String,
-      tableName: String,
       serviceAccountIds: List[String],
       rawCredsReports: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]],
       allowedAwsAccountIds: List[String]
@@ -181,11 +217,13 @@ class IamOutdatedCredentials(
         allowedAwsAccountIds,
         serviceAccountIds
       )
+
       // we won't execute these operations, but can log them instead
-      _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(dummyOperation)
+      _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(logOperationOnly)
+
       // now we know what operations need to be performed, so let's run each of those
       results <- Attempt.traverse(filteredOperations.allowedOperations)(
-        performRemediationOperation(_, now, notificationTopicArn, tableName)
+        performRemediationOperation(_, now)
       )
     } yield results
     result.tap {
@@ -240,10 +278,10 @@ object IamOutdatedCredentials extends LazyLogging {
         iamClients = iamClients,
         dynamo = dynamo,
         devXSecurityAccountMaybe = devXSecurityAccount,
-        dryRun = settings.dryRun
-      ).disableOutdatedCredentials(
+        dryRun = settings.dryRun,
         notificationTopicArn = anghammaradSnsArn,
-        tableName = iamDynamoTableName,
+        tableName = iamDynamoTableName
+      ).disableOutdatedCredentials(
         serviceAccountIds = accountIdsForIamRemediationService,
         rawCredsReports = listOfCredentialReports,
         allowedAwsAccountIds = allowedAccountIds

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -754,7 +754,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
 
   "performRemediationOperation" - {
 
-    val fakeRemediationSnsClient = new SnsAsyncClient {
+    def getFakeRemediationSnsClient() = new SnsAsyncClient {
       private var notificationCount = 0
 
       override def publish(publishRequest: PublishRequest): CompletableFuture[PublishResponse] = {
@@ -798,7 +798,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     }
 
     def getIamOutdatedCredentials(dryRun: Boolean) = new IamOutdatedCredentials(
-      snsClient = fakeRemediationSnsClient,
+      snsClient = getFakeRemediationSnsClient(),
       iamClients = List(AwsClient(fakeRemediationIamClient, account, Region.of("us-east-1"))),
       dynamo = fakeRemediationDb,
       dryRun = dryRun
@@ -873,10 +873,22 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           devXSecurityAccountMaybe = securityAccount
         )
         result.value().length shouldBe 1
-        result.value().head shouldBe "sns-2"
+        result.value().head shouldBe "sns-1"
       }
 
-      "should return two notifications for remediation" in {
+      "should return one notification for remediation when security account is not present" in {
+        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+          getOperation(Remediation),
+          new DateTime(),
+          fakeTopicArn,
+          fakeRemediationTableName,
+          devXSecurityAccountMaybe = None
+        )
+        result.value().length shouldBe 1
+        result.value().head shouldBe "sns-1"
+      }
+
+      "should return two notifications for remediation when security account is present" in {
         val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
           getOperation(Remediation),
           new DateTime(),
@@ -885,9 +897,8 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           devXSecurityAccountMaybe = securityAccount
         )
         result.value().length shouldBe 2
-        result.value().head shouldBe "sns-3"
-        result.value().tail.head shouldBe "sns-4"
-
+        result.value().head shouldBe "sns-1"
+        result.value().tail.head shouldBe "sns-2"
       }
     }
   }

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -754,7 +754,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
 
   "performRemediationOperation" - {
 
-    def getFakeRemediationSnsClient() = new SnsAsyncClient {
+    def getFakeRemediationSnsClient = new SnsAsyncClient {
       private var notificationCount = 0
 
       override def publish(publishRequest: PublishRequest): CompletableFuture[PublishResponse] = {
@@ -797,13 +797,14 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       ): Attempt[String] = Attempt.Right("fake-dynamo-write-id")
     }
 
-    def getIamOutdatedCredentials(dryRun: Boolean, devXSecurityAccountMaybe: Option[AwsAccount]) = new IamOutdatedCredentials(
-      snsClient = getFakeRemediationSnsClient(),
-      iamClients = List(AwsClient(fakeRemediationIamClient, account, Region.of("us-east-1"))),
-      dynamo = fakeRemediationDb,
-      devXSecurityAccountMaybe = devXSecurityAccountMaybe,
-      dryRun = dryRun
-    )
+    def getIamOutdatedCredentials(dryRun: Boolean, devXSecurityAccountMaybe: Option[AwsAccount]) =
+      new IamOutdatedCredentials(
+        snsClient = getFakeRemediationSnsClient,
+        iamClients = List(AwsClient(fakeRemediationIamClient, account, Region.of("us-east-1"))),
+        dynamo = fakeRemediationDb,
+        devXSecurityAccountMaybe = devXSecurityAccountMaybe,
+        dryRun = dryRun
+      )
 
     val fakeTopicArn = "arn:aws:sns:eu-west-1:123456789012:test-topic"
     val fakeRemediationTableName = "test-remediation-table"
@@ -832,7 +833,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           getOperation(FinalWarning),
           new DateTime(),
           fakeTopicArn,
-          fakeRemediationTableName,
+          fakeRemediationTableName
         )
         result.value() shouldEqual Nil
       }
@@ -842,7 +843,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           getOperation(Remediation),
           new DateTime(),
           fakeTopicArn,
-          fakeRemediationTableName,
+          fakeRemediationTableName
         )
         result.value() shouldEqual Nil
       }

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -1,7 +1,9 @@
 package logic
 
+import aws.AwsClient
 import config.CoreConfig
 import config.CoreConfig.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
+import db.IamRemediationDb
 import logic.IamOutdatedCredentials.*
 import model.*
 import org.joda.time.DateTime
@@ -9,8 +11,21 @@ import org.scalatest.Inside.inside
 import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
-import utils.attempt.AttemptValues
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.iam.IamAsyncClient
+import software.amazon.awssdk.services.iam.model.{
+  AccessKeyMetadata,
+  ListAccessKeysRequest,
+  ListAccessKeysResponse,
+  StatusType,
+  UpdateAccessKeyResponse
+}
+import software.amazon.awssdk.services.sns.SnsAsyncClient
+import software.amazon.awssdk.services.sns.model.{PublishRequest, PublishResponse}
+import utils.attempt.{Attempt, AttemptValues}
 
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionValues with AttemptValues {
@@ -734,6 +749,146 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       formatRemediationOperation(
         operation
       ) shouldEqual "OutdatedCredential FinalWarning for user machine.user from account testAccountId"
+    }
+  }
+
+  "performRemediationOperation" - {
+
+    val fakeRemediationSnsClient = new SnsAsyncClient {
+      private var notificationCount = 0
+
+      override def publish(publishRequest: PublishRequest): CompletableFuture[PublishResponse] = {
+        notificationCount += 1
+        CompletableFuture.completedFuture(PublishResponse.builder().messageId(s"sns-$notificationCount").build())
+      }
+
+      override def serviceName(): String = "sns"
+
+      override def close(): Unit = ()
+    }
+
+    val fakeRemediationIamClient = new IamAsyncClient {
+      override def listAccessKeys(request: ListAccessKeysRequest): CompletableFuture[ListAccessKeysResponse] = {
+        val accessKeyMetadata = AccessKeyMetadata
+          .builder()
+          .userName(request.userName())
+          .accessKeyId("TEST_KEY")
+          .status(StatusType.ACTIVE)
+          .createDate(Instant.ofEpochMilli(machineAccessKeyOldAndEnabled.lastRotated.get.getMillis))
+          .build()
+        CompletableFuture.completedFuture(
+          ListAccessKeysResponse.builder().accessKeyMetadata(accessKeyMetadata).build()
+        )
+      }
+
+      override def updateAccessKey(
+          request: software.amazon.awssdk.services.iam.model.UpdateAccessKeyRequest
+      ): CompletableFuture[UpdateAccessKeyResponse] =
+        CompletableFuture.completedFuture(UpdateAccessKeyResponse.builder().build())
+
+      override def serviceName(): String = "iam"
+
+      override def close(): Unit = ()
+    }
+
+    val fakeRemediationDb = new IamRemediationDb(null) {
+      override def writeRemediationActivity(iamRemediationActivity: IamRemediationActivity, tableName: String)(implicit
+          ec: scala.concurrent.ExecutionContext
+      ): Attempt[String] = Attempt.Right("fake-dynamo-write-id")
+    }
+
+    def getIamOutdatedCredentials(dryRun: Boolean) = new IamOutdatedCredentials(
+      snsClient = fakeRemediationSnsClient,
+      iamClients = List(AwsClient(fakeRemediationIamClient, account, Region.of("us-east-1"))),
+      dynamo = fakeRemediationDb,
+      dryRun = dryRun
+    )
+
+    val fakeTopicArn = "arn:aws:sns:eu-west-1:123456789012:test-topic"
+    val fakeRemediationTableName = "test-remediation-table"
+    val securityAccount = Some(AwsAccount("security", "Security", "role", "999999999999"))
+    def getOperation(IamRemediationActivityType: IamRemediationActivityType) = RemediationOperation(
+      IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, Nil),
+      IamRemediationActivityType,
+      OutdatedCredential,
+      machineAccessKeyOldAndEnabled.lastRotated.get
+    )
+
+    "in dry run mode" - {
+      val dryRun = true
+      "should return no notifications for warning" in {
+        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+          getOperation(Warning),
+          new DateTime(),
+          fakeTopicArn,
+          fakeRemediationTableName,
+          devXSecurityAccountMaybe = securityAccount
+        )
+        result.value() shouldEqual Nil
+      }
+
+      "should return no notifications for final warning" in {
+        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+          getOperation(FinalWarning),
+          new DateTime(),
+          fakeTopicArn,
+          fakeRemediationTableName,
+          devXSecurityAccountMaybe = securityAccount
+        )
+        result.value() shouldEqual Nil
+      }
+
+      "should return no notifications for remediation" in {
+        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+          getOperation(Remediation),
+          new DateTime(),
+          fakeTopicArn,
+          fakeRemediationTableName,
+          devXSecurityAccountMaybe = securityAccount
+        )
+        result.value() shouldEqual Nil
+      }
+    }
+
+    "not in dry run mode" - {
+      val dryRun = false
+      "should return one notification for warning" in {
+        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+          getOperation(Warning),
+          new DateTime(),
+          fakeTopicArn,
+          fakeRemediationTableName,
+          devXSecurityAccountMaybe = securityAccount
+        )
+        result.value().length shouldBe 1
+        result.value().head shouldBe "sns-1"
+      }
+
+      "should return one notification for final warning" in {
+        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+          getOperation(FinalWarning),
+          new DateTime(),
+          fakeTopicArn,
+          fakeRemediationTableName,
+          devXSecurityAccountMaybe = securityAccount
+        )
+        result.value().length shouldBe 1
+        result.value().head shouldBe "sns-2"
+      }
+
+      "should return two notifications for remediation" in {
+        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+          getOperation(Remediation),
+          new DateTime(),
+          fakeTopicArn,
+          fakeRemediationTableName,
+          devXSecurityAccountMaybe = securityAccount
+        )
+        result.value().length shouldBe 2
+        result.value().head shouldBe "sns-3"
+        result.value().tail.head shouldBe "sns-4"
+
+      }
     }
   }
 

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -797,16 +797,17 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       ): Attempt[String] = Attempt.Right("fake-dynamo-write-id")
     }
 
-    def getIamOutdatedCredentials(dryRun: Boolean) = new IamOutdatedCredentials(
+    def getIamOutdatedCredentials(dryRun: Boolean, devXSecurityAccountMaybe: Option[AwsAccount]) = new IamOutdatedCredentials(
       snsClient = getFakeRemediationSnsClient(),
       iamClients = List(AwsClient(fakeRemediationIamClient, account, Region.of("us-east-1"))),
       dynamo = fakeRemediationDb,
+      devXSecurityAccountMaybe = devXSecurityAccountMaybe,
       dryRun = dryRun
     )
 
     val fakeTopicArn = "arn:aws:sns:eu-west-1:123456789012:test-topic"
     val fakeRemediationTableName = "test-remediation-table"
-    val securityAccount = Some(AwsAccount("security", "Security", "role", "999999999999"))
+    val securityAccount = AwsAccount("security", "Security", "role", "999999999999")
     def getOperation(IamRemediationActivityType: IamRemediationActivityType) = RemediationOperation(
       IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, Nil),
       IamRemediationActivityType,
@@ -817,34 +818,31 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     "in dry run mode" - {
       val dryRun = true
       "should return no notifications for warning" in {
-        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
           new DateTime(),
           fakeTopicArn,
-          fakeRemediationTableName,
-          devXSecurityAccountMaybe = securityAccount
+          fakeRemediationTableName
         )
         result.value() shouldEqual Nil
       }
 
       "should return no notifications for final warning" in {
-        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(FinalWarning),
           new DateTime(),
           fakeTopicArn,
           fakeRemediationTableName,
-          devXSecurityAccountMaybe = securityAccount
         )
         result.value() shouldEqual Nil
       }
 
       "should return no notifications for remediation" in {
-        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Remediation),
           new DateTime(),
           fakeTopicArn,
           fakeRemediationTableName,
-          devXSecurityAccountMaybe = securityAccount
         )
         result.value() shouldEqual Nil
       }
@@ -853,48 +851,44 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     "not in dry run mode" - {
       val dryRun = false
       "should return one notification for warning" in {
-        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
           new DateTime(),
           fakeTopicArn,
-          fakeRemediationTableName,
-          devXSecurityAccountMaybe = securityAccount
+          fakeRemediationTableName
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
       }
 
       "should return one notification for final warning" in {
-        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(FinalWarning),
           new DateTime(),
           fakeTopicArn,
-          fakeRemediationTableName,
-          devXSecurityAccountMaybe = securityAccount
+          fakeRemediationTableName
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
       }
 
       "should return one notification for remediation when security account is not present" in {
-        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+        val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
           getOperation(Remediation),
           new DateTime(),
           fakeTopicArn,
-          fakeRemediationTableName,
-          devXSecurityAccountMaybe = None
+          fakeRemediationTableName
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
       }
 
       "should return two notifications for remediation when security account is present" in {
-        val result = getIamOutdatedCredentials(dryRun).performRemediationOperation(
+        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Remediation),
           new DateTime(),
           fakeTopicArn,
-          fakeRemediationTableName,
-          devXSecurityAccountMaybe = securityAccount
+          fakeRemediationTableName
         )
         result.value().length shouldBe 2
         result.value().head shouldBe "sns-1"

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -797,17 +797,19 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       ): Attempt[String] = Attempt.Right("fake-dynamo-write-id")
     }
 
+    val fakeTopicArn = "arn:aws:sns:eu-west-1:123456789012:test-topic"
+    val fakeRemediationTableName = "test-remediation-table"
     def getIamOutdatedCredentials(dryRun: Boolean, devXSecurityAccountMaybe: Option[AwsAccount]) =
       new IamOutdatedCredentials(
         snsClient = getFakeRemediationSnsClient,
         iamClients = List(AwsClient(fakeRemediationIamClient, account, Region.of("us-east-1"))),
         dynamo = fakeRemediationDb,
         devXSecurityAccountMaybe = devXSecurityAccountMaybe,
-        dryRun = dryRun
+        dryRun = dryRun,
+        notificationTopicArn = fakeTopicArn,
+        tableName = fakeRemediationTableName
       )
 
-    val fakeTopicArn = "arn:aws:sns:eu-west-1:123456789012:test-topic"
-    val fakeRemediationTableName = "test-remediation-table"
     val securityAccount = AwsAccount("security", "Security", "role", "999999999999")
     def getOperation(IamRemediationActivityType: IamRemediationActivityType) = RemediationOperation(
       IamUserRemediationHistory(account, machineWithOneOldEnabledAccessKey, Nil),
@@ -821,9 +823,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return no notifications for warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
-          new DateTime(),
-          fakeTopicArn,
-          fakeRemediationTableName
+          new DateTime()
         )
         result.value() shouldEqual Nil
       }
@@ -831,9 +831,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return no notifications for final warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(FinalWarning),
-          new DateTime(),
-          fakeTopicArn,
-          fakeRemediationTableName
+          new DateTime()
         )
         result.value() shouldEqual Nil
       }
@@ -841,9 +839,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return no notifications for remediation" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Remediation),
-          new DateTime(),
-          fakeTopicArn,
-          fakeRemediationTableName
+          new DateTime()
         )
         result.value() shouldEqual Nil
       }
@@ -854,9 +850,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return one notification for warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
-          new DateTime(),
-          fakeTopicArn,
-          fakeRemediationTableName
+          new DateTime()
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
@@ -865,9 +859,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return one notification for final warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(FinalWarning),
-          new DateTime(),
-          fakeTopicArn,
-          fakeRemediationTableName
+          new DateTime()
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
@@ -876,9 +868,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return one notification for remediation when security account is not present" in {
         val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
           getOperation(Remediation),
-          new DateTime(),
-          fakeTopicArn,
-          fakeRemediationTableName
+          new DateTime()
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
@@ -887,9 +877,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return two notifications for remediation when security account is present" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Remediation),
-          new DateTime(),
-          fakeTopicArn,
-          fakeRemediationTableName
+          new DateTime()
         )
         result.value().length shouldBe 2
         result.value().head shouldBe "sns-1"

--- a/script/setup
+++ b/script/setup
@@ -44,6 +44,7 @@ downloadConfig() {
     # BSD sed (macOS)
     sed -i '' 's|"/Users/ADD_YOUR_NAME|${HOME}"|g' ~/.gu/security-hq/security-hq.local.conf
   fi
+}
 
 startDynamoDb() {
   docker-compose up -d


### PR DESCRIPTION
## What does this change?

This PR adds an additional notification to DevX/Security whenever a credential is de-activated.

This provides us with a helpful heads-up that we are likely to have a team somewhere with a broken process.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216793019549897