### PR TITLE
Reorganise metrics and add better alerts

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -42,6 +42,10 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuParameter",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
       "GuDeveloperPolicyExperimental",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
@@ -441,6 +445,174 @@ exports[`HQ stack matches the snapshot 1`] = `
         ],
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DisableAccessKeyNotRunningAlarm94D518B3": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to emit vulnerable access key metrics",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "IamDisableAccessKey",
+        "Namespace": "SecurityHQ",
+        "Period": 259200,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DisableOutdatedKeysFailureAlarmEB74E827": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to disable an outdated access key (new stack)",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Failure",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "IamDisableOutdatedKeys",
+        "Namespace": "SecurityHQ",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DisableOutdatedKeysNotRunningAlarm496E6C34": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to emit outdated access key metrics",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "IamDisableOutdatedKeys",
+        "Namespace": "SecurityHQ",
+        "Period": 604800,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -1166,6 +1338,60 @@ exports[`HQ stack matches the snapshot 1`] = `
         ],
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RemovePasswordNotRunningAlarmB4DB66B6": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to emit vulnerable password metrics",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "IamRemovePassword",
+        "Namespace": "SecurityHQ",
+        "Period": 259200,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -591,7 +591,7 @@ exports[`HQ stack matches the snapshot 1`] = `
         "EvaluationPeriods": 1,
         "MetricName": "IamDisableOutdatedKeys",
         "Namespace": "SecurityHQ",
-        "Period": 604800,
+        "Period": 259200,
         "Statistic": "Sum",
         "Tags": [
           {
@@ -1367,6 +1367,12 @@ exports[`HQ stack matches the snapshot 1`] = `
         "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
         "AlarmName": "Security HQ failed to emit vulnerable password metrics",
         "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Success",
+          },
+        ],
         "EvaluationPeriods": 1,
         "MetricName": "IamRemovePassword",
         "Namespace": "SecurityHQ",

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -386,7 +386,7 @@ export class SecurityHQ extends GuStack {
       metric: new Metric({
         metricName: "IamDisableOutdatedKeys",
         namespace: "SecurityHQ",
-        period: Duration.days(7), // we only remediate on tuesdays, twice
+        period: Duration.days(3), // we do not run sat/sun
         statistic: "sum",
       }),
       treatMissingData: TreatMissingData.BREACHING,

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -269,7 +269,8 @@ export class SecurityHQ extends GuStack {
       alarmName:
         "Security HQ failed to remove a vulnerable password (new stack)",
       alarmDescription:
-        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
       snsTopicName: notificationTopic.topicName,
       threshold: 1,
       evaluationPeriods: 1,
@@ -286,12 +287,32 @@ export class SecurityHQ extends GuStack {
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
     });
 
+    new GuAlarm(this, "RemovePasswordNotRunningAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName: "Security HQ failed to emit vulnerable password metrics",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 0,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamRemovePassword",
+        namespace: "SecurityHQ",
+        period: Duration.days(3), // we do not run sat/sun
+        statistic: "sum",
+      }),
+      treatMissingData: TreatMissingData.BREACHING,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+    });
+
     new GuAlarm(this, "DisableAccessKeyFailureAlarm", {
       app: SecurityHQ.app.app,
       alarmName:
         "Security HQ failed to disable a vulnerable access key (new stack)",
       alarmDescription:
-        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
       snsTopicName: notificationTopic.topicName,
       threshold: 1,
       evaluationPeriods: 1,
@@ -306,6 +327,67 @@ export class SecurityHQ extends GuStack {
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    });
+
+    new GuAlarm(this, "DisableAccessKeyNotRunningAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName: "Security HQ failed to emit vulnerable access key metrics",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit." +
+        " Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 0,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamDisableAccessKey",
+        namespace: "SecurityHQ",
+        period: Duration.days(3), // we do not run sat/sun
+        statistic: "sum",
+      }),
+      treatMissingData: TreatMissingData.BREACHING,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+    });
+
+    new GuAlarm(this, "DisableOutdatedKeysFailureAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName:
+        "Security HQ failed to disable an outdated access key (new stack)",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamDisableOutdatedKeys",
+        namespace: "SecurityHQ",
+        period: Duration.seconds(60),
+        statistic: "sum",
+        dimensionsMap: {
+          ReaperExecutionStatus: "Failure",
+        },
+      }),
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    });
+
+    new GuAlarm(this, "DisableOutdatedKeysNotRunningAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName: "Security HQ failed to emit outdated access key metrics",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit." +
+        " Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 0,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamDisableOutdatedKeys",
+        namespace: "SecurityHQ",
+        period: Duration.days(7), // we only remediate on tuesdays, twice
+        statistic: "sum",
+      }),
+      treatMissingData: TreatMissingData.BREACHING,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
     });
 
     new GuDeveloperPolicyExperimental(this, "RunSecurityHqLocallyPolicy", {

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -301,6 +301,9 @@ export class SecurityHQ extends GuStack {
         namespace: "SecurityHQ",
         period: Duration.days(3), // we do not run sat/sun
         statistic: "sum",
+        dimensionsMap: {
+          ReaperExecutionStatus: "Success",
+        },
       }),
       treatMissingData: TreatMissingData.BREACHING,
       comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,

--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -254,9 +254,7 @@ object IAMClient extends LazyLogging {
             logger.info(
               s"Attempt to disable access keys was successful. ${updateAccessKeyResults.length} key(s) were disabled in ${account.name}."
             )
-            if (updateAccessKeyResults.nonEmpty) {
-              Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success, updateAccessKeyResults.length)
-            }
+            Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success, updateAccessKeyResults.length)
           }
         )
       )

