### PR TITLE
Handle Trusted Advisor timestamps better

### DIFF
--- a/core/src/main/scala/logic/DateUtils.scala
+++ b/core/src/main/scala/logic/DateUtils.scala
@@ -1,14 +1,20 @@
 package logic
 
+import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.{DateTime, DateTimeZone, Duration}
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 
-object DateUtils {
+object DateUtils extends LazyLogging {
   val formatter = ISODateTimeFormat.dateTimeParser()
   val isoDateTimeParser = ISODateTimeFormat.dateTimeParser().withZoneUTC()
 
-  def fromISOString(dateTime: String): DateTime = {
+  def fromISOString(dateTime: String): DateTime = try {
     formatter.parseDateTime(dateTime)
+  } catch {
+    case e: Throwable =>
+      val currentDateTime = new DateTime()
+      logger.error(s"Invalid ISO date string: $dateTime; returning $currentDateTime", e)
+      currentDateTime
   }
   def toISOString(dateTime: DateTime) = ISODateTimeFormat.dateTime().print(dateTime)
 


### PR DESCRIPTION
## What does this change?

We have logging indicating the timestamp handling is not correct:

```
	at aws.support.TrustedAdvisor$.parseTrustedAdvisorCheckResult$$anonfun$1(TrustedAdvisor.scala:121)
```

This field is not actually used!  First step is to understand the problem.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
