### PR TITLE
feat: Enable unrecognised users lambda

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1900,7 +1900,7 @@ exports[`HQ stack matches the snapshot 1`] = `
             "APP": "iam-unrecognised-users",
             "CONFIG_BUCKET": "security-dist",
             "CONFIG_KEY": "security/PROD/security-hq/security-hq.conf",
-            "DRY_RUN": "true",
+            "DRY_RUN": "false",
             "IAM_UNRECOGNISED_USER_S3_BUCKET": "gu-security-hq-audit",
             "IAM_UNRECOGNISED_USER_S3_KEY": "security/PROD/janus-data-export/janusData.conf",
             "STACK": "security",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -416,7 +416,7 @@ export class SecurityHQ extends GuStack {
         environment: {
           STACK: this.stack,
           STAGE: this.stage,
-          DRY_RUN: "true",
+          DRY_RUN: "false",
           CONFIG_BUCKET: "security-dist",
           CONFIG_KEY: `security/${this.stage}/security-hq/security-hq.conf`,
           IAM_UNRECOGNISED_USER_S3_BUCKET: SecurityHQ.auditBucketName,


### PR DESCRIPTION
Now that we see the same dry-run behaviour in the old Play app service and the new lambda, we can switch on the lambda for real and check that it works.

See [Asana ticket](https://app.asana.com/1/1210045093164357/project/1213214650045516/task/1216038883987063?focus=true).