### PR TITLE
Update wording of credential deactivation warning notifications

### DIFF
--- a/core/src/main/scala/notifications/AnghammaradNotifications.scala
+++ b/core/src/main/scala/notifications/AnghammaradNotifications.scala
@@ -5,7 +5,7 @@ import com.gu.anghammarad.models.{Email, Notification, Preferred, Target, AwsAcc
 import com.typesafe.scalalogging.LazyLogging
 import config.CoreConfig.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
 import logic.DateUtils.printDay
-import model.{AwsAccount, IAMUser, Tag}
+import model.{AwsAccount, CredentialMetadata, IAMUser, Tag}
 import org.joda.time.DateTime
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import utils.attempt.{Attempt, Failure}
@@ -42,32 +42,73 @@ object AnghammaradNotifications extends LazyLogging {
   private def notificationTargets(awsAccount: AwsAccount, iamUser: IAMUser): List[Target] =
     Tag.tagsToAnghammaradTargets(iamUser.tags) :+ Account(awsAccount.accountNumber)
 
-  private def tagText(iamUser: IAMUser) = iamUser.tags.map(t => s"${t.key}=${t.value}").mkString(", ")
+  // The console shows you an option to add a description for a key. This is implemented as a tag
+  // on the IAM user, which has the same Key as the Access Key ID.
+  private def keyDescription(iamUser: IAMUser, key: CredentialMetadata): String =
+    iamUser.tags.find(_.key == key.accessKeyId).map(_.value) match {
+      case Some(description) => s"This access key has description: $description"
+      case None              => "This access key has no description set."
+    }
+
+  // All of the tags on the User which are *not* added as descriptions for individual keys.
+  private def userTags(iamUser: IAMUser) = iamUser.tags
+    .filterNot(_.key.startsWith("AKIA")) // Common prefix for IAM user static credentials
+    .map(t => s"${t.key}=${t.value}")
+    .mkString(", ")
+
+  private def credentialInfo(
+      awsAccount: AwsAccount,
+      iamUser: IAMUser,
+      credentialThatWillBeDisabled: CredentialMetadata
+  ): String =
+    s"""Further info:
+       |This is the access key which is affected: ${credentialThatWillBeDisabled.accessKeyId}
+       |${keyDescription(iamUser, credentialThatWillBeDisabled)}
+       |This user's tags:
+       |  ${userTags(iamUser)}
+       |Follow this link to find the user in the console: (remember you'll need to sign into the ${awsAccount.name} account first via Janus)
+       |https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/${iamUser.username}?section=security_credentials
+       |""".stripMargin
+
+  private def outdatedCredentialWarningMessage(
+      awsAccount: AwsAccount,
+      iamUser: IAMUser,
+      problemCreationDate: String,
+      credentialThatWillBeDisabled: CredentialMetadata,
+      deadline: String
+  ): String =
+    s"""Please rotate the permanent credential for ${iamUser.username} in AWS Account ${awsAccount.name},
+       |which has been flagged because it was last rotated on ${problemCreationDate}.
+       |
+       |${credentialInfo(awsAccount, iamUser, credentialThatWillBeDisabled)}
+       |
+       |If no action is taken before ${deadline}, this credential will be automatically disabled
+       |on or shortly after that date, which will likely break any applications still using it!
+       |
+       |$genericCredentialWarningText
+       |""".stripMargin
 
   def outdatedCredentialWarning(
       awsAccount: AwsAccount,
       iamUser: IAMUser,
       problemCreationDate: DateTime,
+      credentialThatWillBeDisabled: CredentialMetadata,
       now: DateTime
   ): Notification = {
     val deadline = printDay(
       now.plusDays(daysBetweenWarningAndFinalNotification + daysBetweenFinalNotificationAndRemediation)
     )
-    val message =
-      s"""
-         |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
-         |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
-         |(if you're already planning on doing this, please ignore this message).
-         |
-         |If this is not rectified before $deadline, Security HQ will automatically disable this user.
-         |
-         |Further info: this credential is tagged with:
-         |  ${tagText(iamUser)}
-         |""".stripMargin
+    val message = outdatedCredentialWarningMessage(
+      awsAccount,
+      iamUser,
+      printDay(problemCreationDate),
+      credentialThatWillBeDisabled,
+      deadline
+    )
     val subject = s"Action required by $deadline: long-lived credential detected in ${awsAccount.name}"
     Notification(
       subject,
-      message + genericOutdatedCredentialText,
+      message,
       Nil,
       notificationTargets(awsAccount, iamUser),
       channel,
@@ -79,25 +120,21 @@ object AnghammaradNotifications extends LazyLogging {
       awsAccount: AwsAccount,
       iamUser: IAMUser,
       problemCreationDate: DateTime,
+      credentialThatWillBeDisabled: CredentialMetadata,
       now: DateTime
   ): Notification = {
     val deadline = printDay(now.plusDays(daysBetweenFinalNotificationAndRemediation))
-    val message =
-      s"""
-         |Please check the permanent credential ${iamUser.username} in AWS Account ${awsAccount.name},
-         |which has been flagged because it was last rotated on ${printDay(problemCreationDate)}.
-         |(if you're already planning on doing this, please ignore this message).
-         |
-         |If this is not rectified before $deadline,
-         |Security HQ will automatically disable this user *at the next opportunity*.
-         |
-         |Further info: this credential is tagged with:
-         |  ${tagText(iamUser)}
-         |""".stripMargin
+    val message = outdatedCredentialWarningMessage(
+      awsAccount,
+      iamUser,
+      printDay(problemCreationDate),
+      credentialThatWillBeDisabled,
+      deadline
+    )
     val subject = s"Action required by $deadline: long-lived credential in ${awsAccount.name} will be disabled soon"
     Notification(
       subject,
-      message + genericOutdatedCredentialText,
+      message,
       Nil,
       notificationTargets(awsAccount, iamUser),
       channel,
@@ -108,22 +145,25 @@ object AnghammaradNotifications extends LazyLogging {
   def outdatedCredentialRemediation(
       awsAccount: AwsAccount,
       iamUser: IAMUser,
-      problemCreationDate: DateTime
+      problemCreationDate: DateTime,
+      credentialThatWasDisabled: CredentialMetadata
   ): Notification = {
     val message =
-      s"""
-         |The permanent credential, ${iamUser.username}, in ${awsAccount.name} was disabled today,
+      s"""A permanent credential for ${iamUser.username} in AWS Account ${awsAccount.name} was disabled today,
          |because it was last rotated on ${printDay(problemCreationDate)}.
          |
-         |If you still require the disabled user, add new access keys(s) and rotate regularly. Otherwise, delete them.
+         |${credentialInfo(awsAccount, iamUser, credentialThatWasDisabled)}
          |
-         |Further info: this credential is tagged with:
-         |  ${tagText(iamUser)}
+         |If any applications were still relying on this credential, they have likely been broken!
+         |If you still require access using this user, you should create a new credential and rotate regularly.
+         |Otherwise, please delete the ${iamUser.username} IAM user.
+         |
+         |$genericCredentialWarningText
          |""".stripMargin
     val subject = s"DISABLED long-lived credential in ${awsAccount.name}"
     Notification(
       subject,
-      message + genericOutdatedCredentialText,
+      message,
       Nil,
       notificationTargets(awsAccount, iamUser),
       channel,
@@ -135,14 +175,14 @@ object AnghammaradNotifications extends LazyLogging {
       awsAccount: AwsAccount,
       iamUser: IAMUser,
       problemCreationDate: DateTime,
-      devXSecurityAccount: AwsAccount
+      devXSecurityAccount: AwsAccount,
+      credentialThatWillBeDisabled: CredentialMetadata
   ): Notification = {
     val endUserNotificationTargets = notificationTargets(awsAccount, iamUser)
     val devxSecurityNotificationTargets = List(Account(devXSecurityAccount.accountNumber))
     val endUserTargetsString = endUserNotificationTargets.map(_.toString).mkString(", ")
     val message =
-      s"""
-         |The permanent credential, ${iamUser.username}, in ${awsAccount.name} was eligible for deactivation today,
+      s"""A permanent credential for ${iamUser.username} in ${awsAccount.name} was eligible for deactivation today,
          |because it was last rotated on ${printDay(problemCreationDate)}.
          |
          |It wasn't deactivated because it's not Deactivation Tuesday.
@@ -153,13 +193,12 @@ object AnghammaradNotifications extends LazyLogging {
          |
          |BE PREPARED FOR USERS TO BE UPSET!
          |
-         |Further info: this credential is tagged with:
-         |  ${tagText(iamUser)}
+         |${credentialInfo(awsAccount, iamUser, credentialThatWillBeDisabled)}
          |""".stripMargin
     val subject = s"Imminent disabling of long-lived credential in ${awsAccount.name}"
     Notification(
       subject,
-      message + genericOutdatedCredentialText,
+      message,
       Nil,
       devxSecurityNotificationTargets,
       channel,
@@ -171,7 +210,8 @@ object AnghammaradNotifications extends LazyLogging {
       awsAccount: AwsAccount,
       iamUser: IAMUser,
       problemCreationDate: DateTime,
-      devXSecurityAccount: AwsAccount
+      devXSecurityAccount: AwsAccount,
+      credentialThatWillBeDisabled: CredentialMetadata
   ): Notification = {
     val endUserNotificationTargets = notificationTargets(awsAccount, iamUser)
     val devxSecurityNotificationTargets = List(Account(devXSecurityAccount.accountNumber))
@@ -186,13 +226,13 @@ object AnghammaradNotifications extends LazyLogging {
          |THIS ACTION HAS HIGH POTENTIAL TO BREAK THINGS.
          |
          |BE PREPARED FOR USERS TO BE UPSET!
-         | Further info: this credential is tagged with:
-         |  ${tagText(iamUser)}
+         |
+         |${credentialInfo(awsAccount, iamUser, credentialThatWillBeDisabled)}
          |""".stripMargin
     val subject = s"DISABLED long-lived credential in ${awsAccount.name}"
     Notification(
       subject,
-      message + genericOutdatedCredentialText,
+      message,
       Nil,
       devxSecurityNotificationTargets,
       channel,
@@ -200,25 +240,25 @@ object AnghammaradNotifications extends LazyLogging {
     )
   }
 
-  private val genericOutdatedCredentialText = {
-    s"""
-       |To find out how to rectify this, see Grafana (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).
+  private val genericCredentialWarningText =
+    s"""If you're not sure what this warning means, would like help resolving or have any questions, please contact the Developer Experience team: devx@theguardian.com.
+       |
+       |To see more details on the status of this or any other credential, see this dashboard: https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1.
        |Here is some helpful documentation on:
-       |rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,
-       |deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_console,
-       |If you have any questions, please contact the Developer Experience team: devx@theguardian.com.
+       |rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id-credentials-access-keys-update.html#rotating_access_keys_console
+       |deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_remove.html
        |""".stripMargin
-  }
 
   def unrecognisedUserRemediation(awsAccount: AwsAccount, iamUser: IAMUser): Notification = {
     val message =
-      s"""
-         |The permanent credential, ${iamUser.username}, in ${awsAccount.name} was disabled today.
-         |Please check Grafana to review the IAM users in your account (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).
-         |If you still require the disabled user, ensure they are tagged correctly with their Google username
+      s"""A permanent credential for ${iamUser.username}, in ${awsAccount.name} was disabled today.
+         |This is because it was identified as belonging to a person who does not have an entry in Janus.
+         |
+         |If you still require the disabled user, please ensure they are tagged correctly with their Google username
          |and have an entry in Janus.
-         |If the disabled user has left the organisation, they should be deleted.
-         |If you have any questions, contact devx@theguardian.com.
+         |If the disabled user has left the organisation, this IAM user should be deleted.
+         |
+         |$genericCredentialWarningText
          |""".stripMargin
     val subject = s"AWS IAM User ${iamUser.username} DISABLED in ${awsAccount.name} Account"
     Notification(subject, message, Nil, notificationTargets(awsAccount, iamUser), channel, sourceSystem)

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -77,7 +77,7 @@ class IamOutdatedCredentials(
       iamUser: IAMUser,
       problemCreationDate: DateTime,
       thisRemediationActivity: IamRemediationActivity
-  )(implicit ec: ExecutionContext) = {
+  )(implicit ec: ExecutionContext): Attempt[List[String]] = {
     if (dryRun) {
       logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
       Attempt.Right(Nil)
@@ -85,31 +85,43 @@ class IamOutdatedCredentials(
       logger.info(
         s"""It's not "Remediation Tuesday"!  We will not execute remediation for $awsAccount, $iamUser TODAY, but we will SOON"""
       )
-      val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
-        AnghammaradNotifications.outdatedCredentialNoRemediationDevXSecurity(
-          awsAccount,
-          iamUser,
-          problemCreationDate,
-          devXSecurityAccount
+      for {
+        userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
+        credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
+        notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
+          AnghammaradNotifications.outdatedCredentialNoRemediationDevXSecurity(
+            awsAccount,
+            iamUser,
+            problemCreationDate,
+            devXSecurityAccount,
+            credentialToDisable
+          )
         )
-      )
-      sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe).map(_.toList)
+        notificationIds <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe).map(_.toList)
+      } yield notificationIds
     } else {
-      val notification =
-        AnghammaradNotifications.outdatedCredentialRemediation(awsAccount, iamUser, problemCreationDate)
-      val notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
-        AnghammaradNotifications.outdatedCredentialRemediationDevXSecurity(
-          awsAccount,
-          iamUser,
-          problemCreationDate,
-          devXSecurityAccount
-        )
-      )
+
       for {
         // plan the disable action for the correct credential
         userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
         credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
 
+        notification =
+          AnghammaradNotifications.outdatedCredentialRemediation(
+            awsAccount,
+            iamUser,
+            problemCreationDate,
+            credentialToDisable
+          )
+        notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
+          AnghammaradNotifications.outdatedCredentialRemediationDevXSecurity(
+            awsAccount,
+            iamUser,
+            problemCreationDate,
+            devXSecurityAccount,
+            credentialToDisable
+          )
+        )
         // record, then alert, then do.  Different order to the above.
         // If we do the remediation, it's vitally important that the record happens, and the alert happens.
         // So do them first.
@@ -139,9 +151,17 @@ class IamOutdatedCredentials(
   )(implicit ec: ExecutionContext) = {
     if (!dryRun) {
 
-      val notification =
-        AnghammaradNotifications.outdatedCredentialFinalWarning(awsAccount, iamUser, problemCreationDate, now)
       for {
+        userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
+        credentialThatWillBeDisabled <- lookupCredentialId(problemCreationDate, userCredentialInformation)
+        notification =
+          AnghammaradNotifications.outdatedCredentialFinalWarning(
+            awsAccount,
+            iamUser,
+            problemCreationDate,
+            credentialThatWillBeDisabled,
+            now
+          )
         // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
         // don't want to record we sent a final warning if we didn't, so we do it in this order
         snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
@@ -161,9 +181,17 @@ class IamOutdatedCredentials(
       thisRemediationActivity: IamRemediationActivity
   )(implicit ec: ExecutionContext) = {
     if (!dryRun) {
-      val notification =
-        AnghammaradNotifications.outdatedCredentialWarning(awsAccount, iamUser, problemCreationDate, now)
       for {
+        userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
+        credentialThatWillBeDisabled <- lookupCredentialId(problemCreationDate, userCredentialInformation)
+        notification =
+          AnghammaradNotifications.outdatedCredentialWarning(
+            awsAccount,
+            iamUser,
+            problemCreationDate,
+            credentialThatWillBeDisabled,
+            now
+          )
         // alert then record: user might get alerted but the database write fails; we want to make sure the alert is sent
         // don't want to record we sent a warning if we didn't, so we do it in this order
         snsId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
@@ -235,20 +263,31 @@ class IamOutdatedCredentials(
       _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(logOperationOnly)
 
       // now we know what operations need to be performed, so let's run each of those
-      results <- Attempt.traverse(filteredOperations.allowedOperations)(
+      results <- Attempt.traverseWithFailures(filteredOperations.allowedOperations)(
         performRemediationOperation(_, now)
       )
     } yield results
     result.tap {
+      // A Left here is unlikely due to `traverseWithFailures` - the top-level result should be a success.
+      // Any failures are more likely to be picked up by the Right() case.
       case Left(failedAttempt) =>
         logger.error(
           s"Failure during 'disable outdated credentials' job: ${failedAttempt.logMessage}",
           failedAttempt.firstException.orNull // make sure the exception goes into the log, if present
         )
-      case Right(operationIds) =>
+      case Right(operations) =>
+        val failedOperations = operations.collect { case Left(failure) => failure }
+        val successfulOperations = operations.collect { case Right(ids) => ids }
         logger.info(
-          s"Successfully completed 'disable outdated credentials' job, with ${operationIds.length} operations"
+          s"Completed 'disable outdated credentials job', with ${successfulOperations.length} successful operations and ${failedOperations.length} failed operations"
         )
+        failedOperations.zipWithIndex.foreach { case ((failedAttempt), i) =>
+          // TODO emit metrics counting the number of operations which failed and create alarm
+          logger.error(
+            s"Failed operation $i of ${failedOperations.length}: ${failedAttempt.logMessage}",
+            failedAttempt.firstException.orNull
+          )
+        }
     }.unit
   }
 


### PR DESCRIPTION
## What does this change?

Updates the wording in the notifications emitted to contain more pointers to what exactly needs updating, and hopefully clarify urgency and be a little bit more helpful for readers who are not already familiar with the process

Comparison table of the various notifications (contents extracted and placeholders inserted by Copilot)

| Notification function | Before | After |
|---|---|---|
| outdatedCredentialWarning | Subject: Action required by (deadline): long-lived credential detected in (aws-account-name)<br><br>Body:<br>Please check the permanent credential (username) in AWS Account (aws-account-name),<br>which has been flagged because it was last rotated on (problem-creation-date).<br>(if you're already planning on doing this, please ignore this message).<br><br>If this is not rectified before (deadline), Security HQ will automatically disable this user.<br><br>Further info: this credential is tagged with:<br>  (all-user-tags)<br><br>To find out how to rectify this, see Grafana (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_console,<br>If you have any questions, please contact the Developer Experience team: devx@theguardian.com. | Subject: Action required by (deadline): long-lived credential detected in (aws-account-name)<br><br>Body:<br>Please rotate the permanent credential for (username) in AWS Account (aws-account-name),<br>which has been flagged because it was last rotated on (problem-creation-date).<br><br>Further info:<br>This is the access key which will be disabled: (access-key-id)<br>This access key has this description: (access-key-description-or-no-description)<br>This user's tags:<br>  (non-access-key-description-tags)<br>Follow this link to find the user in the console: (remember you'll need to sign into the (aws-account-name) account first via Janus)<br>https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/(username)?section=security_credentials<br><br>If no action is taken before (deadline), this credential will be automatically disabled<br>on or shortly after that date, which will likely break any applications still using it!<br><br>If you're not sure what this warning means, would like help resolving or have any questions, please contact the Developer Experience team: devx@theguardian.com.<br><br>To see more details on the status of this or any other credential, see this dashboard: https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1.<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id-credentials-access-keys-update.html#rotating_access_keys_console<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_remove.html |
| outdatedCredentialFinalWarning | Subject: Action required by (deadline): long-lived credential in (aws-account-name) will be disabled soon<br><br>Body:<br>Please check the permanent credential (username) in AWS Account (aws-account-name),<br>which has been flagged because it was last rotated on (problem-creation-date).<br>(if you're already planning on doing this, please ignore this message).<br><br>If this is not rectified before (deadline),<br>Security HQ will automatically disable this user at the next opportunity.<br><br>Further info: this credential is tagged with:<br>  (all-user-tags)<br><br>To find out how to rectify this, see Grafana (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_console,<br>If you have any questions, please contact the Developer Experience team: devx@theguardian.com. | Subject: Action required by (deadline): long-lived credential in (aws-account-name) will be disabled soon<br><br>Body:<br>Please rotate the permanent credential for (username) in AWS Account (aws-account-name),<br>which has been flagged because it was last rotated on (problem-creation-date).<br><br>Further info:<br>This is the access key which will be disabled: (access-key-id)<br>This access key has this description: (access-key-description-or-no-description)<br>This user's tags:<br>  (non-access-key-description-tags)<br>Follow this link to find the user in the console: (remember you'll need to sign into the (aws-account-name) account first via Janus)<br>https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/(username)?section=security_credentials<br><br>If no action is taken before (deadline), this credential will be automatically disabled<br>on or shortly after that date, which will likely break any applications still using it!<br><br>If you're not sure what this warning means, would like help resolving or have any questions, please contact the Developer Experience team: devx@theguardian.com.<br><br>To see more details on the status of this or any other credential, see this dashboard: https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1.<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id-credentials-access-keys-update.html#rotating_access_keys_console<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_remove.html |
| outdatedCredentialRemediation | Subject: DISABLED long-lived credential in (aws-account-name)<br><br>Body:<br>The permanent credential, (username), in (aws-account-name) was disabled today,<br>because it was last rotated on (problem-creation-date).<br><br>If you still require the disabled user, add new access keys(s) and rotate regularly. Otherwise, delete them.<br><br>Further info: this credential is tagged with:<br>  (all-user-tags)<br><br>To find out how to rectify this, see Grafana (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_console,<br>If you have any questions, please contact the Developer Experience team: devx@theguardian.com. | Subject: DISABLED long-lived credential in (aws-account-name)<br><br>Body:<br>A permanent credential for (username) in AWS Account (aws-account-name) was disabled today,<br>because it was last rotated on (problem-creation-date).<br><br>Further info:<br>This is the access key which will be disabled: (access-key-id)<br>This access key has this description: (access-key-description-or-no-description)<br>This user's tags:<br>  (non-access-key-description-tags)<br>Follow this link to find the user in the console: (remember you'll need to sign into the (aws-account-name) account first via Janus)<br>https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/(username)?section=security_credentials<br><br>If any applications were still relying on this credential, they have likely been broken!<br>If you still require access using this user, you should create a new credential and rotate regularly.<br>Otherwise, please delete them.<br><br>If you're not sure what this warning means, would like help resolving or have any questions, please contact the Developer Experience team: devx@theguardian.com.<br><br>To see more details on the status of this or any other credential, see this dashboard: https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1.<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id-credentials-access-keys-update.html#rotating_access_keys_console<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_remove.html |
| outdatedCredentialNoRemediationDevXSecurity | Subject: Imminent disabling of long-lived credential in (aws-account-name)<br><br>Body:<br>The permanent credential, (username), in (aws-account-name) was eligible for deactivation today,<br>because it was last rotated on (problem-creation-date).<br><br>It wasn't deactivated because it's not Deactivation Tuesday.<br><br>The end users are (end-user-targets).<br><br>THIS ACTION HAS HIGH POTENTIAL TO BREAK THINGS.<br><br>BE PREPARED FOR USERS TO BE UPSET!<br><br>Further info: this credential is tagged with:<br>  (all-user-tags)<br><br>To find out how to rectify this, see Grafana (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_console,<br>If you have any questions, please contact the Developer Experience team: devx@theguardian.com. | Subject: Imminent disabling of long-lived credential in (aws-account-name)<br><br>Body:<br>A permanent credential for (username) in (aws-account-name) was eligible for deactivation today,<br>because it was last rotated on (problem-creation-date).<br><br>It wasn't deactivated because it's not Deactivation Tuesday.<br><br>The end users are (end-user-targets)<br><br>THIS ACTION HAS HIGH POTENTIAL TO BREAK THINGS.<br><br>BE PREPARED FOR USERS TO BE UPSET!<br><br>Further info:<br>This is the access key which will be disabled: (access-key-id)<br>This access key has this description: (access-key-description-or-no-description)<br>This user's tags:<br>  (non-access-key-description-tags)<br>Follow this link to find the user in the console: (remember you'll need to sign into the (aws-account-name) account first via Janus)<br>https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/(username)?section=security_credentials |
| outdatedCredentialRemediationDevXSecurity | Subject: DISABLED long-lived credential in (aws-account-name)<br><br>Body:<br>The permanent credential, (username), in (aws-account-name) was disabled today,<br>because it was last rotated on (problem-creation-date).<br><br>Notification(s) have been sent to (end-user-targets), who are the owners of the disabled credential.<br><br>THIS ACTION HAS HIGH POTENTIAL TO BREAK THINGS.<br><br>BE PREPARED FOR USERS TO BE UPSET!<br>Further info: this credential is tagged with:<br>  (all-user-tags)<br><br>To find out how to rectify this, see Grafana (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html,<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_console,<br>If you have any questions, please contact the Developer Experience team: devx@theguardian.com. | Subject: DISABLED long-lived credential in (aws-account-name)<br><br>Body:<br>The permanent credential, (username), in (aws-account-name) was disabled today,<br>because it was last rotated on (problem-creation-date).<br><br>Notification(s) have been sent to (end-user-targets), who are the owners of the disabled credential.<br><br>THIS ACTION HAS HIGH POTENTIAL TO BREAK THINGS.<br><br>BE PREPARED FOR USERS TO BE UPSET!<br><br>Further info:<br>This is the access key which will be disabled: (access-key-id)<br>This access key has this description: (access-key-description-or-no-description)<br>This user's tags:<br>  (non-access-key-description-tags)<br>Follow this link to find the user in the console: (remember you'll need to sign into the (aws-account-name) account first via Janus)<br>https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users/details/(username)?section=security_credentials |
| unrecognisedUserRemediation | Subject: AWS IAM User (username) DISABLED in (aws-account-name) Account<br><br>Body:<br>The permanent credential, (username), in (aws-account-name) was disabled today.<br>Please check Grafana to review the IAM users in your account (https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1).<br>If you still require the disabled user, ensure they are tagged correctly with their Google username<br>and have an entry in Janus.<br>If the disabled user has left the organisation, they should be deleted.<br>If you have any questions, contact devx@theguardian.com. | Subject: AWS IAM User (username) DISABLED in (aws-account-name) Account<br><br>Body:<br>A permanent credential for (username), in (aws-account-name) was disabled today.<br>This is because it was identified as belonging to a person who does not have an entry in Janus.<br><br>If you still require the disabled user, please ensure they are tagged correctly with their Google username<br>and have an entry in Janus.<br>If the disabled user has left the organisation, this IAM user should be deleted.<br><br>If you're not sure what this warning means, would like help resolving or have any questions, please contact the Developer Experience team: devx@theguardian.com.<br><br>To see more details on the status of this or any other credential, see this dashboard: https://metrics.gutools.co.uk/d/bdn97cui5rbi8f/iam-credentials-report?orgId=1.<br>Here is some helpful documentation on:<br>rotating credentials: https://docs.aws.amazon.com/IAM/latest/UserGuide/id-credentials-access-keys-update.html#rotating_access_keys_console<br>deleting users: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_remove.html |

