### PR TITLE
Only construct a single IAM client per account

### DIFF
--- a/core/src/main/scala/aws/AWS.scala
+++ b/core/src/main/scala/aws/AWS.scala
@@ -1,6 +1,7 @@
 package aws
 
 import config.CoreConfig
+import iam.IAMClient
 import model.AwsAccount
 import software.amazon.awssdk.auth.credentials.{AwsCredentialsProviderChain, ProfileCredentialsProvider}
 import software.amazon.awssdk.awscore
@@ -111,9 +112,10 @@ object AWS {
     client(withCustomThreadPool(IamAsyncClient.builder()), account, region)
   private val iamClientCache = new AwsClientCache(iamClientBuilder)
 
-  def iamClient(account: AwsAccount, region: Region): AwsClient[IamAsyncClient] =
-    iamClientCache.getClient(account, region)
+  // Only needs Regions.US_EAST_1
+  def iamClient(account: AwsAccount): AwsClient[IamAsyncClient] =
+    iamClientCache.getClient(account, IAMClient.SOLE_REGION)
 
-  def iamClients(accounts: List[AwsAccount], regions: List[Region]): AwsClients[IamAsyncClient] =
-    iamClientCache.getClients(accounts, regions)
+  def iamClients(accounts: List[AwsAccount]): AwsClients[IamAsyncClient] =
+    iamClientCache.getClients(accounts, List(IAMClient.SOLE_REGION))
 }

--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -97,7 +97,7 @@ object IAMClient extends LazyLogging {
       delay: FiniteDuration = 3.seconds
   )(implicit executionContext: ExecutionContext): Attempt[CredentialReportDisplay] = {
     for {
-      client <- iamClients.get(account, SOLE_REGION)
+      client <- iamClients.get(account)
       _ <- Retry.until(
         generateCredentialsReport(client),
         CredentialsReport.isComplete,
@@ -132,7 +132,7 @@ object IAMClient extends LazyLogging {
       ec: ExecutionContext
   ): Attempt[List[CredentialMetadata]] = {
     for {
-      client <- iamClients.get(account, SOLE_REGION)
+      client <- iamClients.get(account)
       result <- listAccessKeys(client, user)
       keyMetdatas = result.accessKeyMetadata.asScala.toList
       credentialMetadatas <- Attempt.traverse(keyMetdatas) { akm =>
@@ -188,7 +188,7 @@ object IAMClient extends LazyLogging {
       .status("Inactive")
       .build()
     for {
-      client <- iamClients.get(awsAccount, SOLE_REGION)
+      client <- iamClients.get(awsAccount)
       result <- handleAWSErrs(client)(asScala(client.client.updateAccessKey(request)))
     } yield result
   }
@@ -209,7 +209,7 @@ object IAMClient extends LazyLogging {
   ): Attempt[Option[DeleteLoginProfileResponse]] = {
     val request = DeleteLoginProfileRequest.builder.userName(username).build()
     for {
-      client <- iamClients.get(awsAccount, SOLE_REGION)
+      client <- iamClients.get(awsAccount)
       result <- handleDeleteLoginProfileErrs(client, username)(asScala(client.client.deleteLoginProfile(request)))
     } yield result
   }

--- a/core/src/test/scala/aws/AWSTest.scala
+++ b/core/src/test/scala/aws/AWSTest.scala
@@ -32,7 +32,7 @@ class AWSTest extends AnyFreeSpec with Matchers with AttemptValues {
     }
 
     "iam" in {
-      AWS.iamClients(accounts, regions) should have size (allRegionsSize)
+      AWS.iamClients(accounts) should have size (singleRegionSize)
     }
 
   }

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -93,7 +93,7 @@ class AppComponents(context: Context)
   private val cfnClients = AWS.cfnClients(awsAccounts, availableRegions)
   private val taClients = AWS.taClients(awsAccounts)
   private val s3Clients = AWS.s3Clients(awsAccounts, availableRegions)
-  private val iamClients = AWS.iamClients(awsAccounts, availableRegions)
+  private val iamClients = AWS.iamClients(awsAccounts)
   private val devXSecurityAccountMaybe = awsAccounts.find(_.id == IamOutdatedCredentials.SECURITY_ACCOUNT_ID)
 
   /*

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -279,7 +279,7 @@ object IamOutdatedCredentials extends LazyLogging {
 
     for {
       availableRegions: List[Region] <- CoreConfig.calculateAvailableRegions(settings.stack, settings.stage)
-      iamClients = AWS.iamClients(awsAccounts, availableRegions)
+      iamClients = AWS.iamClients(awsAccounts)
       cfnClients = AWS.cfnClients(awsAccounts, availableRegions)
       reportAttemptsList <- Attempt.traverseWithFailures(awsAccounts) { account =>
         IAMClient.getUpdatedCredentialsReport(account, cfnClients, iamClients, availableRegions)

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -74,7 +74,7 @@ object UnrecognisedUsers extends LazyLogging {
       awsAccounts = CoreConfig.parseAccounts(conf)
       allowedAccountIds = conf.getStringList(ALLOWED_ACCOUNT_IDS).asScala.toList
       anghammaradSnsArn = conf.getString(ANGHAMMARAD_SNS_ARN)
-      iamClients = AWS.iamClients(awsAccounts, regions)
+      iamClients = AWS.iamClients(awsAccounts)
       cfnClients = AWS.cfnClients(awsAccounts, regions)
       startingData = awsAccounts.map(account => account -> unloadedReport(account)).toMap
       // fetch and parse our stored Janus config to use as the canonical source of "recognised" usernames


### PR DESCRIPTION
## What does this change?

IAM is a "global" service, and only operates in the us-east-1 region. We construct IAM clients for every region, but then only select and use the us-east-1 ones. Skip constructing the unnecessary and unused clients

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Small performance improvement, hopefully less confusion


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
