### PR TITLE
Add generate credential report policy to dev policy

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1306,6 +1306,11 @@ exports[`HQ stack matches the snapshot 1`] = `
               "Resource": "*",
               "Sid": "DiscoverRegions",
             },
+            {
+              "Action": "iam:GenerateCredentialReport",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -335,6 +335,7 @@ export class SecurityHQ extends GuStack {
         this.listAuditBucketPolicy(),
         this.getAuditObjectPolicy(),
         this.discoverRegionsPolicy(),
+        this.getIamGenerateCredentialReportPolicy(),
       ],
     });
 
@@ -476,6 +477,15 @@ export class SecurityHQ extends GuStack {
     return new PolicyStatement({
       effect: Effect.ALLOW,
       actions: ["sts:GetCallerIdentity"],
+      resources: ["*"],
+    });
+  }
+
+  private getIamGenerateCredentialReportPolicy() {
+    // ONLY used when running lambda locally because it would usually be obtained from an assumed role
+    return new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["iam:GenerateCredentialReport"],
       resources: ["*"],
     });
   }


### PR DESCRIPTION
## What does this change?

Adds iam:GenerateCredentialReport to the dev policy used to run lambdas locally.

This is not required for the "real" lambda because it obtains the same privilege, per target account, via an assume role.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
