### PR TITLE
Remove outdated credentials from app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,9 @@ ThisBuild / scalaVersion := "3.3.8"
 ThisBuild / scalacOptions ++= Seq(
   "-feature",
   "-no-indent", // don't support significant indentation
+  "-Wunused:all", // fail the build on unused imports, vals, params, and private members
+  "-Wconf:src=.*/twirl/.*&msg=.*unused.*:silent", // ignore dead-code warnings in generated Twirl sources
+  "-Wconf:src=.*/routes/.*&msg=.*unused.*:silent", // ignore dead-code warnings in generated Play routes sources
   "-Xfatal-warnings"
 )
 

--- a/core/src/main/scala/aws/package.scala
+++ b/core/src/main/scala/aws/package.scala
@@ -50,7 +50,7 @@ package object aws extends LazyLogging {
               )
             )
           )
-        case multipleClients =>
+        case _ =>
           val errorString =
             s"More than one ${classTag.runtimeClass.getSimpleName} client exists for ${account.id} - perhaps you need to use get(account, region)??"
           logger.warn(errorString)

--- a/core/src/main/scala/aws/s3/S3.scala
+++ b/core/src/main/scala/aws/s3/S3.scala
@@ -1,15 +1,12 @@
 package aws.s3
 
 import model.{BucketEncryptionResponse, BucketNotFound, Encrypted, NotEncrypted}
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.{GetBucketEncryptionRequest, GetObjectRequest, S3Exception}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
-import scala.concurrent.ExecutionContext
 import scala.io.BufferedSource
 import scala.util.control.NonFatal
