### PR TITLE
Add better alerts

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -474,6 +474,12 @@ exports[`HQ stack matches the snapshot 1`] = `
         "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
         "AlarmName": "Security HQ failed to emit vulnerable access key metrics",
         "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Success",
+          },
+        ],
         "EvaluationPeriods": 1,
         "MetricName": "IamDisableAccessKey",
         "Namespace": "SecurityHQ",
@@ -588,6 +594,12 @@ exports[`HQ stack matches the snapshot 1`] = `
         "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
         "AlarmName": "Security HQ failed to emit outdated access key metrics",
         "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Success",
+          },
+        ],
         "EvaluationPeriods": 1,
         "MetricName": "IamDisableOutdatedKeys",
         "Namespace": "SecurityHQ",

--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -42,6 +42,10 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuParameter",
       "GuAlarm",
       "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
+      "GuAlarm",
       "GuDeveloperPolicyExperimental",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
@@ -441,6 +445,174 @@ exports[`HQ stack matches the snapshot 1`] = `
         ],
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DisableAccessKeyNotRunningAlarm94D518B3": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to emit vulnerable access key metrics",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "IamDisableAccessKey",
+        "Namespace": "SecurityHQ",
+        "Period": 259200,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DisableOutdatedKeysFailureAlarmEB74E827": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to disable an outdated access key (new stack)",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Failure",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "IamDisableOutdatedKeys",
+        "Namespace": "SecurityHQ",
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "DisableOutdatedKeysNotRunningAlarm496E6C34": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to emit outdated access key metrics",
+        "ComparisonOperator": "LessThanThreshold",
+        "EvaluationPeriods": 1,
+        "MetricName": "IamDisableOutdatedKeys",
+        "Namespace": "SecurityHQ",
+        "Period": 259200,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
@@ -1166,6 +1338,66 @@ exports[`HQ stack matches the snapshot 1`] = `
         ],
         "Threshold": 1,
         "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "RemovePasswordNotRunningAlarmB4DB66B6": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:eu-west-1:",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "NotificationTopicEB7A0DF1",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "AlarmName": "Security HQ failed to emit vulnerable password metrics",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "ReaperExecutionStatus",
+            "Value": "Success",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "IamRemovePassword",
+        "Namespace": "SecurityHQ",
+        "Period": 259200,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/security-hq",
+          },
+          {
+            "Key": "Stack",
+            "Value": "security",
+          },
+          {
+            "Key": "Stage",
+            "Value": "PROD",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "breaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
     },

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -346,6 +346,9 @@ export class SecurityHQ extends GuStack {
         namespace: "SecurityHQ",
         period: Duration.days(3), // we do not run sat/sun
         statistic: "sum",
+        dimensionsMap: {
+          ReaperExecutionStatus: "Success",
+        },
       }),
       treatMissingData: TreatMissingData.BREACHING,
       comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
@@ -388,6 +391,9 @@ export class SecurityHQ extends GuStack {
         namespace: "SecurityHQ",
         period: Duration.days(3), // we do not run sat/sun
         statistic: "sum",
+        dimensionsMap: {
+          ReaperExecutionStatus: "Success",
+        },
       }),
       treatMissingData: TreatMissingData.BREACHING,
       comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -269,7 +269,8 @@ export class SecurityHQ extends GuStack {
       alarmName:
         "Security HQ failed to remove a vulnerable password (new stack)",
       alarmDescription:
-        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
       snsTopicName: notificationTopic.topicName,
       threshold: 1,
       evaluationPeriods: 1,
@@ -286,12 +287,35 @@ export class SecurityHQ extends GuStack {
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
     });
 
+    new GuAlarm(this, "RemovePasswordNotRunningAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName: "Security HQ failed to emit vulnerable password metrics",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 0,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamRemovePassword",
+        namespace: "SecurityHQ",
+        period: Duration.days(3), // we do not run sat/sun
+        statistic: "sum",
+        dimensionsMap: {
+          ReaperExecutionStatus: "Success",
+        },
+      }),
+      treatMissingData: TreatMissingData.BREACHING,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+    });
+
     new GuAlarm(this, "DisableAccessKeyFailureAlarm", {
       app: SecurityHQ.app.app,
       alarmName:
         "Security HQ failed to disable a vulnerable access key (new stack)",
       alarmDescription:
-        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
       snsTopicName: notificationTopic.topicName,
       threshold: 1,
       evaluationPeriods: 1,
@@ -306,6 +330,67 @@ export class SecurityHQ extends GuStack {
       }),
       treatMissingData: TreatMissingData.NOT_BREACHING,
       comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    });
+
+    new GuAlarm(this, "DisableAccessKeyNotRunningAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName: "Security HQ failed to emit vulnerable access key metrics",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit." +
+        " Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 0,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamDisableAccessKey",
+        namespace: "SecurityHQ",
+        period: Duration.days(3), // we do not run sat/sun
+        statistic: "sum",
+      }),
+      treatMissingData: TreatMissingData.BREACHING,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
+    });
+
+    new GuAlarm(this, "DisableOutdatedKeysFailureAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName:
+        "Security HQ failed to disable an outdated access key (new stack)",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ logs either success or failure to cloudwatch, and this alarm lets us know when it logs a failure. " +
+        "Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 1,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamDisableOutdatedKeys",
+        namespace: "SecurityHQ",
+        period: Duration.seconds(60),
+        statistic: "sum",
+        dimensionsMap: {
+          ReaperExecutionStatus: "Failure",
+        },
+      }),
+      treatMissingData: TreatMissingData.NOT_BREACHING,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    });
+
+    new GuAlarm(this, "DisableOutdatedKeysNotRunningAlarm", {
+      app: SecurityHQ.app.app,
+      alarmName: "Security HQ failed to emit outdated access key metrics",
+      alarmDescription:
+        "The credentials reaper feature of Security HQ emits metrics showing how many actions it has taken, and this alarm lets us know when it does not emit." +
+        " Check the application logs for more details https://logs.gutools.co.uk/s/devx/goto/f9915a6e4e94a000732d67026cea91be.",
+      snsTopicName: notificationTopic.topicName,
+      threshold: 0,
+      evaluationPeriods: 1,
+      metric: new Metric({
+        metricName: "IamDisableOutdatedKeys",
+        namespace: "SecurityHQ",
+        period: Duration.days(3), // we do not run sat/sun
+        statistic: "sum",
+      }),
+      treatMissingData: TreatMissingData.BREACHING,
+      comparisonOperator: ComparisonOperator.LESS_THAN_THRESHOLD,
     });
 
     new GuDeveloperPolicyExperimental(this, "RunSecurityHqLocallyPolicy", {


### PR DESCRIPTION
## What does this change?

Each of the three lambda metrics is now alerted on (1) >0 remediation failure and (2) extended absence.

In addition, the lambdas already have an alert for failure of the process as a whole.

Future task: We need to consider what the consumer of the `vulnerabilities` metrics will be or remove them.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
