### PR TITLE
Turn on Outdated Credentials lambda

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1531,7 +1531,7 @@ exports[`HQ stack matches the snapshot 1`] = `
             "APP": "iam-outdated-credentials",
             "CONFIG_BUCKET": "security-dist",
             "CONFIG_KEY": "security/PROD/security-hq/security-hq.conf",
-            "DRY_RUN": "true",
+            "DRY_RUN": "false",
             "STACK": "security",
             "STAGE": "PROD",
           },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -373,7 +373,7 @@ export class SecurityHQ extends GuStack {
         environment: {
           STACK: this.stack,
           STAGE: this.stage,
-          DRY_RUN: "true",
+          DRY_RUN: "false",
           CONFIG_BUCKET: "security-dist",
           CONFIG_KEY: `security/${this.stage}/security-hq/security-hq.conf`,
         },


### PR DESCRIPTION
## What does this change?

Flips the switch to turn the Outdated Credentials lambda from dry run to active.

This will result in warnings being sent and deactivations being made from the very next run.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
