### PR TITLE
chore: Small improvements for running iam-unrecognised-users locally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,6 +159,7 @@ lazy val iamOutdatedCredentials = (project in file("iam-outdated-credentials"))
   .dependsOn(core % "compile->compile;test->test")
   .settings(
     name := """iam-outdated-credentials""",
+    scalacOptions += "--deprecation",
     fileDescriptorLimit := Some("16384"), // This increases the number of open files allowed when running in AWS
     Assets / pipelineStages := Seq(digest),
     // exclude docs
@@ -186,6 +187,7 @@ lazy val iamUnrecognisedUsers = (project in file("iam-unrecognised-users"))
   .enablePlugins(AssemblyPlugin)
   .settings(
     name := "iam-unrecognised-users",
+    scalacOptions += "--deprecation",
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.4.0",
       "org.scalatest" %% "scalatest" % "3.2.20" % Test

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1289,6 +1289,12 @@ exports[`HQ stack matches the snapshot 1`] = `
               "Sid": "LoadAccountConfig",
             },
             {
+              "Action": "s3:ListBucket",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::gu-security-hq-audit",
+              "Sid": "ListAuditBucket",
+            },
+            {
               "Action": "ec2:DescribeRegions",
               "Effect": "Allow",
               "Resource": "*",

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1295,6 +1295,12 @@ exports[`HQ stack matches the snapshot 1`] = `
               "Sid": "ListAuditBucket",
             },
             {
+              "Action": "s3:GetObject",
+              "Effect": "Allow",
+              "Resource": "arn:aws:s3:::gu-security-hq-audit/*",
+              "Sid": "GetAuditObject",
+            },
+            {
               "Action": "ec2:DescribeRegions",
               "Effect": "Allow",
               "Resource": "*",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -67,6 +67,8 @@ export class SecurityHQ extends GuStack {
     app: "security-hq",
   };
 
+  private static readonly auditBucketName = "gu-security-hq-audit";
+
   constructor(scope: App, id: string, props: SecurityHQProps) {
     super(scope, id, props);
 
@@ -330,6 +332,7 @@ export class SecurityHQ extends GuStack {
           distBucket.valueAsString,
           configS3BucketPath,
         ),
+        this.listAuditBucketPolicy(),
         this.discoverRegionsPolicy(),
       ],
     });
@@ -424,7 +427,7 @@ export class SecurityHQ extends GuStack {
           DRY_RUN: "true",
           CONFIG_BUCKET: "security-dist",
           CONFIG_KEY: `security/${this.stage}/security-hq/security-hq.conf`,
-          IAM_UNRECOGNISED_USER_S3_BUCKET: "gu-security-hq-audit",
+          IAM_UNRECOGNISED_USER_S3_BUCKET: SecurityHQ.auditBucketName,
           IAM_UNRECOGNISED_USER_S3_KEY: `security/${this.stage}/janus-data-export/janusData.conf`,
         },
         fileName: `iam-unrecognised-users-${buildIdentifier}.jar`,
@@ -503,6 +506,16 @@ export class SecurityHQ extends GuStack {
       effect: Effect.ALLOW,
       actions: ["s3:GetObject"],
       resources: [`arn:aws:s3:::${bucketName}/${path}`],
+    });
+  }
+
+  private listAuditBucketPolicy() {
+    // Used by the local dev setup to list the audit data bucket (for example Janus data exports)
+    return new PolicyStatement({
+      sid: "ListAuditBucket",
+      effect: Effect.ALLOW,
+      actions: ["s3:ListBucket"],
+      resources: [`arn:aws:s3:::${SecurityHQ.auditBucketName}`],
     });
   }
 

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -333,6 +333,7 @@ export class SecurityHQ extends GuStack {
           configS3BucketPath,
         ),
         this.listAuditBucketPolicy(),
+        this.getAuditObjectPolicy(),
         this.discoverRegionsPolicy(),
       ],
     });
