### PR TITLE
Restrict remediation events to Tuesdays

### DIFF
--- a/core/src/main/scala/notifications/AnghammaradNotifications.scala
+++ b/core/src/main/scala/notifications/AnghammaradNotifications.scala
@@ -118,6 +118,37 @@ object AnghammaradNotifications extends LazyLogging {
     )
   }
 
+  def outdatedCredentialNoRemediationDevXSecurity(
+      awsAccount: AwsAccount,
+      iamUser: IAMUser,
+      problemCreationDate: DateTime,
+      devXSecurityAccount: AwsAccount
+  ): Notification = {
+    val endUserNotificationTargets = notificationTargets(awsAccount, iamUser)
+    val devxSecurityNotificationTargets = List(Account(devXSecurityAccount.accountNumber))
+    val endUserTargetsString = endUserNotificationTargets.map(_.toString).mkString(", ")
+    val message =
+      s"""
+         |The permanent credential, ${iamUser.username}, in ${awsAccount.name} was eligible for deactivation today,
+         |because it was last rotated on ${printDay(problemCreationDate)}.
+         |
+         |It wasn't deactivated because it's not Deactivation Tuesday.
+         |
+         |THIS ACTION HAS HIGH POTENTIAL TO BREAK THINGS.
+         |
+         |BE PREPARED FOR USERS TO BE UPSET!
+         |""".stripMargin
+    val subject = s"DISABLED long-lived credential in ${awsAccount.name}"
+    Notification(
+      subject,
+      message + genericOutdatedCredentialText,
+      Nil,
+      devxSecurityNotificationTargets,
+      channel,
+      sourceSystem
+    )
+  }
+
   def outdatedCredentialRemediationDevXSecurity(
       awsAccount: AwsAccount,
       iamUser: IAMUser,

--- a/core/src/main/scala/notifications/AnghammaradNotifications.scala
+++ b/core/src/main/scala/notifications/AnghammaradNotifications.scala
@@ -138,7 +138,7 @@ object AnghammaradNotifications extends LazyLogging {
          |
          |BE PREPARED FOR USERS TO BE UPSET!
          |""".stripMargin
-    val subject = s"DISABLED long-lived credential in ${awsAccount.name}"
+    val subject = s"Imminent disabling of long-lived credential in ${awsAccount.name}"
     Notification(
       subject,
       message + genericOutdatedCredentialText,

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -10,7 +10,7 @@ import logic.IamOutdatedCredentials.*
 import logic.IamUnrecognisedUsers.*
 import model.*
 import notifications.AnghammaradNotifications
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeConstants}
 import settings.Settings
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.iam.IamAsyncClient
@@ -68,17 +68,32 @@ class IamOutdatedCredentials(
         )
 
       case (Remediation, OutdatedCredential) =>
-        remediation(awsAccount, iamUser, problemCreationDate, thisRemediationActivity)
+        remediation(now, awsAccount, iamUser, problemCreationDate, thisRemediationActivity)
     }
   }
 
   private def remediation(
+      now: DateTime,
       awsAccount: AwsAccount,
       iamUser: IAMUser,
       problemCreationDate: DateTime,
       thisRemediationActivity: IamRemediationActivity
   )(implicit ec: ExecutionContext) = {
-    if (!dryRun) {
+    if (dryRun) {
+      logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
+      Attempt.Right(Nil)
+    } else if (now.dayOfWeek().get() != DateTimeConstants.TUESDAY) {
+      logger.info(s"""It's not "Remediation Tuesday"!  We will not execute remediation for $awsAccount, $iamUser TODAY, but we will SOON""")
+      val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
+        AnghammaradNotifications.outdatedCredentialNoRemediationDevXSecurity(
+          awsAccount,
+          iamUser,
+          problemCreationDate,
+          devXSecurityAccount
+        )
+      )
+      sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe).map(_.toList)
+    } else {
       val notification =
         AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
       val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
@@ -111,9 +126,6 @@ class IamOutdatedCredentials(
           iamClients
         )
       } yield List(userNotificationId) ++ securityNotificationIdMaybe
