### PR TITLE
Remove SHQ App

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -14,31 +14,6 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuDynamoDBWritePolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
-      "GuAnghammaradTopicParameter",
-      "GuAnghammaradSenderPolicy",
-      "GuVpcParameter",
-      "GuSubnetListParameter",
-      "GuSubnetListParameter",
-      "GuEc2AppExperimental",
-      "GuCertificate",
-      "GuInstanceRole",
-      "GuSsmSshPolicy",
-      "GuDescribeEC2Policy",
-      "GuLoggingStreamNameParameter",
-      "GuLogShippingPolicy",
-      "GuGetDistributablePolicy",
-      "GuParameterStoreReadPolicy",
-      "GuAmiParameter",
-      "GuHttpsEgressSecurityGroup",
-      "GuAutoScalingGroup",
-      "GuApplicationLoadBalancer",
-      "GuAccessLoggingBucketParameter",
-      "GuApplicationTargetGroup",
-      "GuHttpsApplicationListener",
-      "GuRiffRaffDeploymentIdParameterExperimental",
-      "GuCname",
-      "GuHttpsEgressSecurityGroup",
-      "GuStringParameter",
       "GuParameter",
       "GuAlarm",
       "GuAlarm",
@@ -47,6 +22,8 @@ exports[`HQ stack matches the snapshot 1`] = `
       "GuAlarm",
       "GuAlarm",
       "GuDeveloperPolicyExperimental",
+      "GuAnghammaradTopicParameter",
+      "GuAnghammaradSenderPolicy",
       "GuScheduledLambda",
       "GuLambdaErrorPercentageAlarm",
       "GuScheduledLambda",
@@ -54,27 +31,7 @@ exports[`HQ stack matches the snapshot 1`] = `
     ],
     "gu:cdk:version": "TEST",
   },