--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -10,6 +10,8 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.iam.IamAsyncClient
 import software.amazon.awssdk.services.iam.model.*
 import utils.attempt.{Attempt, FailedAttempt, Failure}
+import logging.Cloudwatch
+import logging.Cloudwatch.ReaperExecutionStatus
 
 import scala.concurrent.duration.*
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,7 +19,7 @@ import scala.jdk.CollectionConverters.*
 
 object IAMClient extends LazyLogging {
 
-  val SOLE_REGION = Region.of("us-east-1")
+  val SOLE_REGION: Region = Region.of("us-east-1")
 
   /*
    * Note: the report is actually generated a maximum of once every 4 hours.
@@ -86,7 +88,7 @@ object IAMClient extends LazyLogging {
     }
   }
 
-  def getCredentialReportDisplay(
+  private def getCredentialReportDisplay(
       account: AwsAccount,
       currentData: Either[FailedAttempt, CredentialReportDisplay],
       iamClients: AwsClients[IamAsyncClient]
@@ -191,10 +193,23 @@ object IAMClient extends LazyLogging {
       .accessKeyId(accessKeyId)
       .status("Inactive")
       .build()
-    for {
+    (for {
       client <- iamClients.get(awsAccount)
       result <- handleAWSErrs(client)(asScala(client.client.updateAccessKey(request)))
-    } yield result
+    } yield result).tap(
+      _.fold(
+        { failure =>
+          logger.error(s"Failed to disable outdated access key: ${failure.logMessage}")
+          Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.failure)
+        },
+        { _ =>
+          logger.info(
+            s"Attempt to disable outdated access key $accessKeyId for IAM user $username was successful in account ${awsAccount.name}."
+          )
+          Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.success)
+        }
+      )
+    )
   }
 
   private def handleDeleteLoginProfileErrs(awsClient: AwsClient[IamAsyncClient], username: String)(
@@ -217,4 +232,69 @@ object IAMClient extends LazyLogging {
       result <- handleDeleteLoginProfileErrs(client, username)(asScala(client.client.deleteLoginProfile(request)))
     } yield result
   }
+
+  def disableAccountAccessKeys(
+      accountUnrecognisedKeys: AccountUnrecognisedAccessKeys,
+      iamClients: AwsClients[IamAsyncClient],
+      dryRun: Boolean
+  )(implicit ec: ExecutionContext): Attempt[List[UpdateAccessKeyResponse]] = {
+    if (!dryRun) {
+      val AccountUnrecognisedAccessKeys(account, accessKeys) = accountUnrecognisedKeys
+      val activeAccessKeys = accessKeys.filter(_.status == CredentialActive)
+      val disableKeysAttempt =
+        Attempt.traverse(activeAccessKeys)(key => disableAccessKey(account, key.username, key.accessKeyId, iamClients))
+
+      disableKeysAttempt.tap(
+        _.fold(
+          { failure =>
+            logger.error(s"Failed to disable access key: ${failure.logMessage}")
+            Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
+          },
+          { updateAccessKeyResults =>
+            logger.info(
+              s"Attempt to disable access keys was successful. ${updateAccessKeyResults.length} key(s) were disabled in ${account.name}."
+            )
+            if (updateAccessKeyResults.nonEmpty) {
+              Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success)
+            }
+          }
+        )
+      )
+    } else {
+      if (accountUnrecognisedKeys.vulnerableAccessKey.nonEmpty) {
+        logger.info(
+          s"DRY RUN: Would disable access keys in account '${accountUnrecognisedKeys.account.name}' for IAM users: ${accountUnrecognisedKeys.vulnerableAccessKey.map(_.username).mkString("'", "', '", "'")}."
+        )
+      }
+      Attempt.Right(Nil)
+    }
+  }
+
+  def removeAccountPasswords(
+      accountUnrecognisedUsers: AccountUnrecognisedUsers,
+      iamClients: AwsClients[IamAsyncClient],
+      dryRun: Boolean
+  )(implicit ec: ExecutionContext): Attempt[List[Option[DeleteLoginProfileResponse]]] = {
+    if (!dryRun) {
+      val results = Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
+        deleteLoginProfile(accountUnrecognisedUsers.account, user.username, iamClients)
+      )
+      results.tap {
+        case Left(failure) =>
+          logger.error(s"failed to delete at least one password: ${failure.logMessage}")
+          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
+        case Right(success) =>
+          logger.info(
+            s"passwords deleted for ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString(",")}"
+          )
+          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, success.flatten.length)
+      }
+    } else {
+      logger.info(
+        s"DRY RUN: Would delete passwords in account '${accountUnrecognisedUsers.account.name}' for IAM users: ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString("'", "', '", "'")}."
+      )
+      Attempt.Right(Nil)
+    }
+  }
+
 }

--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -255,7 +255,7 @@ object IAMClient extends LazyLogging {
               s"Attempt to disable access keys was successful. ${updateAccessKeyResults.length} key(s) were disabled in ${account.name}."
             )
             if (updateAccessKeyResults.nonEmpty) {
-              Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success)
+              Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success, updateAccessKeyResults.length)
             }
           }
         )

--- a/core/src/main/scala/logging/Cloudwatch.scala
+++ b/core/src/main/scala/logging/Cloudwatch.scala
@@ -12,21 +12,28 @@ import scala.util.{Failure, Success, Try}
 
 object Cloudwatch extends LazyLogging {
 
-  val cloudwatchClient = CloudWatchClient.builder.build()
+  private val cloudwatchClient = CloudWatchClient.builder.build()
 
-  val defaultNamespace = "SecurityHQ"
+  private val defaultNamespace = "SecurityHQ"
 
   object DataType extends Enumeration {
-    val s3Total = Value("s3/total")
-    val iamCredentialsTotal = Value("iam/credentials/total")
-    val iamCredentialsCritical = Value("iam/credentials/critical")
-    val iamCredentialsWarning = Value("iam/credentials/warning")
-    val iamKeysTotal = Value("iam/keys/total")
+    val s3Total: Value = Value("s3/total")
+    val iamCredentialsTotal: Value = Value("iam/credentials/total")
+    val iamCredentialsCritical: Value = Value("iam/credentials/critical")
+    val iamCredentialsWarning: Value = Value("iam/credentials/warning")
+    val iamKeysTotal: Value = Value("iam/keys/total")
+  }
+
+  private object MetricName extends Enumeration {
+    val iamDisableOutdatedKeys = "IamDisableOutdatedKeys"
+    val iamDisableAccessKey = "IamDisableAccessKey"
+    val iamRemovePassword = "IamRemovePassword"
+    val vulnerabilities = "Vulnerabilities"
   }
 
   object ReaperExecutionStatus extends Enumeration {
-    val success = Value("Success")
-    val failure = Value("Failure")
+    val success: Value = Value("Success")
+    val failure: Value = Value("Failure")
   }
 
   def logMetricsForCredentialsReport(data: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]): Unit = {
@@ -47,15 +54,15 @@ object Cloudwatch extends LazyLogging {
         putAwsMetric(account, dataType, details.length)
       case (account: AwsAccount, Left(_)) =>
         logger.error(
-          s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}."
+          s"Attempt to log cloudwatch metric failed. Data of type $dataType is missing for account ${account.name}."
         )
     }
   }
 
-  def putAwsMetric(account: AwsAccount, dataType: DataType.Value, value: Int): Unit = {
+  private def putAwsMetric(account: AwsAccount, dataType: DataType.Value, value: Int): Unit = {
     putMetric(
       defaultNamespace,
-      "Vulnerabilities",
+      MetricName.vulnerabilities,
       Seq(("Account", account.name), ("DataType", dataType.toString)),
       value
     )
@@ -64,7 +71,7 @@ object Cloudwatch extends LazyLogging {
   def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int): Unit = {
     putMetric(
       defaultNamespace,
-      "IamRemovePassword",
+      MetricName.iamRemovePassword,
       Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)),
       value
     )
@@ -73,7 +80,16 @@ object Cloudwatch extends LazyLogging {
   def putIamDisableAccessKeyMetric(reaperExecutionStatus: ReaperExecutionStatus.Value): Unit = {
     putMetric(
       defaultNamespace,
-      "IamDisableAccessKey",
+      MetricName.iamDisableAccessKey,
+      Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)),
+      1
+    )
+  }
+
+  def putIamDisableOutdatedKeysMetric(reaperExecutionStatus: ReaperExecutionStatus.Value): Unit = {
+    putMetric(
+      defaultNamespace,
+      MetricName.iamDisableOutdatedKeys,
       Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)),
       1
     )

--- a/core/src/main/scala/logic/IamUnrecognisedUsers.scala
+++ b/core/src/main/scala/logic/IamUnrecognisedUsers.scala
@@ -1,12 +1,10 @@
 package logic
 
 import aws.AwsClients
-import aws.iam.IAMClient.{deleteLoginProfile, disableAccessKey, listUserAccessKeys}
+import aws.iam.IAMClient.listUserAccessKeys
 import com.gu.anghammarad.models.Notification
 import com.gu.janus.model.JanusData
 import com.typesafe.scalalogging.LazyLogging
-import logging.Cloudwatch
-import logging.Cloudwatch.ReaperExecutionStatus
 import model.*
 import notifications.AnghammaradNotifications.unrecognisedUserRemediation
 import utils.attempt.{Attempt, FailedAttempt}
@@ -16,7 +14,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import scala.concurrent.ExecutionContext
 import software.amazon.awssdk.services.iam.IamAsyncClient
-import software.amazon.awssdk.services.iam.model.{DeleteLoginProfileResponse, UpdateAccessKeyResponse}
 
 object IamUnrecognisedUsers extends LazyLogging {
   val USERNAME_TAG_KEY = "GoogleUsername"
@@ -96,70 +93,6 @@ object IamUnrecognisedUsers extends LazyLogging {
     val AccountUnrecognisedUsers(account, users) = accountUnrecognisedUsers
     Attempt.flatTraverse(users)(listUserAccessKeys(account, _, iamClients)).map {
       AccountUnrecognisedAccessKeys(account, _)
-    }
-  }
-
-  def disableAccountAccessKeys(
-      accountUnrecognisedKeys: AccountUnrecognisedAccessKeys,
-      iamClients: AwsClients[IamAsyncClient],
-      dryRun: Boolean
-  )(implicit ec: ExecutionContext): Attempt[List[UpdateAccessKeyResponse]] = {
-    if (!dryRun) {
-      val AccountUnrecognisedAccessKeys(account, accessKeys) = accountUnrecognisedKeys
-      val activeAccessKeys = accessKeys.filter(_.status == CredentialActive)
-      val disableKeysAttempt =
-        Attempt.traverse(activeAccessKeys)(key => disableAccessKey(account, key.username, key.accessKeyId, iamClients))
-
-      disableKeysAttempt.tap(
-        _.fold(
-          { failure =>
-            logger.error(s"Failed to disable access key: ${failure.logMessage}")
-            Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
-          },
-          { updateAccessKeyResults =>
-            logger.info(
-              s"Attempt to disable access keys was successful. ${updateAccessKeyResults.length} key(s) were disabled in ${account.name}."
-            )
-            if (updateAccessKeyResults.nonEmpty) {
-              Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success)
-            }
-          }
-        )
-      )
-    } else {
-      if (accountUnrecognisedKeys.vulnerableAccessKey.nonEmpty) {
-        logger.info(
-          s"DRY RUN: Would disable access keys in account '${accountUnrecognisedKeys.account.name}' for IAM users: ${accountUnrecognisedKeys.vulnerableAccessKey.map(_.username).mkString("'", "', '", "'")}."
-        )
-      }
-      Attempt.Right(Nil)
-    }
-  }
-
-  def removeAccountPasswords(
-      accountUnrecognisedUsers: AccountUnrecognisedUsers,
-      iamClients: AwsClients[IamAsyncClient],
-      dryRun: Boolean
-  )(implicit ec: ExecutionContext): Attempt[List[Option[DeleteLoginProfileResponse]]] = {
-    if (!dryRun) {
-      val results = Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
-        deleteLoginProfile(accountUnrecognisedUsers.account, user.username, iamClients)
-      )
-      results.tap {
-        case Left(failure) =>
-          logger.error(s"failed to delete at least one password: ${failure.logMessage}")
-          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
-        case Right(success) =>
-          logger.info(
-            s"passwords deleted for ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString(",")}"
-          )
-          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, success.flatten.length)
-      }
-    } else {
-      logger.info(
-        s"DRY RUN: Would delete passwords in account '${accountUnrecognisedUsers.account.name}' for IAM users: ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString("'", "', '", "'")}."
-      )
-      Attempt.Right(Nil)
     }
   }
 

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -72,7 +72,7 @@ class AppComponents(context: Context)
     s"Polling in the following regions: ${availableRegions.map(_.id).mkString(", ")}"
   )
 
-  val regionsNotInSdk: Set[String] = availableRegions
+  private val regionsNotInSdk: Set[String] = availableRegions
     .map(_.id)
     .toSet -- Region.regions.asScala.map(_.id).toSet
   if (regionsNotInSdk.nonEmpty) {

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -122,7 +122,6 @@ class IamOutdatedCredentials(
         securityNotificationIdMaybe <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe)
 
         // only now do we actually disable the credential
-        _ = Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.success, 0)
         _ <- IAMClient.disableAccessKey(
           awsAccount,
           credentialToDisable.username,
@@ -238,6 +237,8 @@ class IamOutdatedCredentials(
       _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(logOperationOnly)
 
       // now we know what operations need to be performed, so let's run each of those
+      // First record a zero so that we know we ran, even if there ends up being nothing to do.
+      _ = Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.success, 0)
       results <- Attempt.traverse(filteredOperations.allowedOperations)(
         performRemediationOperation(_, now)
       )

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -77,7 +77,7 @@ class IamOutdatedCredentials(
       iamUser: IAMUser,
       problemCreationDate: DateTime,
       thisRemediationActivity: IamRemediationActivity
-  )(implicit ec: ExecutionContext) = {
+  )(implicit ec: ExecutionContext): Attempt[List[String]] = {
     if (dryRun) {
       logger.info(s"Dry run: Would execute remediation for $awsAccount, $iamUser")
       Attempt.Right(Nil)

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -1,7 +1,7 @@
 package unrecognised
 
 import aws.AWS
-import aws.iam.IAMClient
+import aws.iam.IAMClient.{disableAccountAccessKeys, removeAccountPasswords, getAllCredentialReports}
 import aws.s3.S3.getS3Object
 import com.gu.janus.JanusConfig
 import com.typesafe.config.ConfigFactory
@@ -50,7 +50,7 @@ object UnrecognisedUsers extends LazyLogging {
     }
   }
 
-  def disableUnrecognisedUsers(
+  private def disableUnrecognisedUsers(
       settings: Settings
   )(using ExecutionContext): Attempt[List[String]] = {
     val s3Client = S3Client.builder
@@ -78,16 +78,15 @@ object UnrecognisedUsers extends LazyLogging {
       janusData = JanusConfig.load(makeFile(janusSource.mkString))
       janusUsernames = getJanusUsernames(janusData)
       // generate a fresh IAM credential report for every configured account, logging the per-account outcome
-      credentialReports <- IAMClient
-        .getAllCredentialReports(awsAccounts, startingData, iamClients)
+      credentialReports <- getAllCredentialReports(awsAccounts, startingData, iamClients)
         .map(_.tap(logCredentialReportResults))
       accountCredsReports = getCredsReportDisplayForAccount(credentialReports.toMap)
       // determine the unrecognised users by comparing Janus usernames to the IAM users (filtered to allowed accounts)
       unrecognisedUsers = unrecognisedUsersForAllowedAccounts(accountCredsReports, janusUsernames, allowedAccountIds)
       accessKeys <- Attempt.traverse(unrecognisedUsers)(listAccountAccessKeys(_, iamClients))
       // deactivate access keys and remove login profiles for unrecognised users (skipped in dry run)
-      _ <- Attempt.traverse(accessKeys)(disableAccountAccessKeys(_, iamClients, settings.dryRun)).map(_ => ())
-      _ <- Attempt.traverse(unrecognisedUsers)(removeAccountPasswords(_, iamClients, settings.dryRun)).map(_ => ())
+      _ <- Attempt.traverse(accessKeys)(disableAccountAccessKeys(_, iamClients, settings.dryRun))
+      _ <- Attempt.traverse(unrecognisedUsers)(removeAccountPasswords(_, iamClients, settings.dryRun))
       // construct and send a notification for each unrecognised user
       notifications = unrecognisedUserNotifications(unrecognisedUsers, settings.dryRun)
       // if in dry run, notifications list is empty


### PR DESCRIPTION
## What does this change?

Metrics are reorganised so that they are emitted in the lambdas.

We emit the first three metrics from the Lambdas, while the app still emits `vulnerabilities`.  Each of the three is emitted in both Success and Failure forms: the count successfully remediated and the count where remediation failed.

In addition, the lambdas already have an alert for failure of the process as a whole.

```
  private object MetricName extends Enumeration {
    val iamDisableOutdatedKeys = "IamDisableOutdatedKeys"
    val iamDisableAccessKey = "IamDisableAccessKey"
    val iamRemovePassword = "IamRemovePassword"
    val vulnerabilities = "Vulnerabilities"
  }
```

Each of the three lambda metrics is now alerted on (1) >0 remediation failure and (2) extended absence.

Future task: We need to consider what the consumer of the `vulnerabilities` metrics will be.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

We need clarity on lambda failure.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