-    } else {
-      logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
-      Attempt.Right(Nil)
     }
   }
 

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -83,7 +83,9 @@ class IamOutdatedCredentials(
       logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
       Attempt.Right(Nil)
     } else if (now.dayOfWeek().get() != DateTimeConstants.TUESDAY) {
-      logger.info(s"""It's not "Remediation Tuesday"!  We will not execute remediation for $awsAccount, $iamUser TODAY, but we will SOON""")
+      logger.info(
+        s"""It's not "Remediation Tuesday"!  We will not execute remediation for $awsAccount, $iamUser TODAY, but we will SOON"""
+      )
       val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
         AnghammaradNotifications.outdatedCredentialNoRemediationDevXSecurity(
           awsAccount,

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -752,6 +752,8 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     }
   }
 
+  private val notTuesday = new DateTime().withDayOfWeek(1)
+  private val tuesday = new DateTime().withDayOfWeek(2)
   "performRemediationOperation" - {
 
     def getFakeRemediationSnsClient = new SnsAsyncClient {
@@ -820,10 +822,11 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
 
     "in dry run mode" - {
       val dryRun = true
+      val today = new DateTime()
       "should return no notifications for warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
-          new DateTime()
+          today
         )
         result.value() shouldEqual Nil
       }
@@ -831,7 +834,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return no notifications for final warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(FinalWarning),
-          new DateTime()
+          today
         )
         result.value() shouldEqual Nil
       }
@@ -839,7 +842,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return no notifications for remediation" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Remediation),
-          new DateTime()
+          today
         )
         result.value() shouldEqual Nil
       }
@@ -850,7 +853,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return one notification for warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
-          new DateTime()
+          notTuesday
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
@@ -859,29 +862,50 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return one notification for final warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(FinalWarning),
-          new DateTime()
+          notTuesday
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
       }
 
-      "should return one notification for remediation when security account is not present" in {
-        val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
-          getOperation(Remediation),
-          new DateTime()
-        )
-        result.value().length shouldBe 1
-        result.value().head shouldBe "sns-1"
+      "on Remediation Tuesdays" - {
+        "should return one notification for remediation when security account is not present" in {
+          val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
+            getOperation(Remediation),
+            tuesday
+          )
+          result.value().length shouldBe 1
+          result.value().head shouldBe "sns-1"
+        }
+
+        "should return two notifications for remediation when security account is present" in {
+          val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
+            getOperation(Remediation),
+            tuesday
+          )
+          result.value().length shouldBe 2
+          result.value().head shouldBe "sns-1"
+          result.value().tail.head shouldBe "sns-2"
+        }
       }
 
-      "should return two notifications for remediation when security account is present" in {
-        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-          getOperation(Remediation),
-          new DateTime()
-        )
-        result.value().length shouldBe 2
-        result.value().head shouldBe "sns-1"
-        result.value().tail.head shouldBe "sns-2"
+      "on other days" - {
+        "should return no notifications for no remediation when security account is not present" in {
+          val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
+            getOperation(Remediation),
+            notTuesday
+          )
+          result.value().length shouldBe 0
+        }
+
+        "should return one notification for no remediation when security account is present" in {
+          val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
+            getOperation(Remediation),
+            notTuesday
+          )
+          result.value().length shouldBe 1
+          result.value().head shouldBe "sns-1"
+        }
       }
     }
   }
@@ -892,7 +916,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       IamUserRemediationHistory(AwsAccount(id, "", "", ""), machineUser, Nil),
       Warning,
       OutdatedCredential,
