### PR TITLE
Remove app call to outdated credentials

### DIFF
--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -1,12 +1,10 @@
 import aws.ec2.EC2
 import aws.{AWS, AwsClient}
-import config.CoreConfig.{getSecurityDynamoDbClient, securityCredentialsProvider}
+import config.CoreConfig.securityCredentialsProvider
 import config.{Config, CoreConfig}
 import controllers.*
-import db.IamRemediationDb
 import filters.HstsFilter
-import logic.IamOutdatedCredentials
-import model.{AwsAccount, Stage}
+import model.AwsAccount
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.WSClient
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -92,7 +90,6 @@ class AppComponents(context: Context)
   private val taClients = AWS.taClients(awsAccounts)
   private val s3Clients = AWS.s3Clients(awsAccounts, availableRegions)
   private val iamClients = AWS.iamClients(awsAccounts)
-  private val devXSecurityAccountMaybe = awsAccounts.find(_.id == IamOutdatedCredentials.SECURITY_ACCOUNT_ID)
 
   /*
       The casting from SdkHttpConfigurationOption[Integer] to AttributeMap.Key[Any] is required because Scala compiler comlains
@@ -117,8 +114,6 @@ class AppComponents(context: Context)
   private val googleAuthConfig =
     Config.googleSettings(stage, stack, configuration, securitySsmClient)
 
-  private val securityDynamoDbClient = getSecurityDynamoDbClient(stage: Stage)
-
   private val securityS3Client = S3Client.builder
     .credentialsProvider(securityCredentialsProvider)
     .region(CoreConfig.region)
@@ -140,31 +135,14 @@ class AppComponents(context: Context)
     cacheService
   )
 
-  private val dynamo = new IamRemediationDb(securityDynamoDbClient)
-  private val dryRun = Config.getOutdatedCredentialsDryRun(configuration)
-  private val notificationTopicArn = Config.getAnghammaradSNSTopicArn(configuration)
-  private val tableName = Config.getIamDynamoTableName(configuration)
-  private val iamOutdatedCredentials =
-    IamOutdatedCredentials(
-      securitySnsClient,
-      iamClients,
-      dynamo,
-      devXSecurityAccountMaybe,
-      dryRun,
-      notificationTopicArn,
-      tableName
-    )
-
   new IamRemediationService(
     cacheService,
     securitySnsClient,
-    dynamo,
     configuration,
     iamClients,
     applicationLifecycle,
     environment,
-    securityS3Client,
-    iamOutdatedCredentials
+    securityS3Client
   )(executionContext)
 
   override def router: Router = new Routes(

--- a/hq/app/AppLoader.scala
+++ b/hq/app/AppLoader.scala
@@ -1,7 +1,5 @@
 import play.api.ApplicationLoader.Context
-import play.api.{Application, ApplicationLoader, Mode}
-
-import scala.concurrent.Future
+import play.api.{Application, ApplicationLoader}
 
 class AppLoader extends ApplicationLoader {
   override def load(context: Context): Application = {

--- a/hq/app/services/IamRemediationService.scala
+++ b/hq/app/services/IamRemediationService.scala
@@ -3,11 +3,9 @@ package services
 import aws.AwsClients
 import aws.s3.S3.getS3Object
 import com.gu.janus.JanusConfig
-import config.Config
 import config.Config.getIamUnrecognisedUserConfig
-import db.IamRemediationDb
 import logic.IamUnrecognisedUsers.*
-import logic.{IamOutdatedCredentials, IamUnrecognisedUsers}
+import logic.IamUnrecognisedUsers
 import notifications.AnghammaradNotifications
 import org.joda.time.{DateTime, DateTimeConstants}
 import play.api.inject.ApplicationLifecycle
@@ -32,13 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
 class IamRemediationService(
     cacheService: CacheService,
     snsClient: SnsAsyncClient,
-    dynamo: IamRemediationDb,
     config: Configuration,
     iamClients: AwsClients[IamAsyncClient],
     lifecycle: ApplicationLifecycle,
     environment: Environment,
-    securityS3Client: S3Client,
-    iamOutdatedCredentials: IamOutdatedCredentials
+    securityS3Client: S3Client
 )(implicit ec: ExecutionContext)
     extends Scheduler {
 
@@ -110,7 +106,6 @@ class IamRemediationService(
           (now.getHourOfDay == 14 && now.getMinuteOfHour == 0)
 
         if (isWeekday && isTimeToRun) {
-          disableOutdatedCredentials()
           disableUnrecognisedUsers()
         }
       }
@@ -118,15 +113,4 @@ class IamRemediationService(
     lifecycle.addStopHook(iamRemediationServiceSubscription)
   }
 
-  private def disableOutdatedCredentials(): Attempt[Unit] = for {
-    serviceAccountIds <- Config.getAccountsForIamRemediationService(config)
-    rawCredsReports = cacheService.getAllCredentials
-    // this tells us which AWS accounts we are allowed to make changes to
-    allowedAwsAccountIds <- Config.getAllowedAccountsForStage(config)
-    result <- iamOutdatedCredentials.disableOutdatedCredentials(
-      serviceAccountIds,
-      rawCredsReports,
-      allowedAwsAccountIds
-    )
-  } yield result
 }


### PR DESCRIPTION
## What does this change?

We fully expect to have nothing left, but it helps to tidy up as we go. This PR removes everything from the app that has moved to the iam outdated credentials lambda.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
