### PR TITLE
Add more permissions to lambda dev-policy

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1255,6 +1255,23 @@ exports[`HQ stack matches the snapshot 1`] = `
               "Effect": "Allow",
               "Resource": "*",
             },
+            {
+              "Action": [
+                "cloudformation:DescribeStacks",
+                "cloudformation:ListStacks",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+            {
+              "Action": [
+                "iam:ListUserTags",
+                "iam:ListAccessKeys",
+                "iam:ListMFADevices",
+              ],
+              "Effect": "Allow",
+              "Resource": "*",
+            },
           ],
           "Version": "2012-10-17",
         },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -323,7 +323,9 @@ export class SecurityHQ extends GuStack {
         this.listAuditBucketPolicy(),
         this.getAuditObjectPolicy(),
         this.discoverRegionsPolicy(),
-        this.getIamGenerateCredentialReportPolicy(),
+        this.getIamCredentialReportPolicy(),
+        this.getCloudformationStacksPolicy(),
+        this.getUserInfoPolicy(),
       ],
     });
 
@@ -469,11 +471,29 @@ export class SecurityHQ extends GuStack {
     });
   }
 
-  private getIamGenerateCredentialReportPolicy() {
+  private getIamCredentialReportPolicy() {
     // ONLY used when running lambda locally because it would usually be obtained from an assumed role
     return new PolicyStatement({
       effect: Effect.ALLOW,
       actions: ["iam:GenerateCredentialReport", "iam:GetCredentialReport"],
+      resources: ["*"],
+    });
+  }
+
+  private getCloudformationStacksPolicy() {
+    // ONLY used when running lambda locally because it would usually be obtained from an assumed role
+    return new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["cloudformation:DescribeStacks", "cloudformation:ListStacks"],
+      resources: ["*"],
+    });
+  }
+
+  private getUserInfoPolicy() {
+    // ONLY used when running lambda locally because it would usually be obtained from an assumed role
+    return new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["iam:ListUserTags", "iam:ListAccessKeys", "iam:ListMFADevices"],
       resources: ["*"],
     });
   }


### PR DESCRIPTION
## What does this change?

Adds all the read permissions I think we need, taken from watched-account.template.yaml.
Write permissions are deliberately not included.  If you want to do writes, you can take .admin permissions.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