-      new DateTime()
+      notTuesday
     )
   }
   def remediationActivity(

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.iam.model.{
   ListAccessKeysRequest,
   ListAccessKeysResponse,
   StatusType,
+  UpdateAccessKeyRequest,
   UpdateAccessKeyResponse
 }
 import software.amazon.awssdk.services.sns.SnsAsyncClient
@@ -26,6 +27,7 @@ import utils.attempt.{Attempt, AttemptValues}
 
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionValues with AttemptValues {
@@ -771,7 +773,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       override def close(): Unit = ()
     }
 
-    val fakeRemediationIamClient = new IamAsyncClient {
+    def getFakeRemediationIamClient(remediationCounter: AtomicInteger): IamAsyncClient = new IamAsyncClient {
       override def listAccessKeys(request: ListAccessKeysRequest): CompletableFuture[ListAccessKeysResponse] = {
         val accessKeyMetadata = AccessKeyMetadata
           .builder()
@@ -787,8 +789,10 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
 
       override def updateAccessKey(
           request: software.amazon.awssdk.services.iam.model.UpdateAccessKeyRequest
-      ): CompletableFuture[UpdateAccessKeyResponse] =
+      ): CompletableFuture[UpdateAccessKeyResponse] = {
+        remediationCounter.incrementAndGet()
         CompletableFuture.completedFuture(UpdateAccessKeyResponse.builder().build())
+      }
 
       override def serviceName(): String = "iam"
 
@@ -803,10 +807,14 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
 
     val fakeTopicArn = "arn:aws:sns:eu-west-1:123456789012:test-topic"
     val fakeRemediationTableName = "test-remediation-table"
-    def getIamOutdatedCredentials(dryRun: Boolean, devXSecurityAccountMaybe: Option[AwsAccount]) =
+    def getIamOutdatedCredentials(
+        dryRun: Boolean,
+        devXSecurityAccountMaybe: Option[AwsAccount],
+        iamAsyncClient: IamAsyncClient
+    ) =
       new IamOutdatedCredentials(
         snsClient = getFakeRemediationSnsClient,
-        iamClients = List(AwsClient(fakeRemediationIamClient, account, Region.of("us-east-1"))),
+        iamClients = List(AwsClient(iamAsyncClient, account, Region.of("us-east-1"))),
         dynamo = fakeRemediationDb,
         devXSecurityAccountMaybe = devXSecurityAccountMaybe,
         dryRun = dryRun,
@@ -825,87 +833,121 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     "in dry run mode" - {
       val dryRun = true
       "should return no notifications for warning" in {
-        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-          getOperation(Warning),
-          today
-        )
+        val remediationCounter = new AtomicInteger(0)
+        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+        val result =
+          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+            getOperation(Warning),
+            today
+          )
         result.value() shouldEqual Nil
+        remediationCounter.get() shouldBe 0
       }
 
       "should return no notifications for final warning" in {
-        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-          getOperation(FinalWarning),
-          today
-        )
+        val remediationCounter = new AtomicInteger(0)
+        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+        val result =
+          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+            getOperation(FinalWarning),
+            today
+          )
         result.value() shouldEqual Nil
+        remediationCounter.get() shouldBe 0
       }
 
       "should return no notifications for remediation" in {
-        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-          getOperation(Remediation),
-          today
-        )
+        val remediationCounter = new AtomicInteger(0)
+        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+        val result =
+          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+            getOperation(Remediation),
+            today
+          )
         result.value() shouldEqual Nil
+        remediationCounter.get() shouldBe 0
       }
     }
 
     "not in dry run mode" - {
       val dryRun = false
       "should return one notification for warning" in {
-        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-          getOperation(Warning),
-          today
-        )
+        val remediationCounter = new AtomicInteger(0)
+        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+        val result =
+          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+            getOperation(Warning),
+            today
+          )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
+        remediationCounter.get() shouldBe 0
       }
 
       "should return one notification for final warning" in {
-        val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-          getOperation(FinalWarning),
-          today
-        )
+        val remediationCounter = new AtomicInteger(0)
+        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+        val result =
+          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+            getOperation(FinalWarning),
+            today
+          )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
+        remediationCounter.get() shouldBe 0
       }
 
       "remediation on Remediation Tuesdays" - {
         "should return one notification when security account is not present" in {
-          val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
+          val remediationCounter = new AtomicInteger(0)
+          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+          val result = getIamOutdatedCredentials(dryRun, None, iamAsyncClient).performRemediationOperation(
             getOperation(Remediation),
             tuesday
           )
           result.value().length shouldBe 1
           result.value().head shouldBe "sns-1"
+          remediationCounter.get() shouldBe 1
         }
 
         "should return two notifications when security account is present" in {
-          val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-            getOperation(Remediation),
-            tuesday
-          )
+          val remediationCounter = new AtomicInteger(0)
+          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+          val result =
+            getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+              getOperation(Remediation),
+              tuesday
+            )
           result.value().length shouldBe 2
           result.value().head shouldBe "sns-1"
           result.value().tail.head shouldBe "sns-2"