-
-import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.S3Exception
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, GetBucketEncryptionRequest}
 
 object S3 {
   def getS3Object(s3Client: S3Client, bucket: String, key: String): Attempt[BufferedSource] = {
@@ -34,9 +31,7 @@ object S3 {
     }
   }
 
-  def getBucketEncryption(client: S3Client, bucketName: String)(implicit
-      ec: ExecutionContext
-  ): Attempt[BucketEncryptionResponse] = {
+  def getBucketEncryption(client: S3Client, bucketName: String): Attempt[BucketEncryptionResponse] = {
     val request = GetBucketEncryptionRequest.builder().bucket(bucketName).build()
     try {
       Attempt.Right {

--- a/core/src/main/scala/aws/support/TrustedAdvisor.scala
+++ b/core/src/main/scala/aws/support/TrustedAdvisor.scala
@@ -1,21 +1,20 @@
 package aws.support
 
 import aws.AwsAsyncHandler.{asScala, handleAWSErrs}
-import aws.{AwsClient, AwsClients}
+import aws.AwsClient
 
 import logic.DateUtils.fromISOString
 import model._
-import utils.attempt.{Attempt, FailedAttempt, Failure}
+import utils.attempt.Attempt
 
 import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.support.SupportAsyncClient
 import software.amazon.awssdk.services.support.model._
 
 object TrustedAdvisor {
-  val portPriorityMap =
+  val portPriorityMap: Seq[(String, Set[Int])] =
     Seq(
       "FTP" -> Set(20, 21),
       "Postgres" -> Set(5432),
@@ -36,9 +35,9 @@ object TrustedAdvisor {
       "SSH" -> Set(22)
     )
 
-  val indexedPortMap = portPriorityMap.zipWithIndex
+  val indexedPortMap: Seq[((String, Set[Int]), Int)] = portPriorityMap.zipWithIndex
 
-  val alertLevelMapping = Map("Red" -> 0, "Yellow" -> 1, "Green" -> 2)
+  val alertLevelMapping: Map[String, Int] = Map("Red" -> 0, "Yellow" -> 1, "Green" -> 2)
 
   // SHOW ALL TRUSTED ADVISOR CHECKS
 

--- a/core/src/main/scala/aws/support/TrustedAdvisorS3.scala
+++ b/core/src/main/scala/aws/support/TrustedAdvisorS3.scala
@@ -12,7 +12,6 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.*
-import scala.util.control.NonFatal
 import scala.util.{Success, Try}
 
 object TrustedAdvisorS3 {

--- a/core/src/main/scala/aws/support/TrustedAdvisorSGOpenPorts.scala
+++ b/core/src/main/scala/aws/support/TrustedAdvisorSGOpenPorts.scala
@@ -34,7 +34,7 @@ object TrustedAdvisorSGOpenPorts {
 
   private[support] def parseSGOpenPortsDetail(detail: TrustedAdvisorResourceDetail): Attempt[SGOpenPortsDetail] = {
     detail.metadata.asScala.toList match {
-      case region :: name :: SGIds(sgId, vpcId) :: protocol :: alertLevel :: port :: _ =>
+      case _ :: name :: SGIds(sgId, vpcId) :: protocol :: alertLevel :: port :: _ =>
         Attempt.Right {
           SGOpenPortsDetail(
             status = detail.status,
@@ -48,7 +48,7 @@ object TrustedAdvisorSGOpenPorts {
             isSuppressed = detail.isSuppressed
           )
         }
-      case region :: name :: sgId :: protocol :: alertLevel :: port :: _ =>
+      case _ :: name :: sgId :: protocol :: alertLevel :: port :: _ =>
         Attempt.Right {
           SGOpenPortsDetail(
             status = detail.status,

--- a/core/src/main/scala/db/IamRemediationDb.scala
+++ b/core/src/main/scala/db/IamRemediationDb.scala
@@ -36,7 +36,7 @@ class IamRemediationDb(client: DynamoDbClient) {
     } yield result.responseMetadata.requestId
   }
 
-  private def scan(request: ScanRequest)(implicit ec: ExecutionContext): Attempt[List[Map[String, AttributeValue]]] = {
+  private def scan(request: ScanRequest): Attempt[List[Map[String, AttributeValue]]] = {
     try {
       Attempt.Right(client.scan(request).items.asScala.toList.map(_.asScala.toMap))
     } catch {
@@ -52,23 +52,7 @@ class IamRemediationDb(client: DynamoDbClient) {
     }
   }
 
-  private def get(request: GetItemRequest)(implicit ec: ExecutionContext): Attempt[Map[String, AttributeValue]] = {
-    try {
-      Attempt.Right(client.getItem(request).item.asScala.toMap)
-    } catch {
-      case NonFatal(e) =>
-        Attempt.Left(
-          Failure(
-            s"unable to get item from dynamoDB table",
-            s"I haven't been able to get the item you were looking for from the dynamo table for the vulnerable user job",
-            500,
-            throwable = Some(e)
-          )
-        )
-    }
-  }
-
-  private def put(request: PutItemRequest)(implicit ec: ExecutionContext): Attempt[PutItemResponse] = {
+  private def put(request: PutItemRequest): Attempt[PutItemResponse] = {
     try {
       Attempt.Right(client.putItem(request))
     } catch {

--- a/core/src/main/scala/notifications/AnghammaradNotifications.scala
+++ b/core/src/main/scala/notifications/AnghammaradNotifications.scala
@@ -5,7 +5,7 @@ import com.gu.anghammarad.models.{Email, Notification, Preferred, Target, AwsAcc
 import com.typesafe.scalalogging.LazyLogging
 import config.CoreConfig.{daysBetweenFinalNotificationAndRemediation, daysBetweenWarningAndFinalNotification}
 import logic.DateUtils.printDay
-import model.{AwsAccount, HumanUser, IAMUser, Tag}
+import model.{AwsAccount, IAMUser, Tag}
 import org.joda.time.DateTime
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import utils.attempt.{Attempt, Failure}

--- a/core/src/test/scala/aws/support/TrustedAdvisorSGOpenPortsTest.scala
+++ b/core/src/test/scala/aws/support/TrustedAdvisorSGOpenPortsTest.scala
@@ -117,7 +117,7 @@ class TrustedAdvisorSGOpenPortsTest extends AnyFreeSpec with Matchers with Attem
     }
 
     "handle simple port" in {
-      TrustedAdvisor.indexedPortMap.foreach { case ((k, ports), idx) =>
+      TrustedAdvisor.indexedPortMap.foreach { case ((_, ports), idx) =>
         ports.foreach { port =>
           TrustedAdvisor.findPortPriorityIndex(port.toString) shouldBe Some(idx)
         }

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -1,12 +1,10 @@
 import aws.ec2.EC2
 import aws.{AWS, AwsClient}
-import config.CoreConfig.{getSecurityDynamoDbClient, securityCredentialsProvider}
+import config.CoreConfig.securityCredentialsProvider
 import config.{Config, CoreConfig}
 import controllers.*
-import db.IamRemediationDb
 import filters.HstsFilter
-import logic.IamOutdatedCredentials
-import model.{AwsAccount, Stage}
+import model.AwsAccount
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -92,7 +90,6 @@ class AppComponents(context: Context)
   private val taClients = AWS.taClients(awsAccounts)
   private val s3Clients = AWS.s3Clients(awsAccounts, availableRegions)
   private val iamClients = AWS.iamClients(awsAccounts)
-  private val devXSecurityAccountMaybe = awsAccounts.find(_.id == IamOutdatedCredentials.SECURITY_ACCOUNT_ID)
 
   /*
       The casting from SdkHttpConfigurationOption[Integer] to AttributeMap.Key[Any] is required because Scala compiler comlains
@@ -117,8 +114,6 @@ class AppComponents(context: Context)
   private val googleAuthConfig =
     Config.googleSettings(stage, stack, configuration, securitySsmClient)
 
-  private val securityDynamoDbClient = getSecurityDynamoDbClient(stage: Stage)
-
   private val securityS3Client = S3Client.builder
     .credentialsProvider(securityCredentialsProvider)
     .region(CoreConfig.region)
@@ -134,37 +129,19 @@ class AppComponents(context: Context)
   )
 
   new MetricService(
-    configuration,
     applicationLifecycle,
     environment,
     cacheService
   )
 
-  private val dynamo = new IamRemediationDb(securityDynamoDbClient)
-  private val dryRun = Config.getOutdatedCredentialsDryRun(configuration)
-  private val notificationTopicArn = Config.getAnghammaradSNSTopicArn(configuration)
-  private val tableName = Config.getIamDynamoTableName(configuration)
-  private val iamOutdatedCredentials =
-    IamOutdatedCredentials(
-      securitySnsClient,
-      iamClients,
-      dynamo,
-      devXSecurityAccountMaybe,
-      dryRun,
-      notificationTopicArn,
-      tableName
-    )
-
   new IamRemediationService(
     cacheService,
     securitySnsClient,
-    dynamo,
     configuration,
     iamClients,
     applicationLifecycle,
     environment,
-    securityS3Client,
-    iamOutdatedCredentials
+    securityS3Client
   )(executionContext)
 
   override def router: Router = new Routes(

--- a/hq/app/AppLoader.scala
+++ b/hq/app/AppLoader.scala
@@ -1,7 +1,5 @@
 import play.api.ApplicationLoader.Context
-import play.api.{Application, ApplicationLoader, Mode}
-
-import scala.concurrent.Future
+import play.api.{Application, ApplicationLoader}
 
 class AppLoader extends ApplicationLoader {
   override def load(context: Context): Application = {

--- a/hq/app/logic/DocumentUtil.scala
+++ b/hq/app/logic/DocumentUtil.scala
@@ -2,7 +2,6 @@ package logic
 
 import com.vladsch.flexmark.html.HtmlRenderer
 import com.vladsch.flexmark.parser.Parser
-import java.io.InputStream
 
 import com.vladsch.flexmark.util.data.MutableDataSet
 

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -3,11 +3,9 @@ package services
 import aws.AwsClients
 import aws.s3.S3.getS3Object
 import com.gu.janus.JanusConfig
-import config.Config
 import config.Config.getIamUnrecognisedUserConfig
-import db.IamRemediationDb
 import logic.IamUnrecognisedUsers.*
-import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
+import logic.IamUnrecognisedUsers
 import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
@@ -32,13 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class IamRemediationService(
     cacheService: CacheService,
     snsClient: SnsAsyncClient,
-    dynamo: IamRemediationDb,
     config: Configuration,
     iamClients: AwsClients[IamAsyncClient],
     lifecycle: ApplicationLifecycle,
     environment: Environment,
-    securityS3Client: S3Client,
-    iamOutdatedCredentials: IamOutdatedCredentials
+    securityS3Client: S3Client
 )(implicit ec: ExecutionContext)
     extends Scheduler {
 
@@ -110,7 +106,6 @@ class IamRemediationService(
           (now.getHourOfDay == 14 && now.getMinuteOfHour == 0)
 
         if (isWeekday && isTimeToRun) {
-          disableOutdatedCredentials()
           disableUnrecognisedUsers()
         }
       }
@@ -118,15 +113,4 @@ class IamRemediationService(
     lifecycle.addStopHook(iamRemediationServiceSubscription)
   }
 
-  private def disableOutdatedCredentials(): Attempt[Unit] = for {
-    serviceAccountIds <- Config.getAccountsForIamRemediationService(config)
-    rawCredsReports = cacheService.getAllCredentials
-    // this tells us which AWS accounts we are allowed to make changes to
-    allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-    result <- iamOutdatedCredentials.disableOutdatedCredentials(
-      serviceAccountIds,
-      rawCredsReports,
-      allowedAwsAccountIds
-    )
-  } yield result
 }

--- a/hq/app/services/MetricService.scala
+++ b/hq/app/services/MetricService.scala
@@ -7,16 +7,13 @@ import play.api.inject.ApplicationLifecycle
 import utils.Scheduler
 import utils.attempt.FailedAttempt
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.*
 
 class MetricService(
-    config: Configuration,
     lifecycle: ApplicationLifecycle,
     environment: Environment,
     cacheService: CacheService
-)(implicit ec: ExecutionContext)
-    extends Scheduler {
+) extends Scheduler {
 
   def collectFailures[T](
       list: List[Map[AwsAccount, Either[FailedAttempt, T]]]

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -58,7 +58,6 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       AccessKey(AccessKeyEnabled, Some(date.minusDays(CoreConfig.iamMachineUserRotationCadence.toInt)))
     val humanEnabledAccessKeyHealthy = AccessKey(AccessKeyEnabled, Some(date.minusMonths(1)))
     val noAccessKey = AccessKey(NoKey, None)
-    val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
     val humanWithOneOldEnabledAccessKey =
       HumanUser("amina.adewusi", true, humanAccessKeyOldAndEnabled, noAccessKey, Green, None, Nil)
     val humanWithHealthyKey =
@@ -533,8 +532,6 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       }
 
       "given a key that was given a final warning 13 days ago, but the task has not run since, carry on" in {
-        // Key was issued a final warning a year ago.
-        val aYearAgo = date.minusMonths(12)
         // Key was issued a warning 14 days ago
         val aYearAndFifteenDaysAgo = date.minusDays(15)
         // Key was issued a final warning 13 days ago
@@ -557,11 +554,9 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       }
 
       "given a key that was given a final warning 14 days ago, but the task has not run since, go back to warning" in {
-        // Key was issued a final warning a year ago.
-        val aYearAgo = date.minusMonths(12)
         // Key was issued a warning 14 days ago
         val aYearAndFifteenDaysAgo = date.minusDays(15)
-        // Key was issued a final warning 13 days ago
+        // Key was issued a final warning 14 days ago
         val aYearAndfourteenDaysAgo = date.minusDays(14)
         val remediationOperation = calculateOutstandingAccessKeyOperations(
           List(
@@ -736,8 +731,6 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
   "formatRemediationOperation" - {
     val date = new DateTime(2021, 1, 1, 1, 1)
     val account = AwsAccount("testAccountId", "testAccount", "roleArn", "12345")
-    val humanUser =
-      HumanUser("human.user", hasMFA = true, AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, Nil)
     val machineUser =
       MachineUser("machine.user", AccessKey(NoKey, None), AccessKey(NoKey, None), Green, None, Nil)
 


### PR DESCRIPTION
## What does this change?

We fully expect to have nothing left, but it helps to tidy up as we go.  This PR removes everything from the app that has moved to the iam outdated credentials lambda.

In order to achieve this, the error for unused code elements has been turned on, but filtered so it doesn't apply to generated code.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
