### PR TITLE
Remove dead code (again) and fix error message handling.

### DIFF
--- a/core/src/main/scala/aws/AWS.scala
+++ b/core/src/main/scala/aws/AWS.scala
@@ -91,19 +91,12 @@ object AWS {
     client(S3Client.builder(), account, region)
   private val s3ClientCache = new AwsClientCache(s3ClientBuilder)
 
-  def s3Client(account: AwsAccount, region: Region): AwsClient[S3Client] =
-    s3ClientCache.getClient(account, region)
-
   def s3Clients(accounts: List[AwsAccount], regions: List[Region]): AwsClients[S3Client] =
     s3ClientCache.getClients(accounts, regions)
 
   private def iamClientBuilder(account: AwsAccount, region: Region): IamAsyncClient =
     client(withCustomThreadPool(IamAsyncClient.builder()), account, region)
   private val iamClientCache = new AwsClientCache(iamClientBuilder)
-
-  // Only needs Regions.US_EAST_1
-  def iamClient(account: AwsAccount): AwsClient[IamAsyncClient] =
-    iamClientCache.getClient(account, IAMClient.SOLE_REGION)
 
   def iamClients(accounts: List[AwsAccount]): AwsClients[IamAsyncClient] =
     iamClientCache.getClients(accounts, List(IAMClient.SOLE_REGION))

--- a/core/src/main/scala/aws/s3/S3.scala
+++ b/core/src/main/scala/aws/s3/S3.scala
@@ -24,6 +24,7 @@ object S3 {
               s"Unable to get S3 object for bucket $bucket and key $key",
               "Failed to fetch an S3 object",
               500,
+              context = Some(Option(e.getMessage).getOrElse(e.getClass.getSimpleName)),
               throwable = Some(e)
             )
           )
@@ -42,9 +43,9 @@ object S3 {
     } catch {
       // If there is no bucket encryption, AWS returns an error...
       // Assume bucket is not encrypted if we receive the specific error
-      case e: S3Exception if e.getMessage.contains("ServerSideEncryptionConfigurationNotFoundError") =>
+      case e: S3Exception if Option(e.getMessage).exists(_.contains("ServerSideEncryptionConfigurationNotFoundError")) =>
         Attempt.Right(NotEncrypted)
-      case e: S3Exception if e.getMessage.contains("NoSuchBucket") =>
+      case e: S3Exception if Option(e.getMessage).exists(_.contains("NoSuchBucket")) =>
         Attempt.Right(BucketNotFound)
       case NonFatal(e) =>
         Attempt.Left(
@@ -53,7 +54,7 @@ object S3 {
               s"unable to get S3 bucket encryption status for bucket $bucketName",
               "Encryption status for this bucket was not found.",
               500,
-              context = Some(e.getMessage),
+              context = Some(Option(e.getMessage).getOrElse(e.getClass.getSimpleName)),
               throwable = Some(e)
             )
           )

--- a/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
+++ b/iam-outdated-credentials/src/main/scala/logic/IamOutdatedCredentials.scala
@@ -299,28 +299,22 @@ class IamOutdatedCredentials(
         performRemediationOperation(_, now)
       )
     } yield results
-    result.tap {
-      // A Left here is unlikely due to `traverseWithFailures` - the top-level result should be a success.
-      // Any failures are more likely to be picked up by the Right() case.
-      case Left(failedAttempt) =>
+
+    // A Left here is unlikely due to `traverseWithFailures` - the top-level result should be a success.
+    // Any failures are more likely to be picked up by the Right() case.
+    // Use .map (not .tap) so logging is sequenced inside the future chain and guaranteed to complete before the lambda exits.
+    result.map { operations =>
+      val (failedOperations, successfulOperations) = operations.partitionMap(identity)
+      logger.info(
+        s"Completed 'disable outdated credentials job', with ${successfulOperations.length} successful operations and ${failedOperations.length} failed operations"
+      )
+      failedOperations.zipWithIndex.foreach { case (failedAttempt, i) =>
         logger.error(
-          s"Failure during 'disable outdated credentials' job: ${failedAttempt.logMessage}",
-          failedAttempt.firstException.orNull // make sure the exception goes into the log, if present
+          s"Failed operation $i of ${failedOperations.length}: ${failedAttempt.logMessage}",
+          failedAttempt.firstException.orNull
         )
-      case Right(operations) =>
-        val failedOperations = operations.collect { case Left(failure) => failure }
-        val successfulOperations = operations.collect { case Right(ids) => ids }
-        logger.info(
-          s"Completed 'disable outdated credentials job', with ${successfulOperations.length} successful operations and ${failedOperations.length} failed operations"
-        )
-        failedOperations.zipWithIndex.foreach { case (failedAttempt, i) =>
-          // TODO emit metrics counting the number of operations which failed and create alarm
-          logger.error(
-            s"Failed operation $i of ${failedOperations.length}: ${failedAttempt.logMessage}",
-            failedAttempt.firstException.orNull
-          )
-        }
-    }.unit
+      }
+    }
   }
 
 }


### PR DESCRIPTION
## What does this change?

We have bad error logging:
```
[[33mwarn[0m] s.CacheService - Exposed Keys updated: 31/36 accounts succeeded. Failed accounts: AI: null caused by: null, Editorial Feeds: null caused by: null, Hiring and Onboarding: null caused by: null, Personalisation: null caused by: null, Secure Collaboration: null caused by: null - see stacktrace for an example cause
```

We want to understand what's going wrong and either fix it so we can _actually_ validate accounts for safety, or decide that we don't care and bin it altogether.

This PR alsos deleted some dead code.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