@@ -510,7 +511,7 @@ export class SecurityHQ extends GuStack {
   }
 
   private listAuditBucketPolicy() {
-    // Used by the local dev setup to list the audit data bucket (for example Janus data exports)
+    // Used by lambdas
     return new PolicyStatement({
       sid: "ListAuditBucket",
       effect: Effect.ALLOW,
@@ -519,8 +520,18 @@ export class SecurityHQ extends GuStack {
     });
   }
 
+  private getAuditObjectPolicy() {
+    // Used by lambdas
+    return new PolicyStatement({
+      sid: "GetAuditObject",
+      effect: Effect.ALLOW,
+      actions: ["s3:GetObject"],
+      resources: [`arn:aws:s3:::${SecurityHQ.auditBucketName}/*`],
+    });
+  }
+
   private discoverRegionsPolicy() {
-    // Used by lambdas to get a list of regions
+    // Used by lambdas
     return new PolicyStatement({
       sid: "DiscoverRegions",
       effect: Effect.ALLOW,

--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -159,7 +159,12 @@ object IAMClient extends LazyLogging {
                 )
               }
           }
-        } yield CredentialMetadata(akm.userName, akm.accessKeyId, new DateTime(akm.createDate.toEpochMilli), credentialStatus)
+        } yield CredentialMetadata(
+          akm.userName,
+          akm.accessKeyId,
+          new DateTime(akm.createDate.toEpochMilli),
+          credentialStatus
+        )
       }
     } yield credentialMetadatas
   }

--- a/core/src/main/scala/logic/IamUnrecognisedUsers.scala
+++ b/core/src/main/scala/logic/IamUnrecognisedUsers.scala
@@ -128,10 +128,10 @@ object IamUnrecognisedUsers extends LazyLogging {
       )
     } else {
       logger.info(
-        s"Attempt to disable access keys was skipped due to dry run."
+        s"DRY RUN: Attempt to disable access keys was skipped."
       )
       logger.info(
-        s"Skipping ${accountUnrecognisedKeys.vulnerableAccessKey.length} keys in ${accountUnrecognisedKeys.account} account."
+        s"DRY RUN: Skipping ${accountUnrecognisedKeys.vulnerableAccessKey.length} keys in ${accountUnrecognisedKeys.account} account."
       )
       Attempt.Right(Nil)
     }
@@ -158,10 +158,10 @@ object IamUnrecognisedUsers extends LazyLogging {
       }
     } else {
       logger.info(
-        s"Attempt to remove account passwords was skipped due to dry run."
+        s"DRY RUN: Attempt to remove account passwords was skipped."
       )
       logger.info(
-        s"Skipping password deletion for ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString(",")}"
+        s"DRY RUN: Skipping password deletion for ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString(",")}."
       )
       Attempt.Right(Nil)
     }
@@ -178,7 +178,7 @@ object IamUnrecognisedUsers extends LazyLogging {
         }
       }
     } else {
-      logger.info(s"Dry run: would send ${accountUsers.length} notification(s).")
+      logger.info(s"DRY RUN: Would send ${accountUsers.length} notification(s).")
       Nil
     }
   }

--- a/iam-unrecognised-users/README.md
+++ b/iam-unrecognised-users/README.md
@@ -51,28 +51,22 @@ environment variables (matching the Play app).
 
 ## Running locally
 
-A local entrypoint is provided at [`Main.runUnrecognisedUsers`](src/main/scala/unrecognised/Main.scala), which can be
-run from sbt:
-
-```sh
-sbt 'iamUnrecognisedUsers/runMain unrecognised.runUnrecognisedUsers'
+The lambda has a [main](src/main/scala/unrecognised/Main.scala) entrypoint to allow it to be run locally 
+for functional testing.
+To run it, use the start script like so:
 ```
