### PR TITLE
Clean up logging for deleted users

### DIFF
--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -57,7 +57,14 @@ object IAMClient extends LazyLogging {
       }
       // If the request to fetch tags fails, just return the original user
       .recover { case error =>
-        logger.warn(s"Failed to fetch tags for user ${credential.user}. Storing user without tags.", error)
+        error.getCause match {
+          case _: NoSuchEntityException =>
+            logger.info(
+              s"User ${credential.user} has been deleted since the report was generated. Storing user without tags."
+            )
+          case _ =>
+            logger.warn(s"Failed to fetch tags for user ${credential.user}. Storing user without tags.", error)
+        }
         credential
       }
   }


### PR DESCRIPTION
## What does this change?

One known issue is that the credentials report can be slightly stale.  If we have deleted a user since the report was generated, we don't care that we can't get information on it.  Clean up the logs with an info instead of a warn+stacktrace

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
