### PR TITLE
Change outdated credentials to run mornings only

### DIFF
--- a/cdk/lib/__snapshots__/security-hq.test.ts.snap
+++ b/cdk/lib/__snapshots__/security-hq.test.ts.snap
@@ -1230,10 +1230,29 @@ exports[`HQ stack matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Role",
     },
-    "iamoutdatedcredentialsiamoutdatedcredentialscron0914MONFRI07494ADB7": {
+    "iamoutdatedcredentialsiamoutdatedcredentialscron09MONFRI0AllowEventRulesecurityhqiamoutdatedcredentials0C07F7DEF59189D6": {
       "Properties": {
-        "Description": "Run iam-outdated-credentials lambda, Monday-Friday at 9AM and 2PM",
-        "ScheduleExpression": "cron(0 9,14 ? * MON-FRI *)",
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "iamoutdatedcredentials652F7EC1",
+            "Arn",
+          ],
+        },
+        "Principal": "events.amazonaws.com",
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "iamoutdatedcredentialsiamoutdatedcredentialscron09MONFRI0EB8C1E06",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "iamoutdatedcredentialsiamoutdatedcredentialscron09MONFRI0EB8C1E06": {
+      "Properties": {
+        "Description": "Run iam-outdated-credentials lambda, Monday-Friday at 9AM",
+        "ScheduleExpression": "cron(0 9 ? * MON-FRI *)",
         "State": "ENABLED",
         "Tags": [
           {
@@ -1270,25 +1289,6 @@ exports[`HQ stack matches the snapshot 1`] = `
         ],
       },
       "Type": "AWS::Events::Rule",
-    },
-    "iamoutdatedcredentialsiamoutdatedcredentialscron0914MONFRI0AllowEventRulesecurityhqiamoutdatedcredentials0C07F7DE459CE6E8": {
-      "Properties": {
-        "Action": "lambda:InvokeFunction",
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "iamoutdatedcredentials652F7EC1",
-            "Arn",
-          ],
-        },
-        "Principal": "events.amazonaws.com",
-        "SourceArn": {
-          "Fn::GetAtt": [
-            "iamoutdatedcredentialsiamoutdatedcredentialscron0914MONFRI07494ADB7",
-            "Arn",
-          ],
-        },
-      },
-      "Type": "AWS::Lambda::Permission",
     },
     "iamunrecognisedusersD1D8EA98": {
       "DependsOn": [

--- a/cdk/lib/security-hq.ts
+++ b/cdk/lib/security-hq.ts
@@ -321,11 +321,11 @@ export class SecurityHQ extends GuStack {
           {
             schedule: Schedule.cron({
               minute: "0",
-              hour: "9,14",
+              hour: "9",
               weekDay: "MON-FRI",
             }),
             description:
-              "Run iam-outdated-credentials lambda, Monday-Friday at 9AM and 2PM",
+              "Run iam-outdated-credentials lambda, Monday-Friday at 9AM",
           },
         ],
         app: "iam-outdated-credentials",

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -11,7 +11,7 @@
         "cdk": "bin/cdk.js"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.5",
+        "@eslint/js": "9.39.5",
         "@guardian/cdk": "64.1.0",
         "@guardian/eslint-config": "16.0.0",
         "@types/jest": "^30.0.0",


### PR DESCRIPTION
## What does this change?

Changes the outdated credentials lambda to only run in the morning slot. We don't see much value in the afternoon running, and it can cause excessive disabling of keys (in the case that a team can't rotate a credential in time, so need to temporarily re-enable it while they unblock themselves)

<!-- Screenshots may be helpful to demonstrate -->

## What is the value of this?


<!-- Why are these changes being made? -->

## Will this require CloudFormation and/or updates to the AWS StackSet?


<!-- Have you committed your changes to the CloudFormation templates? -->

<!-- Has the CloudFormation or StackSet update been completed? -->

## Will this require changes to config?


<!-- Have you updated the PROD and local config files in S3? -->

<!-- Have you alerted colleagues that they will need to pull the latest local conf file? -->

## Any additional notes?


<!-- Have CSS or JS changes been checked and fixed by Prettier? -->

<!-- Does this PR meet the contributing guidelines? https://github.com/guardian/security-hq/blob/main/.github/CONTRIBUTING.md -->