+          remediationCounter.get() shouldBe 1
         }
       }
 
       "remediation on other days" - {
         "should return no notifications when security account is not present" in {
-          val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
+          val remediationCounter = new AtomicInteger(0)
+          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+          val result = getIamOutdatedCredentials(dryRun, None, iamAsyncClient).performRemediationOperation(
             getOperation(Remediation),
             notTuesday
           )
           result.value().length shouldBe 0
+          remediationCounter.get() shouldBe 0
         }
 
         "should return one notification when security account is present" in {
-          val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
-            getOperation(Remediation),
-            notTuesday
-          )
+          val remediationCounter = new AtomicInteger(0)
+          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+          val result =
+            getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+              getOperation(Remediation),
+              notTuesday
+            )
           result.value().length shouldBe 1
           result.value().head shouldBe "sns-1"
+          remediationCounter.get() shouldBe 0
         }
       }
     }

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -752,9 +752,11 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     }
   }
 
-  private val notTuesday = new DateTime().withDayOfWeek(1)
-  private val tuesday = new DateTime().withDayOfWeek(2)
   "performRemediationOperation" - {
+
+    val today = new DateTime()
+    val notTuesday = new DateTime().withDayOfWeek(1)
+    val tuesday = new DateTime().withDayOfWeek(2)
 
     def getFakeRemediationSnsClient = new SnsAsyncClient {
       private var notificationCount = 0
@@ -822,7 +824,6 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
 
     "in dry run mode" - {
       val dryRun = true
-      val today = new DateTime()
       "should return no notifications for warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
@@ -853,7 +854,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return one notification for warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(Warning),
-          notTuesday
+          today
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
@@ -862,14 +863,14 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       "should return one notification for final warning" in {
         val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
           getOperation(FinalWarning),
-          notTuesday
+          today
         )
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
       }
 
-      "on Remediation Tuesdays" - {
-        "should return one notification for remediation when security account is not present" in {
+      "remediation on Remediation Tuesdays" - {
+        "should return one notification when security account is not present" in {
           val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
             getOperation(Remediation),
             tuesday
@@ -878,7 +879,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           result.value().head shouldBe "sns-1"
         }
 
-        "should return two notifications for remediation when security account is present" in {
+        "should return two notifications when security account is present" in {
           val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
             getOperation(Remediation),
             tuesday
@@ -889,8 +890,8 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
         }
       }
 
-      "on other days" - {
-        "should return no notifications for no remediation when security account is not present" in {
+      "remediation on other days" - {
+        "should return no notifications when security account is not present" in {
           val result = getIamOutdatedCredentials(dryRun, None).performRemediationOperation(
             getOperation(Remediation),
             notTuesday
@@ -898,7 +899,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           result.value().length shouldBe 0
         }
 
-        "should return one notification for no remediation when security account is present" in {
+        "should return one notification when security account is present" in {
           val result = getIamOutdatedCredentials(dryRun, Some(securityAccount)).performRemediationOperation(
             getOperation(Remediation),
             notTuesday
@@ -916,7 +917,7 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       IamUserRemediationHistory(AwsAccount(id, "", "", ""), machineUser, Nil),
       Warning,
       OutdatedCredential,
-      notTuesday
+      new DateTime()
     )
   }
   def remediationActivity(


### PR DESCRIPTION
## What does this change?

This PR adds another decision step to the remediation pathway.  Remediations will only take place when the day of the week is Tuesday.

However, notifications to the security team will be sent even if remediation will be skipped, for maximum visibility.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
