### PR TITLE
Cache and reuse constructed AWS clients

### DIFF
--- a/core/src/main/scala/aws/AWS.scala
+++ b/core/src/main/scala/aws/AWS.scala
@@ -3,6 +3,7 @@ package aws
 import config.CoreConfig
 import model.AwsAccount
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, ProfileCredentialsProvider}
+import software.amazon.awssdk.awscore
 import software.amazon.awssdk.awscore.client.builder.{AwsAsyncClientBuilder, AwsClientBuilder}
 import software.amazon.awssdk.core.client.config.SdkAdvancedAsyncClientOption
 import software.amazon.awssdk.regions.Region
@@ -16,6 +17,20 @@ import software.amazon.awssdk.services.support.SupportAsyncClient
 import utils.attempt.{Attempt, Failure}
 
 import java.util.concurrent.Executors.newCachedThreadPool
+import java.util.concurrent.ConcurrentHashMap
+
+private class AwsClientCache[T <: awscore.AwsClient](clientBuilder: (AwsAccount, Region) => T) {
+  private val clients: ConcurrentHashMap[(AwsAccount, String), AwsClient[T]] = new ConcurrentHashMap()
+
+  def getClient(account: AwsAccount, region: Region): AwsClient[T] =
+    clients.computeIfAbsent((account, region.id), _ => AwsClient(clientBuilder(account, region), account, region))
+
+  def getClients(accounts: List[AwsAccount], regions: List[Region]): AwsClients[T] =
+    for {
+      account <- accounts
+      region <- regions
+    } yield getClient(account, region)
+}
 
 object AWS {
 
@@ -46,39 +61,59 @@ object AWS {
     )
   }
 
-  private[aws] def clients[A, B <: AwsClientBuilder[B, A]](
-      builder: AwsClientBuilder[B, A],
-      accounts: List[AwsAccount],
-      regionList: Region*
-  ): AwsClients[A] = {
-    for {
-      account <- accounts
-      region <- regionList
-      client = builder
-        .credentialsProvider(credentialsProvider(account))
-        .region(region)
-        .build()
-    } yield AwsClient(client, account, region)
-  }
+  private def client[A, B <: AwsClientBuilder[B, A]](
+      clientBuilder: AwsClientBuilder[B, A],
+      account: AwsAccount,
+      region: Region
+  ): A =
+    clientBuilder
+      .credentialsProvider(credentialsProvider(account))
+      .region(region)
+      .build()
 
   private lazy val sharedThreadPool = newCachedThreadPool()
 
-  private def withCustomThreadPool[A, B <: AwsAsyncClientBuilder[B, A]] =
-    (asyncClientBuilder: AwsAsyncClientBuilder[B, A]) =>
-      asyncClientBuilder.asyncConfiguration(c =>
-        c.advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, sharedThreadPool)
-      )
+  private def withCustomThreadPool[A, B <: AwsAsyncClientBuilder[B, A]](
+      asyncClientBuilder: AwsAsyncClientBuilder[B, A]
+  ): B = asyncClientBuilder.asyncConfiguration(c =>
+    c.advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, sharedThreadPool)
+  )
+
+  private def cfnClientBuilder(account: AwsAccount, region: Region): CloudFormationAsyncClient =
+    client(withCustomThreadPool(CloudFormationAsyncClient.builder()), account, region)
+  private val cfnClientCache = new AwsClientCache(cfnClientBuilder)
+
+  def cfnClient(account: AwsAccount, region: Region): AwsClient[CloudFormationAsyncClient] =
+    cfnClientCache.getClient(account, region)
 
   def cfnClients(accounts: List[AwsAccount], regions: List[Region]): AwsClients[CloudFormationAsyncClient] =
-    clients(withCustomThreadPool(CloudFormationAsyncClient.builder), accounts, regions: _*)
+    cfnClientCache.getClients(accounts, regions)
+
+  private def taClientBuilder(account: AwsAccount, region: Region): SupportAsyncClient =
+    client(withCustomThreadPool(SupportAsyncClient.builder), account, region)
+  private val taClientCache = new AwsClientCache(taClientBuilder)
 
   // Only needs Regions.US_EAST_1
   def taClients(accounts: List[AwsAccount], region: Region = Region.of("us-east-1")): AwsClients[SupportAsyncClient] =
-    clients(withCustomThreadPool(SupportAsyncClient.builder), accounts, region)
+    taClientCache.getClients(accounts, List(region))
+
+  private def s3ClientBuilder(account: AwsAccount, region: Region): S3Client =
+    client(S3Client.builder(), account, region)
+  private val s3ClientCache = new AwsClientCache(s3ClientBuilder)
+
+  def s3Client(account: AwsAccount, region: Region): AwsClient[S3Client] =
+    s3ClientCache.getClient(account, region)
 
   def s3Clients(accounts: List[AwsAccount], regions: List[Region]): AwsClients[S3Client] =
-    clients(S3Client.builder, accounts, regions: _*)
+    s3ClientCache.getClients(accounts, regions)
+
+  private def iamClientBuilder(account: AwsAccount, region: Region): IamAsyncClient =
+    client(withCustomThreadPool(IamAsyncClient.builder()), account, region)
+  private val iamClientCache = new AwsClientCache(iamClientBuilder)
+
+  def iamClient(account: AwsAccount, region: Region): AwsClient[IamAsyncClient] =
+    iamClientCache.getClient(account, region)
 
   def iamClients(accounts: List[AwsAccount], regions: List[Region]): AwsClients[IamAsyncClient] =
-    clients(withCustomThreadPool(IamAsyncClient.builder), accounts, regions: _*)
+    iamClientCache.getClients(accounts, regions)
 }


### PR DESCRIPTION
## What does this change?

As in the title - create a cache of constructed sdk clients, so we can avoid unnecessary repeated construction.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

This should be more performant

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