-  "Outputs": {
-    "LoadBalancerSecurityhqDnsName": {
-      "Description": "DNS entry for LoadBalancerSecurityhq",
-      "Value": {
-        "Fn::GetAtt": [
-          "LoadBalancerSecurityhqF59D9B82",
-          "DNSName",
-        ],
-      },
-    },
-  },
   "Parameters": {
-    "AMISecurityhq": {
-      "Description": "Amazon Machine Image ID for the app security-hq. Use this in conjunction with AMIgo to keep AMIs up to date.",
-      "Type": "AWS::EC2::Image::Id",
-    },
-    "AccessLoggingBucket": {
-      "Default": "/account/services/access-logging/bucket",
-      "Description": "S3 bucket to store your access logs",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
     "AnghammaradSnsArn": {
       "Default": "/account/services/anghammarad.topic.arn",
       "Description": "SSM parameter containing the ARN of the Anghammarad SNS topic",
@@ -85,10 +42,6 @@ exports[`HQ stack matches the snapshot 1`] = `
       "Description": "Name of the S3 bucket to fetch auditable data from (e.g. Janus data)",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "ClientId": {
-      "Description": "Google OAuth client ID",
-      "Type": "String",
-    },
     "CloudwatchAlarmEmailDestination": {
       "Description": "Send Security HQ cloudwatch alarms to this email address",
       "Type": "String",
@@ -98,79 +51,8 @@ exports[`HQ stack matches the snapshot 1`] = `
       "Description": "SSM parameter containing the S3 bucket name holding distribution artifacts",
       "Type": "AWS::SSM::Parameter::Value<String>",
     },
-    "LoggingStreamName": {
-      "Default": "/account/services/logging.stream.name",
-      "Description": "SSM parameter containing the Name (not ARN) on the kinesis stream",
-      "Type": "AWS::SSM::Parameter::Value<String>",
-    },
-    "RiffRaffDeploymentId": {
-      "Description": "Used by Riff-Raff to inject the deployment ID.",
-      "Type": "String",
-    },
-    "VpcId": {
-      "Default": "/account/vpc/primary/id",
-      "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
-      "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
-    },
-    "securityhqPrivateSubnets": {
-      "Default": "/account/vpc/primary/subnets/private",
-      "Description": "A list of private subnets",
-      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
-    },
-    "securityhqPublicSubnets": {
-      "Default": "/account/vpc/primary/subnets/public",
-      "Description": "A list of public subnets",
-      "Type": "AWS::SSM::Parameter::Value<List<AWS::EC2::Subnet::Id>>",
-    },
   },
   "Resources": {
-    "AlbSsmParam485C1D52": {
-      "Properties": {
-        "DataType": "text",
-        "Description": "The arn of the ALB for security-hq-PROD. N.B. this parameter is created via cdk",
-        "Name": "/infosec/waf/services/PROD/security-hq-alb-arn",
-        "Tags": {
-          "Stack": "security",
-          "Stage": "PROD",
-          "gu:cdk:version": "TEST",
-          "gu:repo": "guardian/security-hq",
-        },
-        "Tier": "Standard",
-        "Type": "String",
-        "Value": {
-          "Ref": "LoadBalancerSecurityhqF59D9B82",
-        },
-      },
-      "Type": "AWS::SSM::Parameter",
-    },
-    "AsgRollingUpdatePolicy2A1DDC6F": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "cloudformation:SignalResource",
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "AWS::StackId",
-              },
-            },
-            {
-              "Action": "elasticloadbalancing:DescribeTargetHealth",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "AsgRollingUpdatePolicy2A1DDC6F",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "AssumeRole3910C09D": {
       "Properties": {
         "PolicyDocument": {
@@ -186,176 +68,10 @@ exports[`HQ stack matches the snapshot 1`] = `
         "PolicyName": "AssumeRole3910C09D",
         "Roles": [
           {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-          {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
           {
             "Ref": "iamunrecognisedusersServiceRole58E0D3DD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "AutoScalingGroupSecurityhqASG8DD277A5": {
-      "CreationPolicy": {
-        "AutoScalingCreationPolicy": {
-          "MinSuccessfulInstancesPercent": 100,
-        },
-        "ResourceSignal": {
-          "Count": 1,
-          "Timeout": "PT5M",
-        },
-      },
-      "DependsOn": [
-        "AsgRollingUpdatePolicy2A1DDC6F",
-      ],
-      "Properties": {
-        "DesiredCapacity": "1",
-        "HealthCheckGracePeriod": 240,
-        "HealthCheckType": "ELB",
-        "LaunchTemplate": {
-          "LaunchTemplateId": {
-            "Ref": "securityPRODsecurityhq7917BE18",
-          },
-          "Version": {
-            "Fn::GetAtt": [
-              "securityPRODsecurityhq7917BE18",
-              "LatestVersionNumber",
-            ],
-          },
-        },
-        "MaxSize": "2",
-        "MetricsCollection": [
-          {
-            "Granularity": "1Minute",
-          },
-        ],
-        "MinSize": "1",
-        "Tags": [
-          {
-            "Key": "App",
-            "PropagateAtLaunch": true,
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "PropagateAtLaunch": true,
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "PropagateAtLaunch": true,
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "LogKinesisStreamName",
-            "PropagateAtLaunch": true,
-            "Value": {
-              "Ref": "LoggingStreamName",
-            },
-          },
-          {
-            "Key": "Stack",
-            "PropagateAtLaunch": true,
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "PropagateAtLaunch": true,
-            "Value": "PROD",
-          },
-          {
-            "Key": "SystemdUnit",
-            "PropagateAtLaunch": true,
-            "Value": "security-hq.service",
-          },
-        ],
-        "TargetGroupARNs": [
-          {
-            "Ref": "TargetGroupSecurityhq530DEDAA",
-          },
-        ],
-        "VPCZoneIdentifier": {
-          "Ref": "securityhqPrivateSubnets",
-        },
-      },
-      "Type": "AWS::AutoScaling::AutoScalingGroup",
-      "UpdatePolicy": {
-        "AutoScalingRollingUpdate": {
-          "MaxBatchSize": 2,
-          "MinInstancesInService": 1,
-          "MinSuccessfulInstancesPercent": 100,
-          "PauseTime": "PT5M",
-          "SuspendProcesses": [
-            "AlarmNotification",
-            "AZRebalance",
-            "HealthCheck",
-            "InstanceRefresh",
-            "ReplaceUnhealthy",
-            "ScheduledActions",
-          ],
-          "WaitOnResourceSignals": true,
-        },
-      },
-    },
-    "CertificateSecurityhqD266EC9D": {
-      "DeletionPolicy": "Retain",
-      "Properties": {
-        "DomainName": "security-hq.gutools.co.uk",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Name",
-            "Value": "security-hq/CertificateSecurityhq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "ValidationMethod": "DNS",
-      },
-      "Type": "AWS::CertificateManager::Certificate",
-      "UpdateReplacePolicy": "Retain",
-    },
-    "DescribeEC2PolicyFF5F9295": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeAutoScalingGroups",
-                "ec2:DescribeTags",
-                "ec2:DescribeInstances",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "describe-ec2-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
           },
         ],
       },
@@ -375,9 +91,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         },
         "PolicyName": "DescribeRegions9F63D96D",
         "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
           {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
@@ -628,23 +341,6 @@ exports[`HQ stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CloudWatch::Alarm",
     },
-    "DnsRecord": {
-      "Properties": {
-        "Name": "security-hq.gutools.co.uk",
-        "RecordType": "CNAME",
-        "ResourceRecords": [
-          {
-            "Fn::GetAtt": [
-              "LoadBalancerSecurityhqF59D9B82",
-              "DNSName",
-            ],
-          },
-        ],
-        "Stage": "PROD",
-        "TTL": 3600,
-      },
-      "Type": "Guardian::DNS::RecordSet",
-    },
     "DynamoReadF4CBA3FD": {
       "Properties": {
         "PolicyDocument": {
@@ -697,9 +393,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         },
         "PolicyName": "DynamoReadF4CBA3FD",
         "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
           {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
@@ -759,42 +452,7 @@ exports[`HQ stack matches the snapshot 1`] = `
         "PolicyName": "DynamoWrite95D291C9",
         "Roles": [
           {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-          {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "GetDistributablePolicySecurityhqC6808A6A": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "s3:GetObject",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:s3:::",
-                    {
-                      "Ref": "DistributionBucketName",
-                    },
-                    "/security/PROD/security-hq/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "GetDistributablePolicySecurityhqC6808A6A",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
           },
         ],
       },
@@ -817,133 +475,10 @@ exports[`HQ stack matches the snapshot 1`] = `
         "PolicyName": "GuAnghammaradSenderPolicy674A3874",
         "Roles": [
           {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-          {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
           {
             "Ref": "iamunrecognisedusersServiceRole58E0D3DD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88": {
-      "Properties": {
-        "GroupDescription": "Allow all outbound HTTPS traffic",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound HTTPS traffic",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "GuHttpsEgressSecurityGroupSecurityhqfromsecurityhqLoadBalancerSecurityhqSecurityGroup3F506C5990004DFA1452": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerSecurityhqSecurityGroup66272916",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "GuHttpsEgressSecurityGroupSecurityhqfromsecurityhqidpaccessSecurityhqE586B5AB900017582D17": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "SourceSecurityGroupId": {
-          "Fn::GetAtt": [
-            "idpaccessSecurityhq802D3912",
-            "GroupId",
-          ],
-        },
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupIngress",
-    },
-    "GuLogShippingPolicy981BFE5A": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "kinesis:Describe*",
-                "kinesis:Put*",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:kinesis:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":stream/",
-                    {
-                      "Ref": "LoggingStreamName",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "GuLogShippingPolicy981BFE5A",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
           },
         ],
       },
@@ -964,9 +499,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
         "Roles": [
           {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-          {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
           {
@@ -975,236 +507,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
-    },
-    "InstanceRoleSecurityhq7C08CA33": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "ec2.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "Path": "/",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "ListenerSecurityhq0F356342": {
-      "Properties": {
-        "Certificates": [
-          {
-            "CertificateArn": {
-              "Ref": "CertificateSecurityhqD266EC9D",
-            },
-          },
-        ],
-        "DefaultActions": [
-          {
-            "AuthenticateOidcConfig": {
-              "AuthenticationRequestExtraParams": {
-                "hd": "guardian.co.uk",
-              },
-              "AuthorizationEndpoint": "https://accounts.google.com/o/oauth2/v2/auth",
-              "ClientId": {
-                "Ref": "ClientId",
-              },
-              "ClientSecret": "{{resolve:secretsmanager:/PROD/deploy/security-hq/client-secret:SecretString:::}}",
-              "Issuer": "https://accounts.google.com",
-              "OnUnauthenticatedRequest": "authenticate",
-              "Scope": "openid",
-              "TokenEndpoint": "https://oauth2.googleapis.com/token",
-              "UserInfoEndpoint": "https://openidconnect.googleapis.com/v1/userinfo",
-            },
-            "Order": 1,
-            "Type": "authenticate-oidc",
-          },
-          {
-            "Order": 2,
-            "TargetGroupArn": {
-              "Ref": "TargetGroupSecurityhq530DEDAA",
-            },
-            "Type": "forward",
-          },
-        ],
-        "LoadBalancerArn": {
-          "Ref": "LoadBalancerSecurityhqF59D9B82",
-        },
-        "Port": 443,
-        "Protocol": "HTTPS",
-        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::Listener",
-    },
-    "LoadBalancerSecurityhqF59D9B82": {
-      "Properties": {
-        "LoadBalancerAttributes": [
-          {
-            "Key": "deletion_protection.enabled",
-            "Value": "true",
-          },
-          {
-            "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
-            "Value": "true",
-          },
-          {
-            "Key": "routing.http.drop_invalid_header_fields.enabled",
-            "Value": "true",
-          },
-          {
-            "Key": "access_logs.s3.enabled",
-            "Value": "true",
-          },
-          {
-            "Key": "access_logs.s3.bucket",
-            "Value": {
-              "Ref": "AccessLoggingBucket",
-            },
-          },
-          {
-            "Key": "access_logs.s3.prefix",
-            "Value": "application-load-balancer/PROD/security/security-hq",
-          },
-        ],
-        "Scheme": "internet-facing",
-        "SecurityGroups": [
-          {
-            "Fn::GetAtt": [
-              "LoadBalancerSecurityhqSecurityGroup66272916",
-              "GroupId",
-            ],
-          },
-          {
-            "Fn::GetAtt": [
-              "idpaccessSecurityhq802D3912",
-              "GroupId",
-            ],
-          },
-        ],
-        "Subnets": {
-          "Ref": "securityhqPublicSubnets",
-        },
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "Type": "application",
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-    },
-    "LoadBalancerSecurityhqSecurityGroup66272916": {
-      "Properties": {
-        "GroupDescription": "Automatically created Security Group for ELB securityhqLoadBalancerSecurityhq4820B44E",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow to IdP endpoint",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "SecurityGroupIngress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow from anyone on port 443",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "LoadBalancerSecurityhqSecurityGrouptosecurityhqGuHttpsEgressSecurityGroupSecurityhqFDD8E89C90004679E20B": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "LoadBalancerSecurityhqSecurityGroup66272916",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
     },
     "NotificationTopicEB7A0DF1": {
       "Properties": {
@@ -1241,57 +543,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::SNS::Subscription",
-    },
-    "ParameterStoreReadSecurityhq5E138D38": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/security/security-hq",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:eu-west-1:",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/PROD/security/security-hq/*",
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "parameter-store-read-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
     },
     "RemovePasswordFailureAlarm68B6574A": {
       "Properties": {
@@ -1548,9 +799,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         "PolicyName": "S3AuditRead9DF4AE59",
         "Roles": [
           {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-          {
             "Ref": "iamoutdatedcredentialsServiceRoleEE7EC16A",
           },
           {
@@ -1650,91 +898,6 @@ exports[`HQ stack matches the snapshot 1`] = `
       },
       "Type": "AWS::DynamoDB::Table",
       "UpdateReplacePolicy": "Retain",
-    },
-    "SsmSshPolicy4CFC977E": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "ec2messages:AcknowledgeMessage",
-                "ec2messages:DeleteMessage",
-                "ec2messages:FailMessage",
-                "ec2messages:GetEndpoint",
-                "ec2messages:GetMessages",
-                "ec2messages:SendReply",
-                "ssm:UpdateInstanceInformation",
-                "ssm:ListInstanceAssociations",
-                "ssm:DescribeInstanceProperties",
-                "ssm:DescribeDocumentParameters",
-                "ssmmessages:CreateControlChannel",
-                "ssmmessages:CreateDataChannel",
-                "ssmmessages:OpenControlChannel",
-                "ssmmessages:OpenDataChannel",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "ssm-ssh-policy",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "TargetGroupSecurityhq530DEDAA": {
-      "Properties": {
-        "HealthCheckIntervalSeconds": 10,
-        "HealthCheckPath": "/healthcheck",
-        "HealthCheckProtocol": "HTTP",
-        "HealthCheckTimeoutSeconds": 5,
-        "HealthyThresholdCount": 5,
-        "Port": 9000,
-        "Protocol": "HTTP",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "TargetGroupAttributes": [
-          {
-            "Key": "deregistration_delay.timeout_seconds",
-            "Value": "30",
-          },
-          {
-            "Key": "stickiness.enabled",
-            "Value": "false",
-          },
-        ],
-        "TargetType": "instance",
-        "UnhealthyThresholdCount": 2,
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::ElasticLoadBalancingV2::TargetGroup",
     },
     "iamoutdatedcredentials652F7EC1": {
       "DependsOn": [
@@ -2519,287 +1682,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::Lambda::Permission",
-    },
-    "idpaccessSecurityhq802D3912": {
-      "Properties": {
-        "GroupDescription": "Allow all outbound HTTPS traffic",
-        "SecurityGroupEgress": [
-          {
-            "CidrIp": "0.0.0.0/0",
-            "Description": "Allow all outbound HTTPS traffic",
-            "FromPort": 443,
-            "IpProtocol": "tcp",
-            "ToPort": 443,
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "security-hq",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/security-hq",
-          },
-          {
-            "Key": "Stack",
-            "Value": "security",
-          },
-          {
-            "Key": "Stage",
-            "Value": "PROD",
-          },
-        ],
-        "VpcId": {
-          "Ref": "VpcId",
-        },
-      },
-      "Type": "AWS::EC2::SecurityGroup",
-    },
-    "idpaccessSecurityhqtosecurityhqGuHttpsEgressSecurityGroupSecurityhqFDD8E89C9000FCD2D08D": {
-      "Properties": {
-        "Description": "Load balancer to target",
-        "DestinationSecurityGroupId": {
-          "Fn::GetAtt": [
-            "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
-            "GroupId",
-          ],
-        },
-        "FromPort": 9000,
-        "GroupId": {
-          "Fn::GetAtt": [
-            "idpaccessSecurityhq802D3912",
-            "GroupId",
-          ],
-        },
-        "IpProtocol": "tcp",
-        "ToPort": 9000,
-      },
-      "Type": "AWS::EC2::SecurityGroupEgress",
-    },
-    "securityPRODsecurityhq7917BE18": {
-      "DependsOn": [
-        "InstanceRoleSecurityhq7C08CA33",
-      ],
-      "Properties": {
-        "LaunchTemplateData": {
-          "IamInstanceProfile": {
-            "Arn": {
-              "Fn::GetAtt": [
-                "securityPRODsecurityhqProfileC4C6F731",
-                "Arn",
-              ],
-            },
-          },
-          "ImageId": {
-            "Ref": "AMISecurityhq",
-          },
-          "InstanceType": "t4g.large",
-          "MetadataOptions": {
-            "HttpTokens": "required",
-            "InstanceMetadataTags": "enabled",
-          },
-          "Monitoring": {
-            "Enabled": false,
-          },
-          "SecurityGroupIds": [
-            {
-              "Fn::GetAtt": [
-                "GuHttpsEgressSecurityGroupSecurityhq0F9CBE88",
-                "GroupId",
-              ],
-            },
-          ],
-          "TagSpecifications": [
-            {
-              "ResourceType": "instance",
-              "Tags": [
-                {
-                  "Key": "App",
-                  "Value": "security-hq",
-                },
-                {
-                  "Key": "gu:build-identifier",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:cdk:version",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:repo",
-                  "Value": "guardian/security-hq",
-                },
-                {
-                  "Key": "Name",
-                  "Value": "security-hq/security-PROD-security-hq",
-                },
-                {
-                  "Key": "Stack",
-                  "Value": "security",
-                },
-                {
-                  "Key": "Stage",
-                  "Value": "PROD",
-                },
-              ],
-            },
-            {
-              "ResourceType": "volume",
-              "Tags": [
-                {
-                  "Key": "App",
-                  "Value": "security-hq",
-                },
-                {
-                  "Key": "gu:build-identifier",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:cdk:version",
-                  "Value": "TEST",
-                },
-                {
-                  "Key": "gu:repo",
-                  "Value": "guardian/security-hq",
-                },
-                {
-                  "Key": "Name",
-                  "Value": "security-hq/security-PROD-security-hq",
-                },
-                {
-                  "Key": "Stack",
-                  "Value": "security",
-                },
-                {
-                  "Key": "Stage",
-                  "Value": "PROD",
-                },
-              ],
-            },
-          ],
-          "UserData": {
-            "Fn::Base64": {
-              "Fn::Join": [
-                "",
-                [
-                  "#!/bin/bash
-function exitTrap(){
-exitCode=$?
-
-        cfn-signal --stack ",
-                  {
-                    "Ref": "AWS::StackId",
-                  },
-                  "           --resource AutoScalingGroupSecurityhqASG8DD277A5           --region eu-west-1           --exit-code $exitCode || echo 'Failed to send Cloudformation Signal'
-        
-}
-trap exitTrap EXIT
-# setup security-hq
-    mkdir -p /etc/gu
-
-    aws --region eu-west-1 s3 cp s3://",
-                  {
-                    "Ref": "DistributionBucketName",
-                  },
-                  "/security/PROD/security-hq/security-hq.conf /etc/gu
-    aws --region eu-west-1 s3 cp s3://",
-                  {
-                    "Ref": "DistributionBucketName",
-                  },
-                  "/security/PROD/security-hq/security-hq-service-account-cert.json /etc/gu
-    aws --region eu-west-1 s3 cp s3://",
-                  {
-                    "Ref": "DistributionBucketName",
-                  },
-                  "/security/PROD/security-hq/security-hq-TEST.deb /tmp/installer.deb
-
-    dpkg -i /tmp/installer.deb
-echo "Launch template last updated by Riff-Raff deployment ID: ",
-                  {
-                    "Ref": "RiffRaffDeploymentId",
-                  },
-                  ""
-# GuEc2AppExperimental Instance Health Check Start
-
-      TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/instance-id")
-
-      STATE=$(aws elbv2 describe-target-health         --target-group-arn ",
-                  {
-                    "Ref": "TargetGroupSecurityhq530DEDAA",
-                  },
-                  "         --region eu-west-1         --targets Id=$INSTANCE_ID,Port=9000         --query "TargetHealthDescriptions[0].TargetHealth.State")
-
-      until [ "$STATE" == "\\"healthy\\"" ]; do
-        echo "Instance running build TEST not yet healthy within target group. Current state $STATE. Sleeping..."
-        sleep 5
-        STATE=$(aws elbv2 describe-target-health           --target-group-arn ",
-                  {
-                    "Ref": "TargetGroupSecurityhq530DEDAA",
-                  },
-                  "           --region eu-west-1           --targets Id=$INSTANCE_ID,Port=9000           --query "TargetHealthDescriptions[0].TargetHealth.State")
-      done
-
-      echo "Instance running build TEST is healthy in target group."
-      
-# GuEc2AppExperimental Instance Health Check End",
-                ],
-              ],
-            },
-          },
-        },
-        "TagSpecifications": [
-          {
-            "ResourceType": "launch-template",
-            "Tags": [
-              {
-                "Key": "App",
-                "Value": "security-hq",
-              },
-              {
-                "Key": "gu:build-identifier",
-                "Value": "TEST",
-              },
-              {
-                "Key": "gu:cdk:version",
-                "Value": "TEST",
-              },
-              {
-                "Key": "gu:repo",
-                "Value": "guardian/security-hq",
-              },
-              {
-                "Key": "Name",
-                "Value": "security-hq/security-PROD-security-hq",
-              },
-              {
-                "Key": "Stack",
-                "Value": "security",
-              },
-              {
-                "Key": "Stage",
-                "Value": "PROD",
-              },
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::EC2::LaunchTemplate",
-    },
-    "securityPRODsecurityhqProfileC4C6F731": {
-      "Properties": {
-        "Roles": [
-          {
-            "Ref": "InstanceRoleSecurityhq7C08CA33",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::InstanceProfile",
     },
   },
 }

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -1,5 +1,4 @@
 import { GuScheduledLambda } from "@guardian/cdk";
-import { AccessScope } from "@guardian/cdk/lib/constants";
 import { GuAlarm } from "@guardian/cdk/lib/constructs/cloudwatch";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import {
@@ -10,9 +9,7 @@ import {
   GuStringParameter,
 } from "@guardian/cdk/lib/constructs/core";
 import type { AppIdentity } from "@guardian/cdk/lib/constructs/core/identity";
-import { GuCname } from "@guardian/cdk/lib/constructs/dns";
 import { GuDynamoTable } from "@guardian/cdk/lib/constructs/dynamodb";
-import { GuHttpsEgressSecurityGroup } from "@guardian/cdk/lib/constructs/ec2";
 import {
   GuAllowPolicy,
   GuDynamoDBReadPolicy,
@@ -23,36 +20,19 @@ import {
 } from "@guardian/cdk/lib/constructs/iam";
 import { GuAnghammaradSenderPolicy } from "@guardian/cdk/lib/constructs/iam/policies/anghammarad";
 import { GuDeveloperPolicyExperimental } from "@guardian/cdk/lib/experimental/constructs/iam/policies";
-import { GuEc2AppExperimental } from "@guardian/cdk/lib/experimental/patterns/ec2-app";
 import type { App } from "aws-cdk-lib";
-import { Duration, RemovalPolicy, SecretValue } from "aws-cdk-lib";
-import type { CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import { Duration, RemovalPolicy } from "aws-cdk-lib";
 import {
   ComparisonOperator,
   Metric,
   TreatMissingData,
 } from "aws-cdk-lib/aws-cloudwatch";
 import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
-import {
-  InstanceClass,
-  InstanceSize,
-  InstanceType,
-  UserData,
-} from "aws-cdk-lib/aws-ec2";
-import {
-  ListenerAction,
-  UnauthenticatedAction,
-} from "aws-cdk-lib/aws-elasticloadbalancingv2";
 import { Schedule } from "aws-cdk-lib/aws-events";
 import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { Topic } from "aws-cdk-lib/aws-sns";
 import { EmailSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
-import {
-  ParameterDataType,
-  ParameterTier,
-  StringParameter,
-} from "aws-cdk-lib/aws-ssm";
 
 interface SecurityHQProps extends GuStackProps {
   /**
@@ -74,6 +54,8 @@ export class SecurityHQ extends GuStack {
 
     const { buildIdentifier } = props;
 
+    // Used by outdated credentials lambda.
+    // See IAM_DYNAMO_TABLE_NAME in config file
     const table = new GuDynamoTable(this, "DynamoTable", {
       tableName: `security-hq-iam`,
       removalPolicy: RemovalPolicy.RETAIN,
@@ -108,18 +90,6 @@ export class SecurityHQ extends GuStack {
       },
     );
     const auditDataS3BucketPath = `${this.stack}/${this.stage}/*`;
-
-    const domainName = "security-hq.gutools.co.uk";
-
-    const userData = UserData.forLinux();
-    userData.addCommands(`# setup security-hq
-    mkdir -p /etc/gu
-
-    aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.stage}/security-hq/security-hq.conf /etc/gu
-    aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.stage}/security-hq/security-hq-service-account-cert.json /etc/gu
-    aws --region eu-west-1 s3 cp s3://${distBucket.valueAsString}/security/${this.stage}/security-hq/security-hq-${buildIdentifier}.deb /tmp/installer.deb
-
-    dpkg -i /tmp/installer.deb`);
 
     const guPutCloudwatchMetricsPolicy = new GuPutCloudwatchMetricsPolicy(this);
     const guGetS3AuditObjectsPolicy = new GuGetS3ObjectsPolicy(
@@ -158,100 +128,6 @@ export class SecurityHQ extends GuStack {
     const guDescribeRegionsPolicy = new GuAllowPolicy(this, "DescribeRegions", {
       resources: ["*"],
       actions: ["ec2:DescribeRegions"],
-    });
-    const appAdditionalPolicies = [
-      GuAnghammaradSenderPolicy.getInstance(this),
-      guPutCloudwatchMetricsPolicy,
-      guGetS3AuditObjectsPolicy,
-      guDynamoDBReadPolicy,
-      guDynamoDBWritePolicy,
-      guAssumeRolePolicy,
-      guDescribeRegionsPolicy,
-    ];
-
-    const ec2App = new GuEc2AppExperimental(this, {
-      buildIdentifier,
-      applicationLogging: {
-        enabled: true,
-      },
-      access: {
-        scope: AccessScope.PUBLIC,
-      },
-      app: "security-hq",
-      applicationPort: 9000,
-      imageRecipe: "arm64-jammy-java21-security",
-      instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.LARGE),
-      certificateProps: {
-        domainName,
-      },
-      monitoringConfiguration: { noMonitoring: true },
-      scaling: {
-        minimumInstances: 1,
-      },
-      userData,
-      additionalPolicies: appAdditionalPolicies,
-      instanceMetricGranularity: "5Minute",
-    });
-
-    /*
-     * Increase the health-check grace period for a new instance added to the ASG
-     * from the default value of 2 mins to 4 mins.
-     * This is in response to occasional failed deploys because of timeouts.
-     *
-     * To do this, we have to access the underlying ASG node.
-     */
-    const cfnAsg = ec2App.autoScalingGroup.node
-      .defaultChild as CfnAutoScalingGroup;
-    cfnAsg.healthCheckGracePeriod = Duration.minutes(4).toSeconds();
-
-    new GuCname(this, "DnsRecord", {
-      app: SecurityHQ.app.app,
-      domainName,
-      ttl: Duration.hours(1),
-      resourceRecord: ec2App.loadBalancer.loadBalancerDnsName,
-    });
-
-    // Need to give the ALB outbound access on 443 for the IdP endpoints (to support Google Auth).
-    const outboundHttpsSecurityGroup = new GuHttpsEgressSecurityGroup(
-      this,
-      "idp-access",
-      {
-        app: SecurityHQ.app.app,
-        vpc: ec2App.vpc,
-      },
-    );
-
-    ec2App.loadBalancer.addSecurityGroup(outboundHttpsSecurityGroup);
-
-    // This parameter is used by https://github.com/guardian/waf
-    new StringParameter(this, "AlbSsmParam", {
-      parameterName: `/infosec/waf/services/${this.stage}/security-hq-alb-arn`,
-      description: `The arn of the ALB for security-hq-${this.stage}. N.B. this parameter is created via cdk`,
-      simpleName: false,
-      stringValue: ec2App.loadBalancer.loadBalancerArn,
-      tier: ParameterTier.STANDARD,
-      dataType: ParameterDataType.TEXT,
-    });
-
-    const clientId = new GuStringParameter(this, "ClientId", {
-      description: "Google OAuth client ID",
-    });
-
-    ec2App.listener.addAction("DefaultAction", {
-      action: ListenerAction.authenticateOidc({
-        authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
-        issuer: "https://accounts.google.com",
-        scope: "openid",
-        authenticationRequestExtraParams: { hd: "guardian.co.uk" },
-        onUnauthenticatedRequest: UnauthenticatedAction.AUTHENTICATE,
-        tokenEndpoint: "https://oauth2.googleapis.com/token",
-        userInfoEndpoint: "https://openidconnect.googleapis.com/v1/userinfo",
-        clientId: clientId.valueAsString,
-        clientSecret: SecretValue.secretsManager(
-          `/${this.stage}/deploy/security-hq/client-secret`,
-        ),
-        next: ListenerAction.forward([ec2App.targetGroup]),
-      }),
     });
 
     const notificationTopic = new Topic(this, "NotificationTopic", {


### PR DESCRIPTION
## What does this change?

We are removing all the Security HQ App code.

Current step: *Remove the resources from the cloudformation stack*

To follow:

 * Remove the app from the WAF list (https://github.com/guardian/waf/pull/96)
 * Remove all unused code (https://github.com/guardian/security-hq/pull/1492)
 * Remove / update documentation and scripts (https://github.com/guardian/security-hq/pull/1493)

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216038883987064