### PR TITLE
Verify Janus data export before running unrecognised users process

### DIFF
--- a/core/src/main/scala/aws/s3/S3.scala
+++ b/core/src/main/scala/aws/s3/S3.scala
@@ -1,7 +1,8 @@
 package aws.s3
 
 import model.{BucketEncryptionResponse, BucketNotFound, Encrypted, NotEncrypted}
-import software.amazon.awssdk.core.ResponseInputStream
+import software.amazon.awssdk.core.ResponseBytes
+import software.amazon.awssdk.core.sync.ResponseTransformer
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.{
   GetBucketEncryptionRequest,
@@ -14,11 +15,11 @@ import utils.attempt.{Attempt, FailedAttempt, Failure}
 import scala.util.control.NonFatal
 
 object S3 {
-  def getS3Object(s3Client: S3Client, bucket: String, key: String): Attempt[ResponseInputStream[GetObjectResponse]] = {
+  def getS3Object(s3Client: S3Client, bucket: String, key: String): Attempt[ResponseBytes[GetObjectResponse]] = {
     val request = GetObjectRequest.builder().bucket(bucket).key(key).build()
     try {
       Attempt.Right {
-        s3Client.getObject(request)
+        s3Client.getObject(request, ResponseTransformer.toBytes())
       }
     } catch {
       case NonFatal(e) =>

--- a/core/src/main/scala/aws/s3/S3.scala
+++ b/core/src/main/scala/aws/s3/S3.scala
@@ -1,20 +1,24 @@
 package aws.s3
 
 import model.{BucketEncryptionResponse, BucketNotFound, Encrypted, NotEncrypted}
+import software.amazon.awssdk.core.ResponseInputStream
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetBucketEncryptionRequest, GetObjectRequest, S3Exception}
+import software.amazon.awssdk.services.s3.model.{
+  GetBucketEncryptionRequest,
+  GetObjectRequest,
+  GetObjectResponse,
+  S3Exception
+}
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
-import scala.io.BufferedSource
 import scala.util.control.NonFatal
 
 object S3 {
-  def getS3Object(s3Client: S3Client, bucket: String, key: String): Attempt[BufferedSource] = {
+  def getS3Object(s3Client: S3Client, bucket: String, key: String): Attempt[ResponseInputStream[GetObjectResponse]] = {
     val request = GetObjectRequest.builder().bucket(bucket).key(key).build()
     try {
       Attempt.Right {
-        scala.io.Source
-          .fromInputStream(s3Client.getObject(request))
+        s3Client.getObject(request)
       }
     } catch {
       case NonFatal(e) =>

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -5,6 +5,8 @@ import aws.iam.IAMClient.getAllCredentialReports
 import aws.s3.S3.getS3Object
 import aws.{AWS, AwsClients}
 import com.gu.janus.JanusConfig
+import com.gu.janus.JanusConfig.JanusConfigurationException
+import com.gu.janus.model.JanusData
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import config.CoreConfig
@@ -15,11 +17,16 @@ import model.*
 import notifications.AnghammaradNotifications
 import software.amazon.awssdk.services.iam.IamAsyncClient
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import software.amazon.awssdk.services.sns.SnsAsyncClient
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
+import java.io.File
+import java.time.Instant
+import java.time.temporal.ChronoUnit.DAYS
 import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext}
+import scala.io.Source
 import scala.jdk.CollectionConverters.*
 import scala.util.chaining.*
 
@@ -59,6 +66,37 @@ object UnrecognisedUsers extends LazyLogging {
   private def unloadedReport(account: AwsAccount): Either[FailedAttempt, CredentialReportDisplay] =
     Left(Failure.notYetLoaded(account.id, "credentials").attempt)
 
+  private def janusConfigIsFresh(objectResponse: GetObjectResponse): Attempt[Boolean] = {
+    val lastModified = objectResponse.lastModified()
+    val isStale = lastModified.isBefore(Instant.now().minus(7, DAYS))
+    if (isStale) {
+      Attempt.Left(
+        FailedAttempt(
+          Failure(
+            "Janus config has not been updated in over 7 days"
+          )
+        )
+      )
+    } else {
+      Attempt.Right(true)
+    }
+  }
+
+  private def loadJanusConfig(dataFile: File): Attempt[JanusData] = {
+    try {
+      Attempt.Right { JanusConfig.load(dataFile) }
+    } catch {
+      case e: JanusConfigurationException =>
+        Attempt.Left(
+          FailedAttempt(
+            Failure(
+              e.getMessage(),
+              throwable = Some(e)
+            )
+          )
+        )
+    }
+  }
   private def disableUnrecognisedUsers(
       settings: Settings
   )(using ExecutionContext): Attempt[List[String]] = {
@@ -70,15 +108,18 @@ object UnrecognisedUsers extends LazyLogging {
 
     for {
       // load Security HQ's config (accounts, allowed accounts, notification topic) from S3
-      configSource <- getS3Object(s3Client, settings.configBucket, settings.configKey)
+      configObject <- getS3Object(s3Client, settings.configBucket, settings.configKey)
+      configSource = Source.fromInputStream(configObject)
       conf = ConfigFactory.parseString(configSource.mkString)
       awsAccounts = CoreConfig.parseAccounts(conf)
       allowedAccountIds = conf.getStringList(ALLOWED_ACCOUNT_IDS).asScala.toList
       anghammaradSnsArn = conf.getString(ANGHAMMARAD_SNS_ARN)
 
       // fetch and parse our stored Janus config to use as the canonical source of "recognised" usernames
-      janusSource <- getS3Object(s3Client, settings.janusBucket, settings.janusKey)
-      janusData = JanusConfig.load(makeFile(janusSource.mkString))
+      janusConfigObject <- getS3Object(s3Client, settings.janusBucket, settings.janusKey)
+      _ <- janusConfigIsFresh(janusConfigObject.response())
+      janusSource = Source.fromInputStream(janusConfigObject)
+      janusData <- loadJanusConfig(makeFile(janusSource.mkString))
       janusUsernames = getJanusUsernames(janusData)
       notificationIds <- new UnrecognisedUsers(
         awsAccounts,

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -22,11 +22,9 @@ import software.amazon.awssdk.services.sns.SnsAsyncClient
 import utils.attempt.{Attempt, FailedAttempt, Failure}
 
 import java.io.File
-import java.time.Instant
-import java.time.temporal.ChronoUnit.DAYS
+import java.time.{Instant, Period}
 import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext}
-import scala.io.Source
 import scala.jdk.CollectionConverters.*
 import scala.util.chaining.*
 
@@ -66,14 +64,15 @@ object UnrecognisedUsers extends LazyLogging {
   private def unloadedReport(account: AwsAccount): Either[FailedAttempt, CredentialReportDisplay] =
     Left(Failure.notYetLoaded(account.id, "credentials").attempt)
 
+  val ONE_WEEK = Period.ofDays(7)
   private def janusConfigIsFresh(objectResponse: GetObjectResponse): Attempt[Boolean] = {
     val lastModified = objectResponse.lastModified()
-    val isStale = lastModified.isBefore(Instant.now().minus(7, DAYS))
+    val isStale = lastModified.isBefore(Instant.now().minus(ONE_WEEK))
     if (isStale) {
       Attempt.Left(
         FailedAttempt(
           Failure(
-            "Janus config has not been updated in over 7 days"
+            s"Janus config has not been updated since ${lastModified.toString()}"
           )
         )
       )
@@ -120,8 +119,7 @@ object UnrecognisedUsers extends LazyLogging {
     for {
       // load Security HQ's config (accounts, allowed accounts, notification topic) from S3
       configObject <- getS3Object(s3Client, settings.configBucket, settings.configKey)
-      configSource = Source.fromInputStream(configObject)
-      conf = ConfigFactory.parseString(configSource.mkString)
+      conf = ConfigFactory.parseString(configObject.asUtf8String())
       awsAccounts = CoreConfig.parseAccounts(conf)
       allowedAccountIds = conf.getStringList(ALLOWED_ACCOUNT_IDS).asScala.toList
       anghammaradSnsArn = conf.getString(ANGHAMMARAD_SNS_ARN)
@@ -129,8 +127,7 @@ object UnrecognisedUsers extends LazyLogging {
       // fetch and parse our stored Janus config to use as the canonical source of "recognised" usernames
       janusConfigObject <- getS3Object(s3Client, settings.janusBucket, settings.janusKey)
       _ <- janusConfigIsFresh(janusConfigObject.response())
-      janusSource = Source.fromInputStream(janusConfigObject)
-      janusData <- loadJanusConfig(makeFile(janusSource.mkString))
+      janusData <- loadJanusConfig(makeFile(janusConfigObject.asUtf8String()))
       janusUsernames = getJanusUsernames(janusData)
       notificationIds <- new UnrecognisedUsers(
         awsAccounts,

--- a/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
+++ b/iam-unrecognised-users/src/main/scala/unrecognised/UnrecognisedUsers.scala
@@ -84,7 +84,18 @@ object UnrecognisedUsers extends LazyLogging {
 
   private def loadJanusConfig(dataFile: File): Attempt[JanusData] = {
     try {
-      Attempt.Right { JanusConfig.load(dataFile) }
+      val config = JanusConfig.load(dataFile)
+      val hasSensibleNumberOfUsers = config.access.userAccess.size > 10
+      if (hasSensibleNumberOfUsers)
+        Attempt.Right(config)
+      else
+        Attempt.Left(
+          FailedAttempt(
+            Failure(
+              s"Janus config only lists ${config.access.userAccess.size} users, which is suspiciously low"
+            )
+          )
+        )
     } catch {
       case e: JanusConfigurationException =>
         Attempt.Left(


### PR DESCRIPTION
## What does this change?

Verify that the Janus data export is fresh (generated within seven days) before running the unrecognised user lambda. We were already throwing if the data export was not in the expected format, but that's now better handled into the standard `Attempt` error handling pattern. We also check that the number of users is a plausible amount (more than 10, ie. the export contained some users, and wasn't empty).

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?

Greater confidence that the app won't attempt to remediate new users that have only recently been added to the Janus config or fail to remediate recent leavers who have been removed from Janus.

<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
