### PR TITLE
wip: region list from ssm global param

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val core = (project in file("core"))
       "software.amazon.awssdk" % "ec2" % awsSdkVersion,
       "software.amazon.awssdk" % "s3" % awsSdkVersion,
       "software.amazon.awssdk" % "sns" % awsSdkVersion,
+      "software.amazon.awssdk" % "ssm" % awsSdkVersion,
       "software.amazon.awssdk" % "sts" % awsSdkVersion,
       "software.amazon.awssdk" % "support" % awsSdkVersion,
       "ch.qos.logback" % "logback-classic" % "1.5.38",

--- a/core/src/main/scala/aws/AwsAsyncHandler.scala
+++ b/core/src/main/scala/aws/AwsAsyncHandler.scala
@@ -25,7 +25,9 @@ object AwsAsyncHandler {
         case ServiceName(serviceName) => Some(serviceName)
         case _                        => None
       }
-      if (e.getMessage.contains("The security token included in the request is expired")) {
+      if (e.getMessage.contains("The security token included in the request is invalid")) {
+        Failure.invalidCredentials(serviceNameOpt, awsClient).attempt
+      } else if (e.getMessage.contains("The security token included in the request is expired")) {
         Failure.expiredCredentials(serviceNameOpt, awsClient).attempt
       } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
         Failure.noCredentials(serviceNameOpt, awsClient).attempt

--- a/core/src/main/scala/aws/ssm/SSM.scala
+++ b/core/src/main/scala/aws/ssm/SSM.scala
@@ -1,0 +1,41 @@
+package aws.ssm
+
+import aws.AwsClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.ssm.SsmAsyncClient
+import software.amazon.awssdk.services.ssm.model.GetParameterRequest
+import scala.concurrent.ExecutionContext
+import utils.attempt.Attempt
+import software.amazon.awssdk.services.ssm.model.GetParametersByPathRequest
+import aws.AwsAsyncHandler.handleAWSErrs
+import aws.AwsAsyncHandler.asScala
+
+import scala.jdk.CollectionConverters.*
+import software.amazon.awssdk.services.s3.S3Client
+import config.CoreConfig
+import software.amazon.awssdk.services.sts.StsClient
+
+object SSM {
+
+  def getAllRegions(client: AwsClient[SsmAsyncClient])(using ExecutionContext): Attempt[List[Region]] = {
+
+    def paginate(found: List[Region], nextToken: Option[String]): Attempt[List[Region]] = {
+      val request = GetParametersByPathRequest
+        .builder()
+        .path("/aws/service/global-infrastructure/regions")
+        .nextToken(nextToken.orNull)
+        .build()
+
+      handleAWSErrs(client)(asScala(client.client.getParametersByPath(request))).flatMap { response =>
+        val regions = found ++ response.parameters().asScala.map(p => Region.of(p.value()))
+        Option(response.nextToken()) match {
+          case Some(value) => paginate(regions, Some(value))
+          case None        => Attempt.Right(regions)
+        }
+      }
+    }
+
+    paginate(Nil, None)
+  }
+
+}

--- a/core/src/main/scala/config/CoreConfig.scala
+++ b/core/src/main/scala/config/CoreConfig.scala
@@ -2,6 +2,7 @@ package config
 
 import aws.AwsClient
 import aws.ec2.EC2
+import aws.ssm.SSM
 import com.typesafe.config.{Config, ConfigFactory}
 import model.{AwsAccount, DEV, PROD, Stage}
 import software.amazon.awssdk.auth.credentials.{
@@ -15,6 +16,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient
 import software.amazon.awssdk.services.ec2.Ec2AsyncClient
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.ssm.SsmAsyncClient
 import utils.attempt.Attempt
 
 import java.net.URI
@@ -32,20 +34,19 @@ object CoreConfig {
   // TODO fetch the region dynamically from the instance
   val region: Region = Region.of("eu-west-1")
 
-  def calculateAvailableRegions(stack: String, stage: Stage)(implicit ec: ExecutionContext): Attempt[List[Region]] = {
-    val ec2Client = AwsClient(
-      Ec2AsyncClient.builder
+  def calculateAvailableRegions(stack: String, stage: Stage)(using ExecutionContext): Attempt[List[Region]] = {
+    val ssmClient = AwsClient(
+      SsmAsyncClient
+        .builder()
         .region(CoreConfig.region)
+        .credentialsProvider(securityCredentialsProvider)
         .build(),
       // This account name is the only useful element (in logging contextString)
       AwsAccount("n/a", stack, "n/a", "n/a"),
       CoreConfig.region
     )
-    (for {
-      ec2RegionList <- EC2.getAvailableRegions(ec2Client)
-      regionList = ec2RegionList.map(ec2Region => Region.of(ec2Region.regionName))
-    } yield regionList)
-      .tap(_ => ec2Client.client.close())
+
+    SSM.getAllRegions(ssmClient).tap(_ => ssmClient.client.close())
   }
 
   val securityCredentialsProvider: AwsCredentialsProviderChain = AwsCredentialsProviderChain.of(

--- a/core/src/main/scala/utils/attempt/Failure.scala
+++ b/core/src/main/scala/utils/attempt/Failure.scala
@@ -34,7 +34,8 @@ case class Failure(
     friendlyMessage: String,
     statusCode: Int,
     context: Option[String] = None,
-    throwable: Option[Throwable] = None
+    throwable: Option[Throwable] = None,
+    isExpected: Boolean = false,
 ) {
   def attempt = FailedAttempt(this)
 }
@@ -83,6 +84,14 @@ object Failure {
       s"expired AWS credentials, service: $serviceName, $context"
     }
     Failure(details, "Failed to request data from AWS, the temporary credentials have expired.", 401)
+  }
+
+  def invalidCredentials(serviceNameOpt: Option[String], clientContext: AwsClient[_]): Failure = {
+    val context = contextString(clientContext)
+    val details = serviceNameOpt.fold(s"invalid AWS credentials, unknown service, $context") { serviceName =>
+      s"invalid AWS credentials, service: $serviceName, $context"  
+    }
+    Failure(details, "Credentials were not valid, which usually means the region is not enabled for this account", 401, isExpected = true)
   }
 
   def noCredentials(serviceNameOpt: Option[String], clientContext: AwsClient[_]): Failure = {

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentialsLambda.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentialsLambda.scala
@@ -2,6 +2,7 @@ package logic
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import settings.Settings
+import utils.attempt.FailedAttempt
 
 import java.io.{InputStream, OutputStream}
 import scala.concurrent.duration.*
@@ -21,10 +22,16 @@ class IamOutdatedCredentialsLambda extends RequestStreamHandler {
       case Right(_) => ()
 
       case Left(failedAttempt) =>
-        throw new RuntimeException(
-          s"IamOutdatedCredentials Lambda execution failed: ${failedAttempt.logMessage}",
-          failedAttempt.firstException.orNull
-        )
+        val (expectedFailures, otherFailures) = failedAttempt.failures.partition(_.isExpected)
+        if (otherFailures.nonEmpty) {
+          val attempt = FailedAttempt(otherFailures)
+          throw new RuntimeException(
+            s"IamOutdatedCredentials Lambda execution failed: ${attempt.logMessage}",
+            attempt.firstException.orNull
+          )
+        } else {
+          ()
+        }
     }
   }
 


### PR DESCRIPTION
We will now have SDK clients which are configured to use invalid combinations of account and region, but we will not want to fail the entire invocation. Instead we should catch the error message and squash the failure before counting and reporting the overall failure rate.

## What does this change?


<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