-
-### Required environment
-
-The locally run program reads `CONFIG_BUCKET` and `CONFIG_KEY` (the name of the Security account distribution bucket
-and the path of `security-hq.conf` within it), plus `IAM_UNRECOGNISED_USER_S3_BUCKET` and `IAM_UNRECOGNISED_USER_S3_KEY`
-(the audit-data bucket and the path of the Janus data file within it), from your local environment. Use the PROD paths
-so the account list and Janus data stay consistent. `REGION` is optional (defaults to `eu-west-1`).
+script/start iam-unrecognised-users
+```
+The script includes the required environment variables.
 
 ### Required permissions
 
-Running locally currently requires the **`dev`** Janus permission for the `security` account. (This will soon change.)  
+Running locally requires the **`Run Security HQ lambdas locally`** Janus permission for the `security` account.
 Use `janus` to assume the role before running so that a `security` profile is available in `~/.aws/credentials`.
 
 ### Limitations when run locally
 
-- Only the `security` account is polled (`restrictToAccountId` is hardcoded), so per-account coverage cannot be
+- Only the `security` account is polled so per-account coverage cannot be
   verified locally.
 - No changes are ever made (`DRY_RUN` is hardcoded), only logged, so the 'would deactivate'/'would send' output should be
   checked in the IDE console rather than in AWS.

--- a/iam-unrecognised-users/src/main/scala/unrecognised/Handler.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/Handler.scala
@@ -3,6 +3,7 @@ package unrecognised
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 
 import java.io.{InputStream, OutputStream}
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.*
 
 /** AWS lambda entrypoint. The trigger payload is ignored. */

--- a/iam-unrecognised-users/src/main/scala/unrecognised/Main.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/Main.scala
@@ -6,8 +6,8 @@ import scala.concurrent.ExecutionContext.Implicits.global
   *
   * Configuration is supplied by the surrounding environment, for example via `script/start iam-unrecognised-users`.
   *
- * `DRY_RUN` is hardcoded to `true` here so that running locally can never accidentally deactivate real IAM users or
- * send real notifications, regardless of what is set in the surrounding environment.
+  * `DRY_RUN` is hardcoded to `true` here so that running locally can never accidentally deactivate real IAM users or
+  * send real notifications, regardless of what is set in the surrounding environment.
   */
 @main def runUnrecognisedUsers(): Unit =
   UnrecognisedUsers.run(

--- a/iam-unrecognised-users/src/main/scala/unrecognised/Main.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/Main.scala
@@ -1,15 +1,15 @@
 package unrecognised
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 /** Local entrypoint for running the unrecognised-users job outside lambda.
   *
-  * `DRY_RUN` is hardcoded to `true` here so that running locally can never accidentally deactivate real IAM users or
-  * send real notifications, regardless of what is set in the surrounding environment.
+  * Configuration is supplied by the surrounding environment, for example via `script/start iam-unrecognised-users`.
   *
-  * `restrictToAccountId` is hardcoded to only poll the `security` account, since local credentials cannot easily assume
-  * the cross-account roles needed to poll every other configured account in production.
+ * `DRY_RUN` is hardcoded to `true` here so that running locally can never accidentally deactivate real IAM users or
+ * send real notifications, regardless of what is set in the surrounding environment.
   */
 @main def runUnrecognisedUsers(): Unit =
   UnrecognisedUsers.run(
-    env = sys.env + ("DRY_RUN" -> "true"),
-    restrictToAccountId = Some("security")
+    env = sys.env + ("DRY_RUN" -> "true")
   )

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -36,13 +36,11 @@ object UnrecognisedUsers extends LazyLogging {
 
   def run(
       env: Map[String, String] = sys.env,
-      restrictToAccountId: Option[String] = None,
       timeout: FiniteDuration = 5.minutes
-  ): Unit = {
-    implicit val ec: ExecutionContext = ExecutionContext.global
+  )(using ExecutionContext): Unit = {
     val settings = Settings.fromEnvironment(env)
     logger.info(s"Starting iam-unrecognised-users job (dryRun=${settings.dryRun}, region=${settings.region.id})")
-    val result = disableUnrecognisedUsers(settings, restrictToAccountId)
+    val result = disableUnrecognisedUsers(settings)
     Await.result(result.asFuture, timeout) match {
       case Left(failure) =>
         logger.error(s"Failed to run unrecognised user job: ${failure.logMessage}")
@@ -54,9 +52,11 @@ object UnrecognisedUsers extends LazyLogging {
 
   def disableUnrecognisedUsers(
       settings: Settings,
-      restrictToAccountId: Option[String] = None
-  )(implicit ec: ExecutionContext): Attempt[List[String]] = {
-    val s3Client = S3Client.builder.region(settings.region).build()
+  )(using ExecutionContext): Attempt[List[String]] = {
+    val s3Client = S3Client.builder
+      .region(settings.region)
+      .credentialsProvider(CoreConfig.securityCredentialsProvider)
+      .build()
     lazy val snsClient = SnsAsyncClient.builder.region(settings.region).build()
     // IAM is global; us-east-1 is required for credential reports. Additional regions only affect CloudFormation stack
     // enrichment, which this job does not rely on.
@@ -71,8 +71,7 @@ object UnrecognisedUsers extends LazyLogging {
       // load Security HQ's config (accounts, allowed accounts, notification topic) from S3
       configSource <- getS3Object(s3Client, settings.configBucket, settings.configKey)
       conf = ConfigFactory.parseString(configSource.mkString)
-      allAccounts = CoreConfig.parseAccounts(conf)
-      awsAccounts = restrictToAccountId.fold(allAccounts)(id => allAccounts.filter(_.id == id))
+      awsAccounts = CoreConfig.parseAccounts(conf)
       allowedAccountIds = conf.getStringList(ALLOWED_ACCOUNT_IDS).asScala.toList
       anghammaradSnsArn = conf.getString(ANGHAMMARAD_SNS_ARN)
       iamClients = AWS.iamClients(awsAccounts, regions)

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -51,7 +51,7 @@ object UnrecognisedUsers extends LazyLogging {
   }
 
   def disableUnrecognisedUsers(
-      settings: Settings,
+      settings: Settings
   )(using ExecutionContext): Attempt[List[String]] = {
     val s3Client = S3Client.builder
       .region(settings.region)

--- a/script/start
+++ b/script/start
@@ -12,8 +12,8 @@ IAM_UNRECOGNISED_USERS_ENV=(
   "IAM_UNRECOGNISED_USER_S3_KEY=security/DEV/janus-data-export/janusData.conf"
 )
 
-# Select which application to run. Defaults to the Play app.
-MODE="${1:-play}"
+# Select which application to run. Fails if no argument.
+MODE="${1}"
 
 case "$MODE" in
   play)

--- a/script/start
+++ b/script/start
@@ -5,4 +5,25 @@ set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 ROOT_DIR="${DIR}/.."
 
-"$ROOT_DIR/sbt" "$*" "project hq; run"
+IAM_UNRECOGNISED_USERS_ENV=(
+  "CONFIG_BUCKET=security-dist"
+  "CONFIG_KEY=security/DEV/security-hq/security-hq.conf"
+  "IAM_UNRECOGNISED_USER_S3_BUCKET=gu-security-hq-audit"
+  "IAM_UNRECOGNISED_USER_S3_KEY=security/DEV/janus-data-export/janusData.conf"
+)
+
+# Select which application to run. Defaults to the Play app.
+MODE="${1:-play}"
+
+case "$MODE" in
+  play)
+    "$ROOT_DIR/sbt" "project hq; run"
+    ;;
+  iam-unrecognised-users)
+    env "${IAM_UNRECOGNISED_USERS_ENV[@]}" "$ROOT_DIR/sbt" "project iamUnrecognisedUsers; run"
+    ;;
+  *)
+    echo "Usage: $(basename "$0") [play|iam-unrecognised-users]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
The small improvements are:
* Made it clearer which logging output is part of the dry run
* Removed the redundant `restrictToAccountId` param as the dev config file only contains the Security account anyway
* Passed the execution context through from `Main` and `Handler` and using Scala 3 terminology ('using' instead of 'implicit', without a value name)
* Added start script for the lambda that supplies the env vars, which are already referred to in the repo so not giving anything away
* Added `deprecation` scalac option to both lambdas as it isn't provided to them by the Play plugin
* Granted the `RunSecurityHqLocallyPolicy` dev policy permission to list the contents of the audit bucket.

To support this, I've added a dev Janus data file to the S3 Dev path.  It has a missing user so that we can see effects without breaking anything in production.
