### PR TITLE
Bump janus-config-tools to v12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ lazy val core = (project in file("core"))
       "com.github.tototoshi" %% "scala-csv" % "2.0.0",
       "joda-time" % "joda-time" % "2.14.2",
       "com.gu" %% "anghammarad-client" % "7.0.0",
-      "com.gu" %% "janus-config-tools" % "11.0.0",
+      "com.gu" %% "janus-config-tools" % "12.0.0",
       "software.amazon.awssdk" % "iam" % awsSdkVersion,
       "software.amazon.awssdk" % "cloudwatch" % awsSdkVersion,
       "software.amazon.awssdk" % "dynamodb" % awsSdkVersion,
@@ -114,7 +114,7 @@ lazy val hq = (project in file("hq"))
       "com.gu" %% "anghammarad-client" % "7.0.0",
       "ch.qos.logback" % "logback-classic" % "1.5.38",
       "net.logstash.logback" % "logstash-logback-encoder" % "9.0",
-      "com.gu" %% "janus-config-tools" % "11.0.0"
+      "com.gu" %% "janus-config-tools" % "12.0.0"
     ) ++ safeTransitiveDependencies,
     Assets / pipelineStages := Seq(digest),
     // exclude docs


### PR DESCRIPTION
See also:
https://github.com/guardian/janus-app/issues/937
https://github.com/guardian/janus/pull/5690

## What does this change?

Bumps janus-config-tools to the latest version, to maintain config file compatibility. This is the first of a few upcoming updates.


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
