### PR TITLE
Handle nulls better

### DIFF
--- a/core/src/main/scala/aws/support/TrustedAdvisor.scala
+++ b/core/src/main/scala/aws/support/TrustedAdvisor.scala
@@ -115,14 +115,17 @@ object TrustedAdvisor {
     val result = response.result
     for {
       resources <- Attempt.traverse(result.flaggedResources.asScala.toList)(parseDetails)
-    } yield TrustedAdvisorDetailsResult(
-      checkId = result.checkId,
-      status = result.status,
-      timestamp = fromISOString(result.timestamp),
-      flaggedResources = sortSecurityFlags(resources),
-      resourcesIgnored = result.resourcesSummary.resourcesIgnored,
-      resourcesFlagged = result.resourcesSummary.resourcesFlagged,
-      resourcesSuppressed = result.resourcesSummary.resourcesSuppressed
-    )
+      maybeSummary = Option(result.resourcesSummary)
+    } yield {
+      TrustedAdvisorDetailsResult(
+        checkId = result.checkId,
+        status = result.status,
+        timestamp = fromISOString(result.timestamp),
+        flaggedResources = sortSecurityFlags(resources),
+        resourcesIgnored = maybeSummary.flatMap(rs => Option(rs.resourcesIgnored).map(ri => ri.longValue())).getOrElse(0L),
+        resourcesFlagged = maybeSummary.flatMap(rs => Option(rs.resourcesFlagged).map(rf => rf.longValue())).getOrElse(0L),
+        resourcesSuppressed = maybeSummary.flatMap(rs => Option(rs.resourcesSuppressed).map(rs => rs.longValue())).getOrElse(0L)
+      )
+    }
   }
 }


### PR DESCRIPTION
## What does this change?

It appears that Java-based Trusted Advisor responses can be null.  This code handles that better.

NB Andrew N has found that this may be cause by TA reporting not being turned on in some target accounts.

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
