### PR TITLE
Handle null exception messages cleanly

### DIFF
--- a/core/src/main/scala/aws/AwsAsyncHandler.scala
+++ b/core/src/main/scala/aws/AwsAsyncHandler.scala
@@ -1,12 +1,17 @@
 package aws
 
+import com.typesafe.scalalogging.LazyLogging
 import utils.attempt.{Attempt, Failure}
 
 import java.util.concurrent.CompletableFuture
 import scala.concurrent.{ExecutionContext, Future, Promise}
 
-object AwsAsyncHandler {
+object AwsAsyncHandler extends LazyLogging {
   private val ServiceName = ".*Service: ([^;]+);.*".r
+  private val Expired = "The security token included in the request is expired".r
+  private val NoCredentials = "Unable to load AWS credentials from any provider in the chain".r
+  private val NotAuthorized = "not authorized to perform".r
+  private val RateExceeded = "Rate exceeded".r
 
   def asScala[T](cf: CompletableFuture[T]): Future[T] = {
     val p = Promise[T]()
@@ -21,20 +26,28 @@ object AwsAsyncHandler {
       awsClient: AwsClient[Client]
   )(f: => Future[T])(implicit ec: ExecutionContext): Attempt[T] = {
     Attempt.fromFuture(f) { case e =>
-      val serviceNameOpt = e.getMessage match {
-        case ServiceName(serviceName) => Some(serviceName)
-        case _                        => None
+      val maybeString = Option(e.getMessage)
+
+      val serviceNameOpt = maybeString match {
+        case Some(ServiceName(serviceName)) => Some(serviceName)
+        case _                              => None
       }
-      if (e.getMessage.contains("The security token included in the request is expired")) {
-        Failure.expiredCredentials(serviceNameOpt, awsClient).attempt
-      } else if (e.getMessage.contains("Unable to load AWS credentials from any provider in the chain")) {
-        Failure.noCredentials(serviceNameOpt, awsClient).attempt
-      } else if (e.getMessage.contains("not authorized to perform")) {
-        Failure.insufficientPermissions(serviceNameOpt, awsClient).attempt
-      } else if (e.getMessage.contains("Rate exceeded")) {
-        Failure.rateLimitExceeded(serviceNameOpt, awsClient).attempt
-      } else {
-        Failure.awsError(serviceNameOpt, awsClient, e).attempt
+
+      maybeString match {
+        case Some(Expired()) =>
+          logger.info(s"Handled ${e.getClass.getSimpleName} exception by string matching: ${e.getMessage}", e)
+          Failure.expiredCredentials(serviceNameOpt, awsClient).attempt
+        case Some(NoCredentials()) =>
+          logger.info(s"Handled ${e.getClass.getSimpleName} exception by string matching: ${e.getMessage}", e)
+          Failure.noCredentials(serviceNameOpt, awsClient).attempt
+        case Some(NotAuthorized()) =>
+          logger.info(s"Handled ${e.getClass.getSimpleName} exception by string matching: ${e.getMessage}", e)
+          Failure.insufficientPermissions(serviceNameOpt, awsClient).attempt
+        case Some(RateExceeded()) =>
+          logger.info(s"Handled ${e.getClass.getSimpleName} exception by string matching: ${e.getMessage}", e)
+          Failure.rateLimitExceeded(serviceNameOpt, awsClient).attempt
+        case _ =>
+          Failure.awsError(serviceNameOpt, awsClient, e).attempt
       }
     }
   }


### PR DESCRIPTION
## What does this change?

We can see NPEs and nulls in the logs.  It appears that these are caused by some AWS exception returning `null` from `getMessage`.

This code will handle those nulls correctly and safely, allowing us to understand the underlying cause.

This is necessary because this code is still used by the lambdas, and will not be removed when we deprecate the SHQ app.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
