### PR TITLE
Remove SSM dev policy in favour of generic .ssh Janus policy

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -43,7 +43,6 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuDeveloperPolicyExperimental",
-      "GuDeveloperPolicyExperimental",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
       "GuScheduledLambda",
@@ -121,64 +120,6 @@ exports[`HQ stack matches the snapshot 1`] = `
     },
   },
   "Resources": {
-    "AccessSecurityHQInstancesBySsm8753B668": {
-      "Properties": {
-        "Description": "Access instances by SSM",
-        "Path": "/developer-policy/guardian/security-hq/security/PROD/security-hq-ssm/",
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "ec2:DescribeTags",
-                "ssm:DescribeSessions",
-                "ssm:GetConnectionStatus",
-                "ssm:DescribeInstanceInformation",
-                "ssm:TerminateSession",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "ssm:StartSession",
-              "Condition": {
-                "ForAnyValue:StringEquals": {
-                  "ssm:resourceTag/aws:autoscaling:groupName": [
-                    {
-                      "Fn::Join": [
-                        "",
-                        [
-                          "arn:",
-                          {
-                            "Ref": "AWS::Partition",
-                          },
-                          ":autoscaling:eu-west-1:",
-                          {
-                            "Ref": "AWS::AccountId",
-                          },
-                          ":autoScalingGroup:*:autoScalingGroupName/",
-                          {
-                            "Ref": "AutoScalingGroupSecurityhqASG8DD277A5",
-                          },
-                        ],
-                      ],
-                    },
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Resource": [
-                "arn:aws:ec2:*:*:instance/*",
-                "arn:aws:ssm:*:*:document/SSM-SessionManagerRunShell",
-              ],
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-      },
-      "Type": "AWS::IAM::ManagedPolicy",
-    },
     "AlbSsmParam485C1D52": {
       "Properties": {
         "DataType": "text",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -308,18 +308,6 @@ export class SecurityHQ extends GuStack {
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
     });
 
-    new GuDeveloperPolicyExperimental(this, "AccessSecurityHQInstancesBySsm", {
-      grantId: "security-hq-ssm",
-      friendlyName: "Access instances by SSM",
-      withoutPolicyChecks: true,
-      statements: [
-        this.getSsmInfoPolicy(),
-        this.getSsmStartSessionPolicy(
-          ec2App.autoScalingGroup.autoScalingGroupArn,
-        ),
-      ],
-    });
-
     new GuDeveloperPolicyExperimental(this, "RunSecurityHqLocallyPolicy", {
       grantId: "security-hq-dev",
       friendlyName: "Run Security HQ lambdas locally",


### PR DESCRIPTION
## What does this change?

Removes an old developer policy which was used to explore ssm access to instances but is now unused.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
