### PR TITLE
Reorganise metrics

### DIFF
--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -103,7 +103,7 @@ object IAMClient extends LazyLogging {
       account: AwsAccount,
       iamClients: AwsClients[IamAsyncClient],
       delay: FiniteDuration = 3.seconds
-  )(implicit executionContext: ExecutionContext): Attempt[CredentialReportDisplay] = {
+  )(using ExecutionContext): Attempt[CredentialReportDisplay] = {
     for {
       client <- iamClients.get(account)
       _ <- Retry.until(
@@ -218,11 +218,12 @@ object IAMClient extends LazyLogging {
     for {
       client <- iamClients.get(awsAccount)
       result <- handleDeleteLoginProfileErrs(client, username)(asScala(client.client.deleteLoginProfile(request)))
-      message = if (result.isDefined) {
-        s"Deleted login profile for IAM user $username in account ${awsAccount.name}."
-      } else {
-        s"No login profile found for IAM user $username in account ${awsAccount.name}; nothing to delete."
-      }
+      message =
+        if (result.isDefined) {
+          s"Deleted login profile for IAM user $username in account ${awsAccount.name}."
+        } else {
+          s"No login profile found for IAM user $username in account ${awsAccount.name}; nothing to delete."
+        }
       _ = logger.info(message)
     } yield result
   }

--- a/core/src/main/scala/aws/iam/IAMClient.scala
+++ b/core/src/main/scala/aws/iam/IAMClient.scala
@@ -17,7 +17,7 @@ import scala.jdk.CollectionConverters.*
 
 object IAMClient extends LazyLogging {
 
-  val SOLE_REGION = Region.of("us-east-1")
+  val SOLE_REGION: Region = Region.of("us-east-1")
 
   /*
    * Note: the report is actually generated a maximum of once every 4 hours.
@@ -86,7 +86,7 @@ object IAMClient extends LazyLogging {
     }
   }
 
-  def getCredentialReportDisplay(
+  private def getCredentialReportDisplay(
       account: AwsAccount,
       currentData: Either[FailedAttempt, CredentialReportDisplay],
       iamClients: AwsClients[IamAsyncClient]
@@ -194,6 +194,9 @@ object IAMClient extends LazyLogging {
     for {
       client <- iamClients.get(awsAccount)
       result <- handleAWSErrs(client)(asScala(client.client.updateAccessKey(request)))
+      _ = logger.info(
+        s"Disabled access key $accessKeyId for IAM user $username in account ${awsAccount.name}."
+      )
     } yield result
   }
 
@@ -215,6 +218,13 @@ object IAMClient extends LazyLogging {
     for {
       client <- iamClients.get(awsAccount)
       result <- handleDeleteLoginProfileErrs(client, username)(asScala(client.client.deleteLoginProfile(request)))
+      message = if (result.isDefined) {
+        s"Deleted login profile for IAM user $username in account ${awsAccount.name}."
+      } else {
+        s"No login profile found for IAM user $username in account ${awsAccount.name}; nothing to delete."
+      }
+      _ = logger.info(message)
     } yield result
   }
+
 }

--- a/core/src/main/scala/logging/Cloudwatch.scala
+++ b/core/src/main/scala/logging/Cloudwatch.scala
@@ -12,21 +12,28 @@ import scala.util.{Failure, Success, Try}
 
 object Cloudwatch extends LazyLogging {
 
-  val cloudwatchClient = CloudWatchClient.builder.build()
+  private val cloudwatchClient = CloudWatchClient.builder.build()
 
-  val defaultNamespace = "SecurityHQ"
+  private val defaultNamespace = "SecurityHQ"
 
   object DataType extends Enumeration {
-    val s3Total = Value("s3/total")
-    val iamCredentialsTotal = Value("iam/credentials/total")
-    val iamCredentialsCritical = Value("iam/credentials/critical")
-    val iamCredentialsWarning = Value("iam/credentials/warning")
-    val iamKeysTotal = Value("iam/keys/total")
+    val s3Total: Value = Value("s3/total")
+    val iamCredentialsTotal: Value = Value("iam/credentials/total")
+    val iamCredentialsCritical: Value = Value("iam/credentials/critical")
+    val iamCredentialsWarning: Value = Value("iam/credentials/warning")
+    val iamKeysTotal: Value = Value("iam/keys/total")
+  }
+
+  private object MetricName extends Enumeration {
+    val iamDisableOutdatedKeys: Value = Value("IamDisableOutdatedKeys")
+    val iamDisableAccessKey: Value = Value("IamDisableAccessKey")
+    val iamRemovePassword: Value = Value("IamRemovePassword")
+    val vulnerabilities: Value = Value("Vulnerabilities")
   }
 
   object ReaperExecutionStatus extends Enumeration {
-    val success = Value("Success")
-    val failure = Value("Failure")
+    val success: Value = Value("Success")
+    val failure: Value = Value("Failure")
   }
 
   def logMetricsForCredentialsReport(data: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]): Unit = {
@@ -47,15 +54,15 @@ object Cloudwatch extends LazyLogging {
         putAwsMetric(account, dataType, details.length)
       case (account: AwsAccount, Left(_)) =>
         logger.error(
-          s"Attempt to log cloudwatch metric failed. Data of type ${dataType} is missing for account ${account.name}."
+          s"Attempt to log cloudwatch metric failed. Data of type $dataType is missing for account ${account.name}."
         )
     }
   }
 
-  def putAwsMetric(account: AwsAccount, dataType: DataType.Value, value: Int): Unit = {
+  private def putAwsMetric(account: AwsAccount, dataType: DataType.Value, value: Int): Unit = {
     putMetric(
       defaultNamespace,
-      "Vulnerabilities",
+      MetricName.vulnerabilities,
       Seq(("Account", account.name), ("DataType", dataType.toString)),
       value
     )
@@ -64,30 +71,39 @@ object Cloudwatch extends LazyLogging {
   def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int): Unit = {
     putMetric(
       defaultNamespace,
-      "IamRemovePassword",
+      MetricName.iamRemovePassword,
       Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)),
       value
     )
   }
 
-  def putIamDisableAccessKeyMetric(reaperExecutionStatus: ReaperExecutionStatus.Value): Unit = {
+  def putIamDisableAccessKeyMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1): Unit = {
     putMetric(
       defaultNamespace,
-      "IamDisableAccessKey",
+      MetricName.iamDisableAccessKey,
       Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)),
-      1
+      value
+    )
+  }
+
+  def putIamDisableOutdatedKeysMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1): Unit = {
+    putMetric(
+      defaultNamespace,
+      MetricName.iamDisableOutdatedKeys,
+      Seq(("ReaperExecutionStatus", reaperExecutionStatus.toString)),
+      value
     )
   }
 
   private def putMetric(
       namespace: String,
-      metricName: String,
+      metricName: MetricName.Value,
       metricDimensions: Seq[(String, String)],
       value: Int
   ): Unit = {
     val dimension = metricDimensions.map(d => Dimension.builder.name(d._1).value(d._2).build()).toList
     val datum = MetricDatum.builder
-      .metricName(metricName)
+      .metricName(metricName.toString)
       .unit(StandardUnit.COUNT)
       .value(value.toDouble)
       .dimensions(dimension.asJava)

--- a/core/src/main/scala/logging/Cloudwatch.scala
+++ b/core/src/main/scala/logging/Cloudwatch.scala
@@ -3,8 +3,9 @@ package logging
 import com.typesafe.scalalogging.LazyLogging
 import logic.CredentialsReportDisplay.reportStatusSummary
 import model.{AwsAccount, CredentialReportDisplay}
-import software.amazon.awssdk.services.cloudwatch.model.*
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import software.amazon.awssdk.services.cloudwatch.model.*
+import software.amazon.awssdk.regions.Region
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -13,7 +14,7 @@ import scala.jdk.FutureConverters.*
 
 object Cloudwatch extends LazyLogging {
 
-  private val cloudwatchClient = CloudWatchAsyncClient.builder.build()
+  private val cloudwatchClient = CloudWatchAsyncClient.builder.region(Region.EU_WEST_1).build()
 
   private val defaultNamespace = "SecurityHQ"
 
@@ -175,4 +176,44 @@ object Cloudwatch extends LazyLogging {
       ).attempt
     }
   }
+
+  /** Emits a metric to CloudWatch based on the outcome of an Attempt.
+    *
+    * If the Attempt is successful, it will execute the onSuccess block and return the resulting attempt.
+    *
+    * If the Attempt fails, it will execute the onFailure block and return the resulting Attempt if it fails, or the
+    * original failure if the onFailure block succeeds.
+    *
+    *
+    * @param result
+    *   Any attempt
+    * @param onSuccess
+    *   The action to perform if the result is successful, typically emitting a success metric.
+    * @param onFailure
+    *   The action to perform if the result is a failure, typically emitting a failure metric.
+    * @param actionLabel
+    *   A label describing the action being performed, used for logging purposes.
+    * @return
+    *   An Attempt that represents the outcome of the original result and the metric emission.
+    */
+  def emitOutcomeMetric[T](
+      result: Attempt[T],
+      onSuccess: => Attempt[Unit],
+      onFailure: => Attempt[Unit],
+      actionLabel: String
+  )(using ExecutionContext): Attempt[Unit] =
+    Attempt
+      .fromFuture(
+        result.underlying.flatMap {
+          case Left(failure) =>
+            logger.error(s"$actionLabel failed: ${failure.logMessage}")
+            onFailure.flatMap(_ => Attempt.Left(failure)).asFuture
+          case Right(_) =>
+            onSuccess.asFuture
+        }
+      )(e => {
+        logger.error(s"Failed to emit $actionLabel metric: ${e.getMessage}", e)
+        FailedAttempt(List(Failure(e.getMessage, e.getMessage, 500)))
+      })
+      .map(_ => ())
 }

--- a/core/src/main/scala/logging/Cloudwatch.scala
+++ b/core/src/main/scala/logging/Cloudwatch.scala
@@ -1,22 +1,23 @@
 package logging
 
 import com.typesafe.scalalogging.LazyLogging
-import logic.CredentialsReportDisplay.{ReportSummary, reportStatusSummary}
+import logic.CredentialsReportDisplay.reportStatusSummary
 import model.{AwsAccount, CredentialReportDisplay}
-import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
-import software.amazon.awssdk.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
-import utils.attempt.FailedAttempt
+import software.amazon.awssdk.services.cloudwatch.model.*
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient
+import utils.attempt.{Attempt, FailedAttempt, Failure}
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.*
-import scala.util.{Failure, Success, Try}
+import scala.jdk.FutureConverters.*
 
 object Cloudwatch extends LazyLogging {
 
-  private val cloudwatchClient = CloudWatchClient.builder.build()
+  private val cloudwatchClient = CloudWatchAsyncClient.builder.build()
 
   private val defaultNamespace = "SecurityHQ"
 
-  object DataType extends Enumeration {
+  private object DataType extends Enumeration {
     val s3Total: Value = Value("s3/total")
     val iamCredentialsTotal: Value = Value("iam/credentials/total")
     val iamCredentialsCritical: Value = Value("iam/credentials/critical")
@@ -36,30 +37,76 @@ object Cloudwatch extends LazyLogging {
     val failure: Value = Value("Failure")
   }
 
-  def logMetricsForCredentialsReport(data: Map[AwsAccount, Either[FailedAttempt, CredentialReportDisplay]]): Unit = {
-    data.toSeq.foreach {
-      case (account: AwsAccount, Right(details: CredentialReportDisplay)) =>
-        val reportSummary: ReportSummary = reportStatusSummary(details)
-        putAwsMetric(account, DataType.iamCredentialsCritical, reportSummary.errors)
-        putAwsMetric(account, DataType.iamCredentialsWarning, reportSummary.warnings)
+  def logMetricsForCredentialsReport(
+      data: Map[AwsAccount, CredentialReportDisplay]
+  )(using ExecutionContext): Attempt[Unit] = {
+    val metricAttempts = data.flatMap { (account, data) =>
+      val reportSummary = reportStatusSummary(data)
+      List(
+        putAwsMetric(account, DataType.iamCredentialsCritical, reportSummary.errors),
+        putAwsMetric(account, DataType.iamCredentialsWarning, reportSummary.warnings),
         putAwsMetric(account, DataType.iamCredentialsTotal, reportSummary.errors + reportSummary.warnings)
-      case (account: AwsAccount, Left(_)) =>
-        logger.error(s"Attempt to log cloudwatch metric failed. IAM data is missing for account ${account.name}.")
+      )
     }
-  }
-
-  def logAsMetric[T](data: Map[AwsAccount, Either[FailedAttempt, List[T]]], dataType: DataType.Value): Unit = {
-    data.toSeq.foreach {
-      case (account: AwsAccount, Right(details: List[T])) =>
-        putAwsMetric(account, dataType, details.length)
-      case (account: AwsAccount, Left(_)) =>
-        logger.error(
-          s"Attempt to log cloudwatch metric failed. Data of type $dataType is missing for account ${account.name}."
+    Attempt
+      .traverse(metricAttempts.toList) { _ =>
+        Attempt.Left(
+          FailedAttempt(
+            List(
+              Failure(
+                message = s"Failed to log cloudwatch metric for credentials report.",
+                friendlyMessage = "Failed to log cloudwatch metric",
+                statusCode = 500,
+                context = None,
+                throwable = None
+              )
+            )
+          )
         )
-    }
+      }
+      .map(_ => ())
   }
 
-  private def putAwsMetric(account: AwsAccount, dataType: DataType.Value, value: Int): Unit = {
+  def logExposedKeysMetric[T](
+      data: Map[AwsAccount, List[T]]
+  )(using ExecutionContext): Attempt[Unit] = {
+    logAsMetric(data = data, dataType = DataType.iamKeysTotal)
+  }
+
+  def logS3TotalMetric[T](
+      data: Map[AwsAccount, List[T]]
+  )(using ExecutionContext): Attempt[Unit] = {
+    logAsMetric(data = data, dataType = DataType.s3Total)
+  }
+
+  private def logAsMetric[T](data: Map[AwsAccount, List[T]], dataType: DataType.Value)(implicit
+      executionContext: ExecutionContext
+  ): Attempt[Unit] = {
+    val metricsAttempts = data.map { case (account, details) =>
+      putAwsMetric(account, dataType, details.length)
+    }
+    Attempt
+      .traverse(metricsAttempts.toList) { _ =>
+        Attempt.Left(
+          FailedAttempt(
+            List(
+              Failure(
+                message = s"Failed to log cloudwatch metric for data of type $dataType.",
+                friendlyMessage = "Failed to log cloudwatch metric",
+                statusCode = 500,
+                context = None,
+                throwable = None
+              )
+            )
+          )
+        )
+      }
+      .map(_ => ())
+  }
+
+  private def putAwsMetric(account: AwsAccount, dataType: DataType.Value, value: Int)(implicit
+      executionContext: ExecutionContext
+  ): Attempt[Unit] = {
     putMetric(
       defaultNamespace,
       MetricName.vulnerabilities,
@@ -68,7 +115,9 @@ object Cloudwatch extends LazyLogging {
     )
   }
 
-  def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int): Unit = {
+  def putIamRemovePasswordMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int)(implicit
+      executionContext: ExecutionContext
+  ): Attempt[Unit] = {
     putMetric(
       defaultNamespace,
       MetricName.iamRemovePassword,
@@ -77,7 +126,9 @@ object Cloudwatch extends LazyLogging {
     )
   }
 
-  def putIamDisableAccessKeyMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1): Unit = {
+  def putIamDisableAccessKeyMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1)(implicit
+      executionContext: ExecutionContext
+  ): Attempt[Unit] = {
     putMetric(
       defaultNamespace,
       MetricName.iamDisableAccessKey,
@@ -86,7 +137,9 @@ object Cloudwatch extends LazyLogging {
     )
   }
 
-  def putIamDisableOutdatedKeysMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1): Unit = {
+  def putIamDisableOutdatedKeysMetric(reaperExecutionStatus: ReaperExecutionStatus.Value, value: Int = 1)(implicit
+      executionContext: ExecutionContext
+  ): Attempt[Unit] = {
     putMetric(
       defaultNamespace,
       MetricName.iamDisableOutdatedKeys,
@@ -100,7 +153,7 @@ object Cloudwatch extends LazyLogging {
       metricName: MetricName.Value,
       metricDimensions: Seq[(String, String)],
       value: Int
-  ): Unit = {
+  )(implicit ec: ExecutionContext): Attempt[Unit] = {
     val dimension = metricDimensions.map(d => Dimension.builder.name(d._1).value(d._2).build()).toList
     val datum = MetricDatum.builder
       .metricName(metricName.toString)
@@ -110,9 +163,16 @@ object Cloudwatch extends LazyLogging {
       .build()
     val request = PutMetricDataRequest.builder.namespace(namespace).metricData(datum).build()
 
-    Try(cloudwatchClient.putMetricData(request)) match {
-      case Success(_) => logger.debug(s"putMetric success: $datum")
-      case Failure(e) => logger.error(s"putMetric failure: $datum", e)
+    val future: Future[Unit] = cloudwatchClient.putMetricData(request).asScala.map(_ => ())
+
+    Attempt.fromFuture(future) { case exception =>
+      Failure(
+        message = s"Failed to put metric data to CloudWatch: ${exception.getMessage}",
+        friendlyMessage = "Failed to put metric data to CloudWatch",
+        statusCode = 500,
+        context = None,
+        throwable = Some(exception)
+      ).attempt
     }
   }
 }

--- a/core/src/main/scala/logic/IamUnrecognisedUsers.scala
+++ b/core/src/main/scala/logic/IamUnrecognisedUsers.scala
@@ -1,12 +1,10 @@
 package logic
 
 import aws.AwsClients
-import aws.iam.IAMClient.{deleteLoginProfile, disableAccessKey, listUserAccessKeys}
+import aws.iam.IAMClient.listUserAccessKeys
 import com.gu.anghammarad.models.Notification
 import com.gu.janus.model.JanusData
 import com.typesafe.scalalogging.LazyLogging
-import logging.Cloudwatch
-import logging.Cloudwatch.ReaperExecutionStatus
 import model.*
 import notifications.AnghammaradNotifications.unrecognisedUserRemediation
 import utils.attempt.{Attempt, FailedAttempt}
@@ -16,7 +14,6 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import scala.concurrent.ExecutionContext
 import software.amazon.awssdk.services.iam.IamAsyncClient
-import software.amazon.awssdk.services.iam.model.{DeleteLoginProfileResponse, UpdateAccessKeyResponse}
 
 object IamUnrecognisedUsers extends LazyLogging {
   val USERNAME_TAG_KEY = "GoogleUsername"
@@ -96,70 +93,6 @@ object IamUnrecognisedUsers extends LazyLogging {
     val AccountUnrecognisedUsers(account, users) = accountUnrecognisedUsers
     Attempt.flatTraverse(users)(listUserAccessKeys(account, _, iamClients)).map {
       AccountUnrecognisedAccessKeys(account, _)
-    }
-  }
-
-  def disableAccountAccessKeys(
-      accountUnrecognisedKeys: AccountUnrecognisedAccessKeys,
-      iamClients: AwsClients[IamAsyncClient],
-      dryRun: Boolean
-  )(implicit ec: ExecutionContext): Attempt[List[UpdateAccessKeyResponse]] = {
-    if (!dryRun) {
-      val AccountUnrecognisedAccessKeys(account, accessKeys) = accountUnrecognisedKeys
-      val activeAccessKeys = accessKeys.filter(_.status == CredentialActive)
-      val disableKeysAttempt =
-        Attempt.traverse(activeAccessKeys)(key => disableAccessKey(account, key.username, key.accessKeyId, iamClients))
-
-      disableKeysAttempt.tap(
-        _.fold(
-          { failure =>
-            logger.error(s"Failed to disable access key: ${failure.logMessage}")
-            Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
-          },
-          { updateAccessKeyResults =>
-            logger.info(
-              s"Attempt to disable access keys was successful. ${updateAccessKeyResults.length} key(s) were disabled in ${account.name}."
-            )
-            if (updateAccessKeyResults.nonEmpty) {
-              Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success)
-            }
-          }
-        )
-      )
-    } else {
-      if (accountUnrecognisedKeys.vulnerableAccessKey.nonEmpty) {
-        logger.info(
-          s"DRY RUN: Would disable access keys in account '${accountUnrecognisedKeys.account.name}' for IAM users: ${accountUnrecognisedKeys.vulnerableAccessKey.map(_.username).mkString("'", "', '", "'")}."
-        )
-      }
-      Attempt.Right(Nil)
-    }
-  }
-
-  def removeAccountPasswords(
-      accountUnrecognisedUsers: AccountUnrecognisedUsers,
-      iamClients: AwsClients[IamAsyncClient],
-      dryRun: Boolean
-  )(implicit ec: ExecutionContext): Attempt[List[Option[DeleteLoginProfileResponse]]] = {
-    if (!dryRun) {
-      val results = Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
-        deleteLoginProfile(accountUnrecognisedUsers.account, user.username, iamClients)
-      )
-      results.tap {
-        case Left(failure) =>
-          logger.error(s"failed to delete at least one password: ${failure.logMessage}")
-          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
-        case Right(success) =>
-          logger.info(
-            s"passwords deleted for ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString(",")}"
-          )
-          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, success.flatten.length)
-      }
-    } else {
-      logger.info(
-        s"DRY RUN: Would delete passwords in account '${accountUnrecognisedUsers.account.name}' for IAM users: ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString("'", "', '", "'")}."
-      )
-      Attempt.Right(Nil)
     }
   }
 

--- a/core/src/main/scala/notifications/AnghammaradNotifications.scala
+++ b/core/src/main/scala/notifications/AnghammaradNotifications.scala
@@ -18,7 +18,7 @@ object AnghammaradNotifications extends LazyLogging {
       notification: Notification,
       topicArn: String,
       snsClient: SnsAsyncClient
-  )(implicit executionContext: ExecutionContext): Attempt[String] = {
+  )(using ExecutionContext): Attempt[String] = {
     Attempt
       .fromFuture(Anghammarad.notify(notification, topicArn, snsClient)) { case NonFatal(e) =>
         Failure(

--- a/hq/app/AppComponents.scala
+++ b/hq/app/AppComponents.scala
@@ -72,7 +72,7 @@ class AppComponents(context: Context)
     s"Polling in the following regions: ${availableRegions.map(_.id).mkString(", ")}"
   )
 
-  val regionsNotInSdk: Set[String] = availableRegions
+  private val regionsNotInSdk: Set[String] = availableRegions
     .map(_.id)
     .toSet -- Region.regions.asScala.map(_.id).toSet
   if (regionsNotInSdk.nonEmpty) {

--- a/hq/app/services/MetricService.scala
+++ b/hq/app/services/MetricService.scala
@@ -7,6 +7,7 @@ import play.api.inject.ApplicationLifecycle
 import utils.Scheduler
 import utils.attempt.FailedAttempt
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.*
 
 class MetricService(
@@ -40,24 +41,38 @@ class MetricService(
    * - https://github.com/guardian/security-hq/pull/211
    * - https://github.com/guardian/security-hq/pull/245#discussion_r632548991
    */
-  def postCachedContentsAsMetrics(): Unit = {
+  def postCachedContentsAsMetrics()(using ExecutionContext): Unit = {
     val allExposedKeys = cacheService.getAllExposedKeys
     val allPublicBuckets = cacheService.getAllPublicBuckets
     val allCredentials = cacheService.getAllCredentials
 
-    val failures = collectFailures(
-      List(allExposedKeys, allPublicBuckets, allCredentials)
-    )
+    val (allExposedKeysFailures, allExposedKeysSuccesses) =
+      allExposedKeys.toSeq.partitionMap {
+        case (account, Right(value)) => Right((account, value))
+        case (_, Left(err))          => Left(err)
+      }
 
-    if (failures.nonEmpty) {
+    val (allPublicBucketsFailures, allPublicBucketsSuccesses) =
+      allPublicBuckets.toSeq.partitionMap {
+        case (account, Right(value)) => Right((account, value))
+        case (_, Left(err))          => Left(err)
+      }
+
+    val (allCredentialsFailures, allCredentialsSuccesses) =
+      allCredentials.toSeq.partitionMap {
+        case (account, Right(value)) => Right((account, value))
+        case (_, Left(err))          => Left(err)
+      }
+
+    if (allExposedKeysFailures.nonEmpty || allPublicBucketsFailures.nonEmpty || allCredentialsFailures.nonEmpty) {
       logger.warn(
-        s"Skipping cloudwatch metrics update as some data is missing from the cache: $failures"
+        s"Skipping cloudwatch metrics update as some data is missing from the cache: $allExposedKeysFailures, $allPublicBucketsFailures, $allCredentialsFailures"
       )
     } else {
       logger.info("Posting new metrics to cloudwatch")
-      Cloudwatch.logAsMetric(allExposedKeys, Cloudwatch.DataType.iamKeysTotal)
-      Cloudwatch.logAsMetric(allPublicBuckets, Cloudwatch.DataType.s3Total)
-      Cloudwatch.logMetricsForCredentialsReport(allCredentials)
+      Cloudwatch.logExposedKeysMetric(allExposedKeysSuccesses.toMap)
+      Cloudwatch.logS3TotalMetric(allPublicBucketsSuccesses.toMap)
+      Cloudwatch.logMetricsForCredentialsReport(allCredentialsSuccesses.toMap)
     }
   }
 
@@ -71,6 +86,7 @@ class MetricService(
         initialDelay = initialDelay,
         interval = 6.hours
       ) { () =>
+        implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
         postCachedContentsAsMetrics()
       }
 

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -6,6 +6,8 @@ import com.gu.anghammarad.models.Notification
 import com.typesafe.scalalogging.LazyLogging
 import config.CoreConfig
 import db.IamRemediationDb
+import logging.Cloudwatch
+import logging.Cloudwatch.ReaperExecutionStatus
 import logic.IamOutdatedCredentials.*
 import logic.IamUnrecognisedUsers.*
 import model.*
@@ -101,11 +103,9 @@ class IamOutdatedCredentials(
       } yield notificationIds
     } else {
 
-      for {
-        // plan the disable action for the correct credential
+      (for {
         userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
         credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
-
         notification =
           AnghammaradNotifications.outdatedCredentialRemediation(
             awsAccount,
@@ -113,6 +113,8 @@ class IamOutdatedCredentials(
             problemCreationDate,
             credentialToDisable
           )
+
+        // plan the disable action for the correct credential
         notificationDevXSecurityMaybe = devXSecurityAccountMaybe.map(devXSecurityAccount =>
           AnghammaradNotifications.outdatedCredentialRemediationDevXSecurity(
             awsAccount,
@@ -130,16 +132,26 @@ class IamOutdatedCredentials(
         userNotificationId <- AnghammaradNotifications.send(notification, notificationTopicArn, snsClient)
         // Send a notification to devx too, if we've got an account for them.
         securityNotificationIdMaybe <- sendSecurityNotification(notificationTopicArn, notificationDevXSecurityMaybe)
-
         // only now do we actually disable the credential
-        _ <- IAMClient.disableAccessKey(
-          awsAccount,
-          credentialToDisable.username,
-          credentialToDisable.accessKeyId,
-          iamClients
-        )
-      } yield List(userNotificationId) ++ securityNotificationIdMaybe
+        _ <- IAMClient
+          .disableAccessKey(
+            awsAccount,
+            credentialToDisable.username,
+            credentialToDisable.accessKeyId,
+            iamClients
+          )
+      } yield List(userNotificationId) ++ securityNotificationIdMaybe).tap(emitMetricsTap)
     }
+  }
+
+  private[logic] def emitMetricsTap[T](result: Either[FailedAttempt, T]): Unit = {
+    result.fold(
+      { (failure: FailedAttempt) =>
+        logger.error(s"Failed to disable outdated access key: ${failure.logMessage}")
+        Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.failure)
+      },
+      { (_: T) => Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.success) }
+    )
   }
 
   private def finalWarn(
@@ -262,6 +274,8 @@ class IamOutdatedCredentials(
       // we won't execute these operations, but can log them instead
       _ = filteredOperations.operationsOnAccountsThatAreNotAllowed.foreach(logOperationOnly)
 
+      // First record a zero so that we know we ran, even if there ends up being nothing to do.
+      _ = Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.success, 0)
       // now we know what operations need to be performed, so let's run each of those
       results <- Attempt.traverseWithFailures(filteredOperations.allowedOperations)(
         performRemediationOperation(_, now)
@@ -281,7 +295,7 @@ class IamOutdatedCredentials(
         logger.info(
           s"Completed 'disable outdated credentials job', with ${successfulOperations.length} successful operations and ${failedOperations.length} failed operations"
         )
-        failedOperations.zipWithIndex.foreach { case ((failedAttempt), i) =>
+        failedOperations.zipWithIndex.foreach { case (failedAttempt, i) =>
           // TODO emit metrics counting the number of operations which failed and create alarm
           logger.error(
             s"Failed operation $i of ${failedOperations.length}: ${failedAttempt.logMessage}",
@@ -593,6 +607,6 @@ object IamOutdatedCredentials extends LazyLogging {
   private val ALLOWED_ACCOUNT_IDS_CONFIG_ITEM = "ALLOWED_ACCOUNT_IDS"
   private val ANGHAMMARAD_SNS_TOPIC_ARN_CONFIG_ITEM = "ANGHAMMARAD_SNS_TOPIC_ARN"
   private val IAM_DYNAMO_TABLE_NAME_CONFIG_ITEM = "IAM_DYNAMO_TABLE_NAME"
-  val SECURITY_ACCOUNT_ID = "security"
+  private val SECURITY_ACCOUNT_ID = "security"
 
 }

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -103,7 +103,7 @@ class IamOutdatedCredentials(
       } yield notificationIds
     } else {
 
-      val x = for {
+      val listOfNotificationsAttempt = for {
         userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
         credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
         notification =
@@ -140,23 +140,24 @@ class IamOutdatedCredentials(
             credentialToDisable.accessKeyId,
             iamClients
           )
-      } yield List(userNotificationId) ++ securityNotificationIdMaybe
-      emitDisableOutdatedCredentialMetrics(x)
-      x
+        notifications = List(userNotificationId) ++ securityNotificationIdMaybe
+      } yield notifications
+      Cloudwatch
+        .emitOutcomeMetric(
+          listOfNotificationsAttempt,
+          successMetric,
+          failureMetric,
+          "disable outdated credential"
+        )
+        .flatMap(_ => listOfNotificationsAttempt)
     }
   }
 
-  private[logic] def emitDisableOutdatedCredentialMetrics[T](
-      result: Attempt[T]
-  )(using ExecutionContext): Unit = {
-    result.fold(
-      { (failure: FailedAttempt) =>
-        logger.error(s"Failed to disable outdated access key: ${failure.logMessage}")
-        Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.failure)
-      },
-      { (_: T) => Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.success) }
-    )
-  }
+  private[logic] def failureMetric(using executionContext: ExecutionContext) =
+    Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.failure)
+
+  private[logic] def successMetric(using executionContext: ExecutionContext) =
+    Cloudwatch.putIamDisableOutdatedKeysMetric(ReaperExecutionStatus.success)
 
   private def finalWarn(
       now: DateTime,

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -103,7 +103,7 @@ class IamOutdatedCredentials(
       } yield notificationIds
     } else {
 
-      (for {
+      val x = for {
         userCredentialInformation <- IAMClient.listUserAccessKeys(awsAccount, iamUser, iamClients)
         credentialToDisable <- lookupCredentialId(problemCreationDate, userCredentialInformation)
         notification =
@@ -140,11 +140,15 @@ class IamOutdatedCredentials(
             credentialToDisable.accessKeyId,
             iamClients
           )
-      } yield List(userNotificationId) ++ securityNotificationIdMaybe).tap(emitMetricsTap)
+      } yield List(userNotificationId) ++ securityNotificationIdMaybe
+      emitDisableOutdatedCredentialMetrics(x)
+      x
     }
   }
 
-  private[logic] def emitMetricsTap[T](result: Either[FailedAttempt, T]): Unit = {
+  private[logic] def emitDisableOutdatedCredentialMetrics[T](
+      result: Attempt[T]
+  )(using ExecutionContext): Unit = {
     result.fold(
       { (failure: FailedAttempt) =>
         logger.error(s"Failed to disable outdated access key: ${failure.logMessage}")
@@ -218,7 +222,7 @@ class IamOutdatedCredentials(
   private def sendSecurityNotification(
       notificationTopicArn: String,
       notificationDevXSecurityMaybe: Option[Notification]
-  )(implicit executionContext: ExecutionContext): Attempt[Option[String]] = {
+  )(using ExecutionContext): Attempt[Option[String]] = {
     notificationDevXSecurityMaybe match {
       case Some(notificationDevXSecurity) =>
         logger.info("Sending notification to devx security account")
@@ -314,7 +318,7 @@ object IamOutdatedCredentials extends LazyLogging {
   // sequentially, and the SnsAsyncClient is used in the middle of the process.  We could use a Resource pattern
   // to manage this better.
 
-  def disableOutdatedCredentials(settings: Settings)(implicit executionContext: ExecutionContext): Attempt[Unit] = {
+  def disableOutdatedCredentials(settings: Settings)(using ExecutionContext): Attempt[Unit] = {
     val snsClient = SnsAsyncClient.builder().build()
     val s3Client = S3Client.builder.build()
 

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -15,15 +15,15 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.iam.IamAsyncClient
 import software.amazon.awssdk.services.iam.model.{
-  StatusType,
   AccessKeyMetadata,
-  UpdateAccessKeyResponse,
+  ListAccessKeysRequest,
   ListAccessKeysResponse,
-  ListAccessKeysRequest
+  StatusType,
+  UpdateAccessKeyResponse
 }
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import software.amazon.awssdk.services.sns.model.{PublishRequest, PublishResponse}
-import utils.attempt.{Attempt, AttemptValues, FailedAttempt}
+import utils.attempt.{Attempt, AttemptValues}
 
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
@@ -817,13 +817,14 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
         notificationTopicArn = fakeTopicArn,
         tableName = fakeRemediationTableName
       ) {
-        override private[logic] def emitDisableOutdatedCredentialMetrics[T](result: Attempt[T])(implicit
-            executionContext: ExecutionContext
-        ): Unit = {
-          result.fold(
-            (_: FailedAttempt) => failureMetricCounter.incrementAndGet(),
-            (_: T) => successMetricCounter.incrementAndGet()
-          )
+        override private[logic] def failureMetric(using executionContext: ExecutionContext) = {
+          failureMetricCounter.incrementAndGet()
+          Attempt.Right(())
+        }
+
+        override private[logic] def successMetric(using executionContext: ExecutionContext) = {
+          successMetricCounter.incrementAndGet()
+          Attempt.Right(())
         }
       }
       (successMetricCounter, failureMetricCounter, iamOutdatedCredentials)

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -6,6 +6,7 @@ import config.CoreConfig.{daysBetweenFinalNotificationAndRemediation, daysBetwee
 import db.IamRemediationDb
 import logic.IamOutdatedCredentials.*
 import model.*
+import model.AccessKey
 import org.joda.time.DateTime
 import org.scalatest.Inside.inside
 import org.scalatest.OptionValues
@@ -18,16 +19,16 @@ import software.amazon.awssdk.services.iam.model.{
   ListAccessKeysRequest,
   ListAccessKeysResponse,
   StatusType,
-  UpdateAccessKeyRequest,
   UpdateAccessKeyResponse
 }
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import software.amazon.awssdk.services.sns.model.{PublishRequest, PublishResponse}
-import utils.attempt.{Attempt, AttemptValues}
+import utils.attempt.{Attempt, AttemptValues, FailedAttempt}
 
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionValues with AttemptValues {
@@ -762,30 +763,34 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
       override def close(): Unit = ()
     }
 
-    def getFakeRemediationIamClient(remediationCounter: AtomicInteger): IamAsyncClient = new IamAsyncClient {
-      override def listAccessKeys(request: ListAccessKeysRequest): CompletableFuture[ListAccessKeysResponse] = {
-        val accessKeyMetadata = AccessKeyMetadata
-          .builder()
-          .userName(request.userName())
-          .accessKeyId("TEST_KEY")
-          .status(StatusType.ACTIVE)
-          .createDate(Instant.ofEpochMilli(machineAccessKeyOldAndEnabled.lastRotated.get.getMillis))
-          .build()
-        CompletableFuture.completedFuture(
-          ListAccessKeysResponse.builder().accessKeyMetadata(accessKeyMetadata).build()
-        )
+    def getFakeRemediationIamClient: (AtomicInteger, IamAsyncClient) = {
+      val remediationCounter: AtomicInteger = new AtomicInteger(0)
+      val iamAsyncClient = new IamAsyncClient {
+        override def listAccessKeys(request: ListAccessKeysRequest): CompletableFuture[ListAccessKeysResponse] = {
+          val accessKeyMetadata = AccessKeyMetadata
+            .builder()
+            .userName(request.userName())
+            .accessKeyId("TEST_KEY")
+            .status(StatusType.ACTIVE)
+            .createDate(Instant.ofEpochMilli(machineAccessKeyOldAndEnabled.lastRotated.get.getMillis))
+            .build()
+          CompletableFuture.completedFuture(
+            ListAccessKeysResponse.builder().accessKeyMetadata(accessKeyMetadata).build()
+          )
+        }
+
+        override def updateAccessKey(
+            request: software.amazon.awssdk.services.iam.model.UpdateAccessKeyRequest
+        ): CompletableFuture[UpdateAccessKeyResponse] = {
+          remediationCounter.incrementAndGet()
+          CompletableFuture.completedFuture(UpdateAccessKeyResponse.builder().build())
+        }
+
+        override def serviceName(): String = "iam"
+
+        override def close(): Unit = ()
       }
-
-      override def updateAccessKey(
-          request: software.amazon.awssdk.services.iam.model.UpdateAccessKeyRequest
-      ): CompletableFuture[UpdateAccessKeyResponse] = {
-        remediationCounter.incrementAndGet()
-        CompletableFuture.completedFuture(UpdateAccessKeyResponse.builder().build())
-      }
-
-      override def serviceName(): String = "iam"
-
-      override def close(): Unit = ()
+      (remediationCounter, iamAsyncClient)
     }
 
     val fakeRemediationDb = new IamRemediationDb(null) {
@@ -799,17 +804,28 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     def getIamOutdatedCredentials(
         dryRun: Boolean,
         devXSecurityAccountMaybe: Option[AwsAccount],
-        iamAsyncClient: IamAsyncClient
-    ) =
-      new IamOutdatedCredentials(
+        iamAsyncClient: Option[IamAsyncClient]
+    ): (AtomicInteger, AtomicInteger, IamOutdatedCredentials) = {
+      val successMetricCounter: AtomicInteger = new AtomicInteger(0)
+      val failureMetricCounter: AtomicInteger = new AtomicInteger(0)
+      val iamOutdatedCredentials = new IamOutdatedCredentials(
         snsClient = getFakeRemediationSnsClient,
-        iamClients = List(AwsClient(iamAsyncClient, account, Region.of("us-east-1"))),
+        iamClients = iamAsyncClient.map(c => AwsClient(c, account, Region.of("us-east-1"))).toList,
         dynamo = fakeRemediationDb,
         devXSecurityAccountMaybe = devXSecurityAccountMaybe,
         dryRun = dryRun,
         notificationTopicArn = fakeTopicArn,
         tableName = fakeRemediationTableName
-      )
+      ) {
+        override private[logic] def emitMetricsTap[T](result: Either[FailedAttempt, T]): Unit = {
+          result.fold(
+            (_: FailedAttempt) => failureMetricCounter.incrementAndGet(),
+            (_: T) => successMetricCounter.incrementAndGet()
+          )
+        }
+      }
+      (successMetricCounter, failureMetricCounter, iamOutdatedCredentials)
+    }
 
     val securityAccount = AwsAccount("security", "Security", "role", "999999999999")
     def getOperation(IamRemediationActivityType: IamRemediationActivityType) = RemediationOperation(
@@ -822,121 +838,165 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
     "in dry run mode" - {
       val dryRun = true
       "should return no notifications for warning" in {
-        val remediationCounter = new AtomicInteger(0)
-        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+        val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+        val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) = getIamOutdatedCredentials(
+          dryRun,
+          Some(securityAccount),
+          Some(iamAsyncClient)
+        )
         val result =
-          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
+          iamOutdatedCredentials.performRemediationOperation(
             getOperation(Warning),
             today
           )
         result.value() shouldEqual Nil
         remediationCounter.get() shouldBe 0
+        failureMetricCounter.get() shouldBe 0
+        successMetricCounter.get() shouldBe 0
       }
 
       "should return no notifications for final warning" in {
-        val remediationCounter = new AtomicInteger(0)
-        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
-        val result =
-          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
-            getOperation(FinalWarning),
-            today
-          )
+        val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+        val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) = getIamOutdatedCredentials(
+          dryRun,
+          Some(securityAccount),
+          Some(iamAsyncClient)
+        )
+        val result = iamOutdatedCredentials.performRemediationOperation(getOperation(FinalWarning), today)
         result.value() shouldEqual Nil
         remediationCounter.get() shouldBe 0
+        failureMetricCounter.get() shouldBe 0
+        successMetricCounter.get() shouldBe 0
       }
 
       "should return no notifications for remediation" in {
-        val remediationCounter = new AtomicInteger(0)
-        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
-        val result =
-          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
-            getOperation(Remediation),
-            today
-          )
+        val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+        val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) = getIamOutdatedCredentials(
+          dryRun,
+          Some(securityAccount),
+          Some(iamAsyncClient)
+        )
+        val result = iamOutdatedCredentials.performRemediationOperation(getOperation(Remediation), today)
         result.value() shouldEqual Nil
         remediationCounter.get() shouldBe 0
+        failureMetricCounter.get() shouldBe 0
+        successMetricCounter.get() shouldBe 0
       }
     }
 
     "not in dry run mode" - {
       val dryRun = false
       "should return one notification for warning" in {
-        val remediationCounter = new AtomicInteger(0)
-        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
+        val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+        val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) = getIamOutdatedCredentials(
+          dryRun,
+          Some(securityAccount),
+          Some(iamAsyncClient)
+        )
         val result =
-          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
-            getOperation(Warning),
-            today
-          )
+          iamOutdatedCredentials.performRemediationOperation(getOperation(Warning), today)
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
         remediationCounter.get() shouldBe 0
+        failureMetricCounter.get() shouldBe 0
+        successMetricCounter.get() shouldBe 0
       }
 
       "should return one notification for final warning" in {
-        val remediationCounter = new AtomicInteger(0)
-        val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
-        val result =
-          getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
-            getOperation(FinalWarning),
-            today
-          )
+        val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+        val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) = getIamOutdatedCredentials(
+          dryRun,
+          Some(securityAccount),
+          Some(iamAsyncClient)
+        )
+        val result = iamOutdatedCredentials.performRemediationOperation(getOperation(FinalWarning), today)
         result.value().length shouldBe 1
         result.value().head shouldBe "sns-1"
         remediationCounter.get() shouldBe 0
+        failureMetricCounter.get() shouldBe 0
+        successMetricCounter.get() shouldBe 0
       }
 
       "remediation on Remediation Tuesdays" - {
         "should return one notification when security account is not present" in {
-          val remediationCounter = new AtomicInteger(0)
-          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
-          val result = getIamOutdatedCredentials(dryRun, None, iamAsyncClient).performRemediationOperation(
-            getOperation(Remediation),
-            tuesday
-          )
+          val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+          val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) =
+            getIamOutdatedCredentials(dryRun, None, Some(iamAsyncClient))
+          val result = iamOutdatedCredentials.performRemediationOperation(getOperation(Remediation), tuesday)
           result.value().length shouldBe 1
           result.value().head shouldBe "sns-1"
           remediationCounter.get() shouldBe 1
+          failureMetricCounter.get() shouldBe 0
+          successMetricCounter.get() shouldBe 1
         }
 
         "should return two notifications when security account is present" in {
-          val remediationCounter = new AtomicInteger(0)
-          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
-          val result =
-            getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
-              getOperation(Remediation),
-              tuesday
+          val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+          val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) =
+            getIamOutdatedCredentials(
+              dryRun,
+              Some(securityAccount),
+              Some(iamAsyncClient)
             )
+          val result = iamOutdatedCredentials.performRemediationOperation(
+            getOperation(Remediation),
+            tuesday
+          )
           result.value().length shouldBe 2
           result.value().head shouldBe "sns-1"
           result.value().tail.head shouldBe "sns-2"
           remediationCounter.get() shouldBe 1
+          failureMetricCounter.get() shouldBe 0
+          successMetricCounter.get() shouldBe 1
+        }
+      }
+
+      "missing client for remediation on Remediation Tuesdays" - {
+        "should emit a failure metric" in {
+          val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) =
+            getIamOutdatedCredentials(dryRun, None, None)
+
+          import scala.concurrent.duration.DurationInt
+          Await.result(
+            iamOutdatedCredentials
+              .performRemediationOperation(
+                getOperation(Remediation),
+                tuesday
+              )
+              .asFuture,
+            4.seconds
+          )
+          failureMetricCounter.get() shouldBe 1
+          successMetricCounter.get() shouldBe 0
         }
       }
 
       "remediation on other days" - {
         "should return no notifications when security account is not present" in {
-          val remediationCounter = new AtomicInteger(0)
-          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
-          val result = getIamOutdatedCredentials(dryRun, None, iamAsyncClient).performRemediationOperation(
-            getOperation(Remediation),
-            notTuesday
-          )
+          val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+          val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) =
+            getIamOutdatedCredentials(dryRun, None, Some(iamAsyncClient))
+          val result = iamOutdatedCredentials.performRemediationOperation(getOperation(Remediation), notTuesday)
           result.value().length shouldBe 0
           remediationCounter.get() shouldBe 0
+          failureMetricCounter.get() shouldBe 0
+          successMetricCounter.get() shouldBe 0
         }
 
         "should return one notification when security account is present" in {
-          val remediationCounter = new AtomicInteger(0)
-          val iamAsyncClient = getFakeRemediationIamClient(remediationCounter)
-          val result =
-            getIamOutdatedCredentials(dryRun, Some(securityAccount), iamAsyncClient).performRemediationOperation(
-              getOperation(Remediation),
-              notTuesday
+          val (remediationCounter, iamAsyncClient) = getFakeRemediationIamClient
+          val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) =
+            getIamOutdatedCredentials(
+              dryRun,
+              Some(securityAccount),
+              Some(iamAsyncClient)
             )
+          val result = iamOutdatedCredentials.performRemediationOperation(getOperation(Remediation), notTuesday)
           result.value().length shouldBe 1
           result.value().head shouldBe "sns-1"
           remediationCounter.get() shouldBe 0
+          failureMetricCounter.get() shouldBe 0
+          successMetricCounter.get() shouldBe 0
         }
       }
     }

--- a/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
+++ b/iam-outdated-credentials/src/test/scala/logic/IamOutdatedCredentialsTest.scala
@@ -6,20 +6,20 @@ import config.CoreConfig.{daysBetweenFinalNotificationAndRemediation, daysBetwee
 import db.IamRemediationDb
 import logic.IamOutdatedCredentials.*
 import model.*
-import model.AccessKey
 import org.joda.time.DateTime
 import org.scalatest.Inside.inside
 import org.scalatest.OptionValues
+import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.iam.IamAsyncClient
 import software.amazon.awssdk.services.iam.model.{
-  AccessKeyMetadata,
-  ListAccessKeysRequest,
-  ListAccessKeysResponse,
   StatusType,
-  UpdateAccessKeyResponse
+  AccessKeyMetadata,
+  UpdateAccessKeyResponse,
+  ListAccessKeysResponse,
+  ListAccessKeysRequest
 }
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import software.amazon.awssdk.services.sns.model.{PublishRequest, PublishResponse}
@@ -28,8 +28,8 @@ import utils.attempt.{Attempt, AttemptValues, FailedAttempt}
 import java.time.Instant
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
 class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionValues with AttemptValues {
   val date = new DateTime(2021, 1, 1, 1, 1)
@@ -817,7 +817,9 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
         notificationTopicArn = fakeTopicArn,
         tableName = fakeRemediationTableName
       ) {
-        override private[logic] def emitMetricsTap[T](result: Either[FailedAttempt, T]): Unit = {
+        override private[logic] def emitDisableOutdatedCredentialMetrics[T](result: Attempt[T])(implicit
+            executionContext: ExecutionContext
+        ): Unit = {
           result.fold(
             (_: FailedAttempt) => failureMetricCounter.incrementAndGet(),
             (_: T) => successMetricCounter.incrementAndGet()
@@ -956,16 +958,16 @@ class IamOutdatedCredentialsTest extends AnyFreeSpec with Matchers with OptionVa
           val (successMetricCounter, failureMetricCounter, iamOutdatedCredentials) =
             getIamOutdatedCredentials(dryRun, None, None)
 
-          import scala.concurrent.duration.DurationInt
-          Await.result(
+          try {
             iamOutdatedCredentials
               .performRemediationOperation(
                 getOperation(Remediation),
                 tuesday
               )
-              .asFuture,
-            4.seconds
-          )
+              .value()
+          } catch {
+            case _: TestFailedException =>
+          }
           failureMetricCounter.get() shouldBe 1
           successMetricCounter.get() shouldBe 0
         }

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -14,7 +14,6 @@ import logic.IamUnrecognisedUsers.*
 import model.*
 import notifications.AnghammaradNotifications
 import software.amazon.awssdk.services.iam.IamAsyncClient
-import software.amazon.awssdk.services.iam.model.{DeleteLoginProfileResponse, UpdateAccessKeyResponse}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import utils.attempt.{Attempt, FailedAttempt, Failure}
@@ -93,13 +92,13 @@ object UnrecognisedUsers extends LazyLogging {
       // First emit a zero metric in case there's no keys to disable
       _ = Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success, 0)
       _ <- Attempt.traverse(accessKeys)(disableAccountAccessKeys(_, iamClients, settings.dryRun))
-      // First emit a zero metric in case there's no passwords to remove
-      _ = Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 0)
       _ <- Attempt.traverse(unrecognisedUsers)(removeAccountPasswords(_, iamClients, settings.dryRun))
       // construct and send a notification for each unrecognised user
       notifications = unrecognisedUserNotifications(unrecognisedUsers, settings.dryRun)
       // if in dry run, notifications list is empty
       notificationIds <- Attempt.traverse(notifications)(AnghammaradNotifications.send(_, anghammaradSnsArn, snsClient))
+      // Finally emit a zero metric in case there were no passwords to remove
+      _ <- Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 0)
     } yield notificationIds
   }
 
@@ -107,60 +106,64 @@ object UnrecognisedUsers extends LazyLogging {
       accountUnrecognisedUsers: AccountUnrecognisedUsers,
       iamClients: AwsClients[IamAsyncClient],
       dryRun: Boolean
-  )(implicit ec: ExecutionContext): Attempt[List[Option[DeleteLoginProfileResponse]]] = {
+  )(implicit ec: ExecutionContext): Attempt[Unit] = {
     if (!dryRun) {
-      Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
-        IAMClient
-          .deleteLoginProfile(accountUnrecognisedUsers.account, user.username, iamClients)
-          .tap(emitRemovePasswordMetrics)
+      val result = Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
+        IAMClient.deleteLoginProfile(accountUnrecognisedUsers.account, user.username, iamClients)
       )
+      emitRemovePasswordMetrics(result)
     } else {
       logger.info(
         s"DRY RUN: Would delete passwords in account '${accountUnrecognisedUsers.account.name}' for IAM users: ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString("'", "', '", "'")}."
       )
-      Attempt.Right(Nil)
+      Attempt.Right(())
     }
   }
 
-  private def emitRemovePasswordMetrics[T](result: Either[FailedAttempt, T]): Unit = {
-    result.fold(
-      { (failure: FailedAttempt) =>
-        logger.error(s"failed to delete at least one password: ${failure.logMessage}")
-        Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
-      },
-      { (_: T) => Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 1) }
-    )
+  private def emitRemovePasswordMetrics[T](result: Attempt[T])(implicit ec: ExecutionContext): Attempt[Unit] = {
+    Attempt.Async.Right(
+      result.fold(
+        { failure =>
+          logger.error(s"failed to delete at least one password: ${failure.logMessage}")
+          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
+        },
+        { _ => Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 1) }
+      ).flatMap(_.asFuture)
+    ).unit
   }
 
   private[unrecognised] def disableAccountAccessKeys(
       accountUnrecognisedKeys: AccountUnrecognisedAccessKeys,
       iamClients: AwsClients[IamAsyncClient],
       dryRun: Boolean
-  )(implicit ec: ExecutionContext): Attempt[List[UpdateAccessKeyResponse]] = {
+  )(implicit ec: ExecutionContext): Attempt[Unit] = {
     if (!dryRun) {
       val AccountUnrecognisedAccessKeys(account, accessKeys) = accountUnrecognisedKeys
       val activeAccessKeys = accessKeys.filter(_.status == CredentialActive)
-      Attempt.traverse(activeAccessKeys)(key =>
-        IAMClient.disableAccessKey(account, key.username, key.accessKeyId, iamClients).tap(emitDisabledAccessKeyMetrics)
+      val result = Attempt.traverse(activeAccessKeys)(key =>
+        IAMClient.disableAccessKey(account, key.username, key.accessKeyId, iamClients)
       )
+      emitDisabledAccessKeyMetrics(result)
     } else {
       if (accountUnrecognisedKeys.vulnerableAccessKey.nonEmpty) {
         logger.info(
           s"DRY RUN: Would disable access keys in account '${accountUnrecognisedKeys.account.name}' for IAM users: ${accountUnrecognisedKeys.vulnerableAccessKey.map(_.username).mkString("'", "', '", "'")}."
         )
       }
-      Attempt.Right(Nil)
+      Attempt.Right(())
     }
   }
 
-  private def emitDisabledAccessKeyMetrics[T](result: Either[FailedAttempt, T]): Unit = {
-    result.fold(
-      { (failure: FailedAttempt) =>
-        logger.error(s"Failed to disable unrecognised user access key: ${failure.logMessage}")
-        Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
-      },
-      { (_: T) => Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success) }
-    )
+  private def emitDisabledAccessKeyMetrics[T](result: Attempt[T])(implicit ec: ExecutionContext): Attempt[Unit] = {
+    Attempt.Async.Right(
+      result.fold(
+        { failure =>
+          logger.error(s"Failed to disable unrecognised user access key: ${failure.logMessage}")
+          Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
+        },
+        { _ => Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success) }
+      ).flatMap(_.asFuture)
+    ).unit
   }
 
   private def logCredentialReportResults(

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -1,15 +1,20 @@
 package unrecognised
 
-import aws.AWS
 import aws.iam.IAMClient
+import aws.iam.IAMClient.getAllCredentialReports
 import aws.s3.S3.getS3Object
+import aws.{AWS, AwsClients}
 import com.gu.janus.JanusConfig
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import config.CoreConfig
+import logging.Cloudwatch
+import logging.Cloudwatch.ReaperExecutionStatus
 import logic.IamUnrecognisedUsers.*
-import model.{AwsAccount, CredentialReportDisplay}
+import model.*
 import notifications.AnghammaradNotifications
+import software.amazon.awssdk.services.iam.IamAsyncClient
+import software.amazon.awssdk.services.iam.model.{DeleteLoginProfileResponse, UpdateAccessKeyResponse}
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import utils.attempt.{Attempt, FailedAttempt, Failure}
@@ -50,7 +55,7 @@ object UnrecognisedUsers extends LazyLogging {
     }
   }
 
-  def disableUnrecognisedUsers(
+  private[unrecognised] def disableUnrecognisedUsers(
       settings: Settings
   )(using ExecutionContext): Attempt[List[String]] = {
     val s3Client = S3Client.builder
@@ -78,21 +83,84 @@ object UnrecognisedUsers extends LazyLogging {
       janusData = JanusConfig.load(makeFile(janusSource.mkString))
       janusUsernames = getJanusUsernames(janusData)
       // generate a fresh IAM credential report for every configured account, logging the per-account outcome
-      credentialReports <- IAMClient
-        .getAllCredentialReports(awsAccounts, startingData, iamClients)
+      credentialReports <- getAllCredentialReports(awsAccounts, startingData, iamClients)
         .map(_.tap(logCredentialReportResults))
       accountCredsReports = getCredsReportDisplayForAccount(credentialReports.toMap)
       // determine the unrecognised users by comparing Janus usernames to the IAM users (filtered to allowed accounts)
       unrecognisedUsers = unrecognisedUsersForAllowedAccounts(accountCredsReports, janusUsernames, allowedAccountIds)
       accessKeys <- Attempt.traverse(unrecognisedUsers)(listAccountAccessKeys(_, iamClients))
       // deactivate access keys and remove login profiles for unrecognised users (skipped in dry run)
-      _ <- Attempt.traverse(accessKeys)(disableAccountAccessKeys(_, iamClients, settings.dryRun)).map(_ => ())
-      _ <- Attempt.traverse(unrecognisedUsers)(removeAccountPasswords(_, iamClients, settings.dryRun)).map(_ => ())
+      // First emit a zero metric in case there's no keys to disable
+      _ = Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success, 0)
+      _ <- Attempt.traverse(accessKeys)(disableAccountAccessKeys(_, iamClients, settings.dryRun))
+      // First emit a zero metric in case there's no passwords to remove
+      _ = Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 0)
+      _ <- Attempt.traverse(unrecognisedUsers)(removeAccountPasswords(_, iamClients, settings.dryRun))
       // construct and send a notification for each unrecognised user
       notifications = unrecognisedUserNotifications(unrecognisedUsers, settings.dryRun)
       // if in dry run, notifications list is empty
       notificationIds <- Attempt.traverse(notifications)(AnghammaradNotifications.send(_, anghammaradSnsArn, snsClient))
     } yield notificationIds
+  }
+
+  private def removeAccountPasswords(
+      accountUnrecognisedUsers: AccountUnrecognisedUsers,
+      iamClients: AwsClients[IamAsyncClient],
+      dryRun: Boolean
+  )(implicit ec: ExecutionContext): Attempt[List[Option[DeleteLoginProfileResponse]]] = {
+    if (!dryRun) {
+      Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
+        IAMClient
+          .deleteLoginProfile(accountUnrecognisedUsers.account, user.username, iamClients)
+          .tap(emitRemovePasswordMetrics)
+      )
+    } else {
+      logger.info(
+        s"DRY RUN: Would delete passwords in account '${accountUnrecognisedUsers.account.name}' for IAM users: ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString("'", "', '", "'")}."
+      )
+      Attempt.Right(Nil)
+    }
+  }
+
+  private def emitRemovePasswordMetrics[T](result: Either[FailedAttempt, T]): Unit = {
+    result.fold(
+      { (failure: FailedAttempt) =>
+        logger.error(s"failed to delete at least one password: ${failure.logMessage}")
+        Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
+      },
+      { (_: T) => Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 1) }
+    )
+  }
+
+  private[unrecognised] def disableAccountAccessKeys(
+      accountUnrecognisedKeys: AccountUnrecognisedAccessKeys,
+      iamClients: AwsClients[IamAsyncClient],
+      dryRun: Boolean
+  )(implicit ec: ExecutionContext): Attempt[List[UpdateAccessKeyResponse]] = {
+    if (!dryRun) {
+      val AccountUnrecognisedAccessKeys(account, accessKeys) = accountUnrecognisedKeys
+      val activeAccessKeys = accessKeys.filter(_.status == CredentialActive)
+      Attempt.traverse(activeAccessKeys)(key =>
+        IAMClient.disableAccessKey(account, key.username, key.accessKeyId, iamClients).tap(emitDisabledAccessKeyMetrics)
+      )
+    } else {
+      if (accountUnrecognisedKeys.vulnerableAccessKey.nonEmpty) {
+        logger.info(
+          s"DRY RUN: Would disable access keys in account '${accountUnrecognisedKeys.account.name}' for IAM users: ${accountUnrecognisedKeys.vulnerableAccessKey.map(_.username).mkString("'", "', '", "'")}."
+        )
+      }
+      Attempt.Right(Nil)
+    }
+  }
+
+  private def emitDisabledAccessKeyMetrics[T](result: Either[FailedAttempt, T]): Unit = {
+    result.fold(
+      { (failure: FailedAttempt) =>
+        logger.error(s"Failed to disable unrecognised user access key: ${failure.logMessage}")
+        Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
+      },
+      { (_: T) => Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success) }
+    )
   }
 
   private def logCredentialReportResults(

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -111,7 +111,12 @@ object UnrecognisedUsers extends LazyLogging {
       val result = Attempt.traverse(accountUnrecognisedUsers.unrecognisedUsers)(user =>
         IAMClient.deleteLoginProfile(accountUnrecognisedUsers.account, user.username, iamClients)
       )
-      emitRemovePasswordMetrics(result)
+      Cloudwatch.emitOutcomeMetric(
+        result,
+        successMetricRemovePassword,
+        failureMetricRemovePassword,
+        actionLabel = "unrecognised user password"
+      )
     } else {
       logger.info(
         s"DRY RUN: Would delete passwords in account '${accountUnrecognisedUsers.account.name}' for IAM users: ${accountUnrecognisedUsers.unrecognisedUsers.map(_.username).mkString("'", "', '", "'")}."
@@ -120,17 +125,11 @@ object UnrecognisedUsers extends LazyLogging {
     }
   }
 
-  private def emitRemovePasswordMetrics[T](result: Attempt[T])(implicit ec: ExecutionContext): Attempt[Unit] = {
-    Attempt.Async.Right(
-      result.fold(
-        { failure =>
-          logger.error(s"failed to delete at least one password: ${failure.logMessage}")
-          Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
-        },
-        { _ => Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 1) }
-      ).flatMap(_.asFuture)
-    ).unit
-  }
+  private def failureMetricRemovePassword[T](using ExecutionContext) =
+    Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.success, 1)
+
+  private def successMetricRemovePassword[T](using ExecutionContext) =
+    Cloudwatch.putIamRemovePasswordMetric(ReaperExecutionStatus.failure, 1)
 
   private[unrecognised] def disableAccountAccessKeys(
       accountUnrecognisedKeys: AccountUnrecognisedAccessKeys,
@@ -143,7 +142,12 @@ object UnrecognisedUsers extends LazyLogging {
       val result = Attempt.traverse(activeAccessKeys)(key =>
         IAMClient.disableAccessKey(account, key.username, key.accessKeyId, iamClients)
       )
-      emitDisabledAccessKeyMetrics(result)
+      Cloudwatch.emitOutcomeMetric(
+        result,
+        onSuccess = successMetricIamDisableAccessKey,
+        onFailure = failureMetricIamDisableAccessKey,
+        actionLabel = "unrecognised user access"
+      )
     } else {
       if (accountUnrecognisedKeys.vulnerableAccessKey.nonEmpty) {
         logger.info(
@@ -154,17 +158,11 @@ object UnrecognisedUsers extends LazyLogging {
     }
   }
 
-  private def emitDisabledAccessKeyMetrics[T](result: Attempt[T])(implicit ec: ExecutionContext): Attempt[Unit] = {
-    Attempt.Async.Right(
-      result.fold(
-        { failure =>
-          logger.error(s"Failed to disable unrecognised user access key: ${failure.logMessage}")
-          Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
-        },
-        { _ => Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success) }
-      ).flatMap(_.asFuture)
-    ).unit
-  }
+  private def successMetricIamDisableAccessKey[T](using ExecutionContext) =
+    Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.success)
+
+  private def failureMetricIamDisableAccessKey[T](using ExecutionContext) =
+    Cloudwatch.putIamDisableAccessKeyMetric(ReaperExecutionStatus.failure)
 
   private def logCredentialReportResults(
       credentialReports: Seq[(AwsAccount, Either[FailedAttempt, CredentialReportDisplay])]


### PR DESCRIPTION
## What does this change?

Metrics are reorganised so that they are emitted in the lambdas.

We emit the first three metrics from the Lambdas, while the app still emits `vulnerabilities`.  Each of the three is emitted in both Success and Failure forms: the count successfully remediated and the count where remediation failed.

```
  private object MetricName extends Enumeration {
    val iamDisableOutdatedKeys = "IamDisableOutdatedKeys"
    val iamDisableAccessKey = "IamDisableAccessKey"
    val iamRemovePassword = "IamRemovePassword"
    val vulnerabilities = "Vulnerabilities"
  }
```

In addition, the result of metrics is now included in the result instead of fire-and-forget in an unchecked Future (in an Attempt).  This is now included in the tests (where it couldn't be, before).

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
