### PR TITLE
add iamOutdatedCredentials to the list of aggregated sbt projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -199,7 +199,7 @@ lazy val iamUnrecognisedUsers = (project in file("iam-unrecognised-users"))
 Global / excludeLintKeys += Universal / topLevelDirectory
 
 lazy val root = (project in file("."))
-  .aggregate(core, hq, iamUnrecognisedUsers)
+  .aggregate(core, hq, iamUnrecognisedUsers, iamOutdatedCredentials)
   .settings(
     name := """security-hq"""
   )


### PR DESCRIPTION
## What does this change?

Add `iamOutdatedCredentials` to the `aggregate` list in the SBT config.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

The project will be included in any top level sbt commands, such as `compile`, `test`, `scalafmtAll` etc.

<!-- Why are these changes being made? -->
